### PR TITLE
Don't wait blocking in WatchSignalsAsync()

### DIFF
--- a/src/Tmds.DBus/CodeGen/DBusAdapter.cs
+++ b/src/Tmds.DBus/CodeGen/DBusAdapter.cs
@@ -94,7 +94,7 @@ namespace Tmds.DBus.CodeGen
 
             try
             {
-                Task.WaitAll(tasks);
+                await Task.WhenAll(tasks);
                 signalDisposables = tasks.Select(task => task.Result);
 
                 if (signalDisposables.Contains(null))

--- a/src/Tmds.DBus/CodeGen/DBusAdapter.cs
+++ b/src/Tmds.DBus/CodeGen/DBusAdapter.cs
@@ -94,7 +94,7 @@ namespace Tmds.DBus.CodeGen
 
             try
             {
-                await Task.WhenAll(tasks);
+                await Task.WhenAll(tasks).ConfigureAwait(false);
                 signalDisposables = tasks.Select(task => task.Result);
 
                 if (signalDisposables.Contains(null))


### PR DESCRIPTION
This seems to be the one place where instead of async-await a blocking wait call was used.