### PR TITLE
Fix method call error handling

### DIFF
--- a/src/Tmds.DBus/CodeGen/DBusAdapter.cs
+++ b/src/Tmds.DBus/CodeGen/DBusAdapter.cs
@@ -149,7 +149,7 @@ namespace Tmds.DBus.CodeGen
             return $"org.freedesktop.DBus.Properties.{iface}.{member}.s{signature?.Value}";
         }
 
-        public Task<Message> HandleMethodCall(Message methodCall)
+        public async Task<Message> HandleMethodCall(Message methodCall)
         {
             var key = GetMethodLookupKey(methodCall.Header.Interface, methodCall.Header.Member, methodCall.Header.Signature);
             MethodCallHandler handler = null;
@@ -169,15 +169,15 @@ namespace Tmds.DBus.CodeGen
                 {
                     try
                     {
-                        return handler(_object, methodCall, _factory);
+                        return await handler(_object, methodCall, _factory);
                     }
                     catch (DBusException be)
                     {
-                        return Task.FromResult(MessageHelper.ConstructErrorReply(methodCall, be.ErrorName, be.ErrorMessage));
+                        return MessageHelper.ConstructErrorReply(methodCall, be.ErrorName, be.ErrorMessage);
                     }
                     catch (Exception e)
                     {
-                        return Task.FromResult(MessageHelper.ConstructErrorReply(methodCall, e.GetType().FullName, e.Message));
+                        return MessageHelper.ConstructErrorReply(methodCall, e.GetType().FullName, e.Message);
                     }
                 }
                 else
@@ -199,7 +199,7 @@ namespace Tmds.DBus.CodeGen
                         }
                         tcs.SetResult(reply);
                     }, null);
-                    return tcs.Task;
+                    return await tcs.Task;
                 }
             }
             else
@@ -211,7 +211,7 @@ namespace Tmds.DBus.CodeGen
 
                 var replyMessage = MessageHelper.ConstructErrorReply(methodCall, "org.freedesktop.DBus.Error.UnknownMethod", errorMessage);
 
-                return Task.FromResult(replyMessage);
+                return replyMessage;
             }
         }
 

--- a/test/Tmds.DBus.Tests/ConnectionTests.cs
+++ b/test/Tmds.DBus.Tests/ConnectionTests.cs
@@ -120,8 +120,9 @@ namespace Tmds.DBus.Tests
 
             public ObjectPath ObjectPath => Path;
 
-            public Task ThrowAsync()
+            public async Task ThrowAsync()
             {
+                await Task.Yield();
                 throw new Exception(ExceptionMessage);
             }
         }


### PR DESCRIPTION
Without the await in DBusAdapter.HandleMethodCall, the handler is returned meaning the try-catch logic is ignored. This causes the exception from a method call to bubble up and crash the host process.