### PR TITLE
Fix AccessDenied error if replying to method call that don't expect reply

### DIFF
--- a/src/Tmds.DBus/CodeGen/ReadMethodFactory.cs
+++ b/src/Tmds.DBus/CodeGen/ReadMethodFactory.cs
@@ -90,7 +90,7 @@ namespace Tmds.DBus.CodeGen
 
             if (ArgTypeInspector.IsDBusObjectType(type, isCompileTimeType: true))
             {
-                return s_messageReaderReadDBusInterface.MakeGenericMethod(new[] { type }); ;
+                return s_messageReaderReadDBusInterface.MakeGenericMethod(new[] { type });
             }
 
             Type elementType;

--- a/src/Tmds.DBus/CodeGen/TypeDescription.cs
+++ b/src/Tmds.DBus/CodeGen/TypeDescription.cs
@@ -150,11 +150,6 @@ namespace Tmds.DBus.CodeGen
 
             foreach (var member in type.GetMethods())
             {
-                // Objects that have properties do not have to have "Async" in their name and is skipped.
-                if (member.IsSpecialName)
-                {
-                    continue;
-                }
                 string memberName = member.ToString();
                 if (!member.Name.EndsWith("Async", StringComparison.Ordinal))
                 {

--- a/src/Tmds.DBus/CodeGen/TypeDescription.cs
+++ b/src/Tmds.DBus/CodeGen/TypeDescription.cs
@@ -150,6 +150,11 @@ namespace Tmds.DBus.CodeGen
 
             foreach (var member in type.GetMethods())
             {
+                // Objects that have properties do not have to have "Async" in their name and is skipped.
+                if (member.IsSpecialName)
+                {
+                    continue;
+                }
                 string memberName = member.ToString();
                 if (!member.Name.EndsWith("Async", StringComparison.Ordinal))
                 {

--- a/src/Tmds.DBus/DBusConnection.cs
+++ b/src/Tmds.DBus/DBusConnection.cs
@@ -711,9 +711,13 @@ namespace Tmds.DBus
             if (_methodHandlers.TryGetValue(methodCall.Header.Path.Value, out methodHandler))
             {
                 var reply = await methodHandler(methodCall);
-                reply.Header.ReplySerial = methodCall.Header.Serial;
-                reply.Header.Destination = methodCall.Header.Sender;
-                SendMessage(reply, peer);
+                // Only reply if the caller expected it. Otherwise DBus will reject with org.freedesktop.DBus.Error.AccessDenied
+                if (methodCall.Header.ReplyExpected)
+                {
+                    reply.Header.ReplySerial = methodCall.Header.Serial;
+                    reply.Header.Destination = methodCall.Header.Sender;
+                    SendMessage(reply, peer);
+                }
             }
             else
             {

--- a/src/Tmds.DBus/DBusConnection.cs
+++ b/src/Tmds.DBus/DBusConnection.cs
@@ -711,7 +711,6 @@ namespace Tmds.DBus
             if (_methodHandlers.TryGetValue(methodCall.Header.Path.Value, out methodHandler))
             {
                 var reply = await methodHandler(methodCall);
-                // Only reply if the caller expected it. Otherwise DBus will reject with org.freedesktop.DBus.Error.AccessDenied
                 if (methodCall.Header.ReplyExpected)
                 {
                     reply.Header.ReplySerial = methodCall.Header.Serial;


### PR DESCRIPTION
When a DBus method call is made, the caller can set a flag that they don't expect a reply. If you don't honor this flag, an Exception will be thrown when you try send the reply.

I've created this patch and it seems to work for me - but @tmds you'd be best to review it.

**Example:**
Using the bluez [gatt API](https://git.kernel.org/pub/scm/bluetooth/bluez.git/tree/doc/gatt-api.txt), there is a particular method I need to export, called StartNotify().

I did this and every time I got called with StartNotify(), Tmds.DBus threw an exception. I traced it down to this:

` Type=error  Endian=l  Flags=1  Version=1  Priority=0 Cookie=8  ReplyCookie=21
  Sender=org.freedesktop.DBus  Destination=:1.597
  ErrorName=org.freedesktop.DBus.Error.AccessDenied  ErrorMessage="Rejected send message, 1 matched rules; type="method_return", sender=":1.597" (uid=1000 pid=26233 comm="python gatt_server_example.py " label="unconfined") interface="(unset)" member="(unset)" error name="(unset)" requested_reply="0" destination=":1.534" (uid=0 pid=5898 comm="/usr/lib/bluetooth/bluetoothd -d --experimental " label="unconfined")"
`

The important part is **requested_reply="0"** 

This is what led me to the implementation in [DBusConnection](https://github.com/tmds/Tmds.DBus/blob/master/src/Tmds.DBus/DBusConnection.cs#L713) where the response is sent but the Flags is not honored.

Feel free to change this if there is a better way to fix this - but the unit tests ran, everything else in my program works fine.