### PR TITLE
TransportSocket: fix completion race

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -1,8 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <packageSources>
-    <clear />
-    <add key="api.nuget.org" value="https://api.nuget.org/v3/index.json" />
-    <add key="dotnet-core" value="https://dotnet.myget.org/F/dotnet-core/api/v3/index.json" />
-  </packageSources>
-</configuration>

--- a/src/Tmds.DBus/Transports/TransportSocket.cs
+++ b/src/Tmds.DBus/Transports/TransportSocket.cs
@@ -220,7 +220,8 @@ namespace Tmds.DBus.Transports
             if (!_supportsFdPassing)
             {
                 var readContext = _receiveData.UserToken as ReadContext;
-                readContext.Tcs = readContext.Tcs ?? new TaskCompletionSource<int>();
+                TaskCompletionSource<int> tcs = readContext.Tcs ?? new TaskCompletionSource<int>();
+                readContext.Tcs = tcs;
                 _receiveData.SetBuffer(buffer, offset, count);
                 readContext.FileDescriptors = fileDescriptors;
                 if (!_socket.ReceiveAsync(_receiveData))
@@ -236,13 +237,14 @@ namespace Tmds.DBus.Transports
                 }
                 else
                 {
-                    return readContext.Tcs.Task;
+                    return tcs.Task;
                 }
             }
             else
             {
                 var readContext = _waitForData.UserToken as ReadContext;
-                readContext.Tcs = readContext.Tcs ?? new TaskCompletionSource<int>();
+                TaskCompletionSource<int> tcs = readContext.Tcs ?? new TaskCompletionSource<int>();
+                readContext.Tcs = tcs;
                 readContext.Buffer = buffer;
                 readContext.Offset = offset;
                 readContext.Count = count;
@@ -271,7 +273,7 @@ namespace Tmds.DBus.Transports
                     }
                     else
                     {
-                        return readContext.Tcs.Task;
+                        return tcs.Task;
                     }
                 }
             }
@@ -401,7 +403,8 @@ namespace Tmds.DBus.Transports
         private Task SendBufferListAsync(List<ArraySegment<byte>> bufferList)
         {
             var sendContext = _sendArgs.UserToken as SendContext;
-            sendContext.Tcs = sendContext.Tcs ?? new TaskCompletionSource<object>();
+            TaskCompletionSource<object> tcs = sendContext.Tcs ?? new TaskCompletionSource<object>();
+            sendContext.Tcs = tcs;
             _sendArgs.BufferList = bufferList;
             if (!_socket.SendAsync(_sendArgs))
             {
@@ -416,7 +419,7 @@ namespace Tmds.DBus.Transports
             }
             else
             {
-                return sendContext.Tcs.Task;
+                return tcs.Task;
             }
         }
 


### PR DESCRIPTION
When the operation completed asynchonously, the TaskCompletionSource
was read from the Read/SendContext. This was racing with the completion
handler which sets that field to null. If the completion handler ran
first, a NullReferenceException was thrown.

Fixes https://github.com/tmds/Tmds.DBus/issues/41