### PR TITLE
UnixTransport: support mono

### DIFF
--- a/src/Tmds.DBus/Transports/SocketUtils.cs
+++ b/src/Tmds.DBus/Transports/SocketUtils.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading.Tasks;
+
+namespace Tmds.DBus.Transports
+{
+    // this netstandard method is not available on mono 4.8
+    internal class SocketUtils
+    {
+        public static Task ConnectAsync(Socket socket, EndPoint ep)
+        {
+            var tcs = new TaskCompletionSource<bool>();
+            var args = new SocketAsyncEventArgs()
+            {
+                RemoteEndPoint = ep,
+                UserToken = tcs
+            };
+            try
+            {
+                args.Completed += OnConnectCompleted;
+                if (!socket.ConnectAsync(args))
+                {
+                    OnConnectCompleted(null, args);
+                }
+            }
+            catch (Exception e)
+            {
+                tcs.SetException(e);
+            }
+            return tcs.Task;
+        }
+
+        private static void OnConnectCompleted(object sender, SocketAsyncEventArgs e)
+        {
+            var tcs = (TaskCompletionSource<bool>)e.UserToken;
+            var errorCode = e.SocketError;
+            if (errorCode == SocketError.Success)
+            {
+                tcs.SetResult(true);
+            }
+            else
+            {
+                tcs.SetException(new SocketException((int)errorCode));
+            }
+        }
+    }
+}

--- a/src/Tmds.DBus/Transports/TcpTransport.cs
+++ b/src/Tmds.DBus/Transports/TcpTransport.cs
@@ -65,7 +65,7 @@ namespace Tmds.DBus.Transports
                 var registration = cancellationToken.Register(() => ((IDisposable)socket).Dispose());
                 try
                 {
-                    await socket.ConnectAsync(address, port);
+                    await SocketUtils.ConnectAsync(socket, new IPEndPoint(address, port));
                     var stream = new NetworkStream(socket, true);
                     try
                     {

--- a/src/Tmds.DBus/Transports/UnixTransport.cs
+++ b/src/Tmds.DBus/Transports/UnixTransport.cs
@@ -124,7 +124,7 @@ namespace Tmds.DBus.Transports
             var endPoint = new Tmds.DBus.Transports.UnixDomainSocketEndPoint(path);
             try
             {
-                await socket.ConnectAsync(endPoint);
+                await SocketUtils.ConnectAsync(socket, endPoint);
                 var stream = new NetworkStream(socket, true);
                 try
                 {


### PR DESCRIPTION
The Socket.Handle is not a netstandard property. The file descriptor is determined
via reflection. The implementation was written for .NET Core which has a SafeHandle
property. Now it will check for a Handle property too.

Fixes https://github.com/tmds/Tmds.DBus/issues/10