### PR TITLE
Avoid a deadlock in DBusConnection.HandleMessage

### DIFF
--- a/src/Tmds.DBus/DBusConnection.cs
+++ b/src/Tmds.DBus/DBusConnection.cs
@@ -862,7 +862,7 @@ namespace Tmds.DBus
             var serial = GenerateSerial();
             msg.Header.Serial = serial;
 
-            TaskCompletionSource<Message> pending = new TaskCompletionSource<Message>();
+            TaskCompletionSource<Message> pending = new TaskCompletionSource<Message>(TaskCreationOptions.RunContinuationsAsynchronously);
             lock (_gate)
             {
                 if (checkConnected)


### PR DESCRIPTION
`DBusConnection.HandleMessage` will invoke `TaskCompletionSource<Message>.SetResult`. This can cause the continuation of that task completion source to be invoked synchronously. This can cause the calling code (i.e. code which invoked a D-Bus method using Tmds.DBus) to delay or block the execution of the `HandleMessage` method and, as such, the entire D-Bus message loop.

Specify `TaskCreationOptions.RunContinuationsAsynchronously` when creating the `TaskCompletionSource` helps avoid this issue.