### PR TITLE
Fix replying to introspectable call

### DIFF
--- a/src/Tmds.DBus/DBusConnection.cs
+++ b/src/Tmds.DBus/DBusConnection.cs
@@ -737,6 +737,7 @@ namespace Tmds.DBus
                         
                         var xml = writer.ToString();
                         SendMessage(MessageHelper.ConstructReply(methodCall, xml), peer);
+                        return;
                     }
                 }
                 SendUnknownMethodError(methodCall, peer);


### PR DESCRIPTION
After replying to org.freedesktop.DBus.Introspectable.Introspect() call the code was sending UnknownMethodError, so the daemon kicked us out of the bus.