### PR TITLE
Update global tool package to .NET Core 3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ addons:
     - dbus
 
 before_install:
-  - curl -sSL -o dotnet.tar.gz https://dotnetcli.blob.core.windows.net/dotnet/Sdk/release/2.0.0/dotnet-sdk-latest-linux-x64.tar.gz
+  - curl -sSL -o dotnet.tar.gz https://download.visualstudio.microsoft.com/download/pr/886b4a4c-30af-454b-8bec-81c72b7b4e1f/d1a0c8de9abb36d8535363ede4a15de6/dotnet-sdk-3.0.100-linux-x64.tar.gz
   - sudo mkdir -p /opt/dotnet && sudo tar zxf dotnet.tar.gz -C /opt/dotnet
   - sudo ln -s /opt/dotnet/dotnet /usr/local/bin
 

--- a/src/Tmds.DBus.Tool/Tmds.DBus.Tool.csproj
+++ b/src/Tmds.DBus.Tool/Tmds.DBus.Tool.csproj
@@ -2,7 +2,9 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
+    <PackAsTool>true</PackAsTool>
+    <ToolCommandName>dotnet-dbus</ToolCommandName>
     <AssemblyName>dotnet-dbus</AssemblyName>
     <PackageId>Tmds.DBus.Tool</PackageId>
     <VersionPrefix>0.7.1</VersionPrefix>

--- a/src/Tmds.DBus/Tmds.DBus.csproj
+++ b/src/Tmds.DBus/Tmds.DBus.csproj
@@ -10,7 +10,7 @@
     <PackageTags>dbus</PackageTags>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/tmds/Tmds.DBus</RepositoryUrl>
-    <PackageLicenseUrl>https://raw.githubusercontent.com/tmds/Tmds.DBus/master/COPYING</PackageLicenseUrl>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <Copyright>Tom Deseyn;Alp Toker</Copyright>
   </PropertyGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.5' ">

--- a/test/Tmds.DBus.Tests/Tmds.DBus.Tests.csproj
+++ b/test/Tmds.DBus.Tests/Tmds.DBus.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This is just a simple upgrade of the Global tool package specifically to .NET Core 3.0 (multitargeting to 2.1 since its an LTS).

I've done some basic testing on my Fedora 30 machine and it seems like it should be compatible with both 3.0 and 2.1.

I've also updated the Travis file to pull a 3.0.100 SDK package (link taken from the [Microsoft release docs](https://github.com/dotnet/core/blob/master/release-notes/3.0/3.0.0/3.0.0-download.md)). I'm honestly not sure if that will be enough, but we'll soon find out!