### PR TITLE
Tool: pack as tool

### DIFF
--- a/src/Tmds.DBus.Tool/Tmds.DBus.Tool.csproj
+++ b/src/Tmds.DBus.Tool/Tmds.DBus.Tool.csproj
@@ -1,8 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <ToolCommandName>dotnet-dbus</ToolCommandName>
+    <PackAsTool>True</PackAsTool>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <AssemblyName>dotnet-dbus</AssemblyName>
     <PackageId>Tmds.DBus.Tool</PackageId>
     <VersionPrefix>0.6.0</VersionPrefix>


### PR DESCRIPTION
This adds the PackAsTool option to Tmds.DBus.Tool.csproj so that it
can be installed as a global tool from the command line