### PR TITLE
Tmds.DBus.Tool: Add support for .NET 6.0

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -18,16 +18,14 @@ jobs:
         fetch-depth: 0
 
     - run: |
-        pushd src/Tmds.DBus && dotnet restore && dotnet pack -c Release && popd
-        pushd src/Tmds.DBus.Protocol && dotnet restore && dotnet pack -c Release && popd
-        pushd test/Tmds.DBus.Tests && dotnet restore && dotnet test && popd
-        pushd src/Tmds.DBus.Tool && dotnet restore && dotnet build && popd
+        pushd test/Tmds.DBus.Tests && dotnet test && popd
+        pushd src/Tmds.DBus.Tool && dotnet build && popd
         dotnet pack src/Tmds.DBus --configuration Release --output src/Tmds.DBus
         dotnet pack src/Tmds.DBus.Protocol --configuration Release --output src/Tmds.DBus.Protocol
         dotnet pack src/Tmds.DBus.Tool --configuration Release --output src/Tmds.DBus.Tool
 
     - run: |
-        curl -H "X-NuGet-ApiKey: ${{ secrets.NUGET_APIKEY }}" -T src/Tmds.DBus/Tmds.DBus.*.nupkg https://www.myget.org/F/tmds/api/v2/package
-        curl -H "X-NuGet-ApiKey: ${{ secrets.NUGET_APIKEY }}" -T src/Tmds.DBus.Protocol/Tmds.DBus.Protocol.*.nupkg https://www.myget.org/F/tmds/api/v2/package
-        curl -H "X-NuGet-ApiKey: ${{ secrets.NUGET_APIKEY }}" -T src/Tmds.DBus.Tool/Tmds.DBus.Tool.*.nupkg https://www.myget.org/F/tmds/api/v2/package
+        dotnet nuget push -s https://www.myget.org/F/tmds/api/v2/package -k "${{ secrets.NUGET_APIKEY }}" src/Tmds.DBus/*.nupkg
+        dotnet nuget push -s https://www.myget.org/F/tmds/api/v2/package -k "${{ secrets.NUGET_APIKEY }}" src/Tmds.DBus.Protocol/*.nupkg
+        dotnet nuget push -s https://www.myget.org/F/tmds/api/v2/package -k "${{ secrets.NUGET_APIKEY }}" src/Tmds.DBus.Tool/*.nupkg
       if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -9,19 +9,25 @@ jobs:
       DOTNET_CLI_TELEMETRY_OPTOUT: 1
 
     steps:
+    - uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: '6.0.x'
+
     - uses: actions/checkout@v2
       with:
         fetch-depth: 0
 
     - run: |
         pushd src/Tmds.DBus && dotnet restore && dotnet pack -c Release && popd
+        pushd src/Tmds.DBus.Protocol && dotnet restore && dotnet pack -c Release && popd
         pushd test/Tmds.DBus.Tests && dotnet restore && dotnet test && popd
-        VERSION_SUFFIX="$(date +"%y%m%d")-${{ github.run_id	}}"
         pushd src/Tmds.DBus.Tool && dotnet restore && dotnet build && popd
         dotnet pack src/Tmds.DBus --configuration Release --output src/Tmds.DBus
+        dotnet pack src/Tmds.DBus.Protocol --configuration Release --output src/Tmds.DBus.Protocol
         dotnet pack src/Tmds.DBus.Tool --configuration Release --output src/Tmds.DBus.Tool
 
     - run: |
         curl -H "X-NuGet-ApiKey: ${{ secrets.NUGET_APIKEY }}" -T src/Tmds.DBus/Tmds.DBus.*.nupkg https://www.myget.org/F/tmds/api/v2/package
+        curl -H "X-NuGet-ApiKey: ${{ secrets.NUGET_APIKEY }}" -T src/Tmds.DBus.Protocol/Tmds.DBus.Protocol.*.nupkg https://www.myget.org/F/tmds/api/v2/package
         curl -H "X-NuGet-ApiKey: ${{ secrets.NUGET_APIKEY }}" -T src/Tmds.DBus.Tool/Tmds.DBus.Tool.*.nupkg https://www.myget.org/F/tmds/api/v2/package
-      if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+      if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-[![Travis](https://api.travis-ci.org/tmds/Tmds.DBus.svg?branch=master)](https://travis-ci.org/tmds/Tmds.DBus)
 [![NuGet](https://img.shields.io/nuget/v/Tmds.DBus.svg)](https://www.nuget.org/packages/Tmds.DBus)
 
 # Introduction

--- a/README.md
+++ b/README.md
@@ -185,3 +185,4 @@ wlp4s0: Activated -> Unavailable
 * [Tmds.DBus Modelling](docs/modelling.md): Describes how to model D-Bus types in C# for use with Tmds.DBus.
 * [Tmds.DBus.Tool](docs/tool.md): Documentation of dotnet dbus tool.
 * [How-to](docs/howto.md): Documents some (advanced) use-cases.
+* [Tmds.DBus.Protocol](docs/protocol.md): Documentation of the protocol library.

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -19,7 +19,7 @@ dotnet new nugetconfig
 Add the `tmds` feed into the file:
 ```xml
 <add key="tmds" value="https://www.myget.org/F/tmds/api/v3/index.json" />
-``
+```
 
 Now add the `Tmds.DBus.Protocol` package:
 ```

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -1,0 +1,156 @@
+# Tmds.DBus.Protocol
+
+The `Tmds.DBus.Protocol` packages provides a D-Bus protocol API.
+
+The following example shows how you can use it to expose and consume a D-Bus service that adds two integers.
+
+Create a console application:
+
+```
+dotnet new console -o example
+cd example
+```
+
+Add a `NuGet.Config` file
+```
+dotnet new nugetconfig
+```
+
+Add the `tmds` feed into the file:
+```xml
+<add key="tmds" value="https://www.myget.org/F/tmds/api/v3/index.json" />
+``
+
+Now add the `Tmds.DBus.Protocol` package:
+```
+dotnet add package --prerelease Tmds.DBus.Protocol
+```
+
+Update `Program.cs`:
+```cs
+using Tmds.DBus.Protocol;
+
+class Program
+{
+    static async Task Main()
+    {
+        string peerName = await StartAddServiceAsync();
+
+        var connection = Connection.Session;
+
+        var addProxy = new AddProxy(connection, peerName);
+
+        int i = 10;
+        int j = 20;
+        int sum = await addProxy.AddAsync(i, j);
+
+        Console.WriteLine($"The sum of {i} and {j} is {sum}.");
+    }
+
+    private async static Task<string> StartAddServiceAsync()
+    {
+        var connection = new Connection(Address.Session!);
+
+        await connection.ConnectAsync();
+
+        connection.AddMethodHandler(new AddImplementation());
+
+        return connection.UniqueName ?? "";
+    }
+}
+
+class AddProxy
+{
+    private const string Interface = "org.example.Adder";
+    private const string Path = "/org/example/Adder";
+
+    private readonly Connection _connection;
+    private readonly string _peer;
+
+    public AddProxy(Connection connection, string peer)
+    {
+        _connection = connection;
+        _peer = peer;
+    }
+
+    public Task<int> AddAsync(int i, int j)
+    {
+        return _connection.CallMethodAsync(
+            CreateAddMessage(),
+            (in Message message, object? state) =>
+            {
+                return message.GetBodyReader().ReadInt32();
+            });
+
+        MessageBuffer CreateAddMessage()
+        {
+            using var writer = _connection.GetMessageWriter();
+
+            writer.WriteMethodCallHeader(
+                destination: _peer,
+                path: Path,
+                @interface: Interface,
+                signature: "ii",
+                member: "Add");
+
+            writer.WriteInt32(i);
+            writer.WriteInt32(j);
+
+            return writer.CreateMessage();
+        }
+    }
+}
+
+class AddImplementation : IMethodHandler
+{
+    public string Path => "/org/example/Adder";
+
+    public bool TryHandleMethod(Connection connection, in Message message)
+    {
+        string method = message.Member.ToString();
+        string sig = message.Signature.ToString();
+
+        switch ((method, sig))
+        {
+            case ("Add", "ii"):
+                Add(connection, message);
+                return true;
+        }
+
+        return false;
+    }
+
+    private void Add(Connection connection, in Message message)
+    {
+        var reader = message.GetBodyReader();
+
+        int i = reader.ReadInt32();
+        int j = reader.ReadInt32();
+
+        int sum = i + j;
+
+        connection.TrySendMessage(CreateResponseMessage(connection, message, sum));
+
+        static MessageBuffer CreateResponseMessage(Connection connection, in Message message, int sum)
+        {
+            using var writer = connection.GetMessageWriter();
+
+            writer.WriteMethodReturnHeader(
+                replySerial: message.Serial,
+                destination: message.Sender,
+                signature: "i"
+            );
+
+            writer.WriteInt32(sum);
+
+            return writer.CreateMessage();
+        }
+    }
+}
+```
+
+Now run the example:
+```
+$ dotnet run
+The sum of 10 and 20 is 30.
+```

--- a/src/Tmds.DBus.Protocol/Address.cs
+++ b/src/Tmds.DBus.Protocol/Address.cs
@@ -1,0 +1,220 @@
+using System.IO.MemoryMappedFiles;
+
+namespace Tmds.DBus.Protocol;
+
+public static class Address
+{
+    private static bool _systemAddressResolved = false;
+    private static string? _systemAddress = null;
+    private static bool _sessionAddressResolved = false;
+    private static string? _sessionAddress = null;
+
+    public static string? System
+    {
+        get
+        {
+            if (_systemAddressResolved)
+            {
+                return _systemAddress;
+            }
+
+            _systemAddress = Environment.GetEnvironmentVariable("DBUS_SYSTEM_BUS_ADDRESS");
+
+            if (string.IsNullOrEmpty(_systemAddress) && !RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                _systemAddress = "unix:path=/var/run/dbus/system_bus_socket";
+            }
+
+            _systemAddressResolved = true;
+            return _systemAddress;
+        }
+    }
+
+    public static string? Session
+    {
+        get
+        {
+            if (_sessionAddressResolved)
+            {
+                return _sessionAddress;
+            }
+
+            _sessionAddress = Environment.GetEnvironmentVariable("DBUS_SESSION_BUS_ADDRESS");
+
+            if (string.IsNullOrEmpty(_sessionAddress))
+            {
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                {
+                    _sessionAddress = GetSessionBusAddressFromSharedMemory();
+                }
+                else
+                {
+                    _sessionAddress = GetSessionBusAddressFromX11();
+                }
+            }
+
+            _sessionAddressResolved = true;
+            return _sessionAddress;
+        }
+    }
+
+    private static string? GetSessionBusAddressFromX11()
+    {
+        if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("DISPLAY")))
+        {
+            var display = XOpenDisplay(null);
+            if (display == IntPtr.Zero)
+            {
+                return null;
+            }
+            string username;
+            unsafe
+            {
+                const int BufLen = 1024;
+                byte* stackBuf = stackalloc byte[BufLen];
+                Passwd passwd;
+                IntPtr result;
+                getpwuid_r(getuid(), out passwd, stackBuf, BufLen, out result);
+                if (result != IntPtr.Zero)
+                {
+                    username = Marshal.PtrToStringAnsi(passwd.Name)!;
+                }
+                else
+                {
+                    return null;
+                }
+            }
+            var machineId = DBusEnvironment.MachineId.Replace("-", string.Empty);
+            var selectionName = $"_DBUS_SESSION_BUS_SELECTION_{username}_{machineId}";
+            var selectionAtom = XInternAtom(display, selectionName, false);
+            if (selectionAtom == IntPtr.Zero)
+            {
+                return null;
+            }
+            var owner = XGetSelectionOwner(display, selectionAtom);
+            if (owner == IntPtr.Zero)
+            {
+                return null;
+            }
+            var addressAtom = XInternAtom(display, "_DBUS_SESSION_BUS_ADDRESS", false);
+            if (addressAtom == IntPtr.Zero)
+            {
+                return null;
+            }
+
+            IntPtr actualReturnType;
+            IntPtr actualReturnFormat;
+            IntPtr nrItemsReturned;
+            IntPtr bytesAfterReturn;
+            IntPtr propReturn;
+
+            int rv = XGetWindowProperty(display, owner, addressAtom, 0, 1024, false, (IntPtr)31 /* XA_STRING */,
+                out actualReturnType, out actualReturnFormat, out nrItemsReturned, out bytesAfterReturn, out propReturn);
+            string? address = rv == 0 ? Marshal.PtrToStringAnsi(propReturn) : null;
+            if (propReturn != IntPtr.Zero)
+            {
+                XFree(propReturn);
+            }
+
+            XCloseDisplay(display);
+
+            return address;
+        }
+        else
+        {
+            return null;
+        }
+    }
+
+    private static string? GetSessionBusAddressFromSharedMemory()
+    {
+        string? result = ReadSharedMemoryString("DBusDaemonAddressInfo", 255);
+        if (string.IsNullOrEmpty(result))
+        {
+            result = ReadSharedMemoryString("DBusDaemonAddressInfoDebug", 255);
+        }
+        return result;
+    }
+
+    private static string? ReadSharedMemoryString(string id, long maxlen = -1)
+    {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            return null;
+        }
+        MemoryMappedFile? shmem;
+        try
+        {
+            shmem = MemoryMappedFile.OpenExisting(id);
+        }
+        catch
+        {
+            shmem = null;
+        }
+        if (shmem == null)
+        {
+            return null;
+        }
+
+        MemoryMappedViewStream s = shmem.CreateViewStream();
+        long len = s.Length;
+        if (maxlen >= 0 && len > maxlen)
+        {
+            len = maxlen;
+        }
+        if (len == 0)
+        {
+            return string.Empty;
+        }
+        if (len > Int32.MaxValue)
+        {
+            len = Int32.MaxValue;
+        }
+        byte[] bytes = new byte[len];
+        int count = s.Read(bytes, 0, (int)len);
+        if (count <= 0)
+        {
+            return string.Empty;
+        }
+
+        count = 0;
+        while (count < len && bytes[count] != 0)
+        {
+            count++;
+        }
+
+        return Encoding.UTF8.GetString(bytes, 0, count);
+    }
+
+    struct Passwd
+    {
+        public IntPtr Name;
+        public IntPtr Password;
+        public uint UserID;
+        public uint GroupID;
+        public IntPtr UserInfo;
+        public IntPtr HomeDir;
+        public IntPtr Shell;
+    }
+
+    [DllImport("libc")]
+    private static extern unsafe int getpwuid_r(uint uid, out Passwd pwd, byte* buf, int bufLen, out IntPtr result);
+    [DllImport("libc")]
+    private static extern uint getuid();
+
+    [DllImport("libX11")]
+    private static extern IntPtr XOpenDisplay(string? name);
+    [DllImport("libX11")]
+    private static extern int XCloseDisplay(IntPtr display);
+    [DllImport("libX11")]
+    private static extern IntPtr XInternAtom(IntPtr display, string atom_name, bool only_if_exists);
+    [DllImport("libX11")]
+    private static extern int XGetWindowProperty(IntPtr display, IntPtr w, IntPtr property,
+        int long_offset, int long_length, bool delete, IntPtr req_type,
+        out IntPtr actual_type_return, out IntPtr actual_format_return,
+        out IntPtr nitems_return, out IntPtr bytes_after_return, out IntPtr prop_return);
+    [DllImport("libX11")]
+    private static extern int XFree(IntPtr data);
+    [DllImport("libX11")]
+    private static extern IntPtr XGetSelectionOwner(IntPtr display, IntPtr Atom);
+}

--- a/src/Tmds.DBus.Protocol/AddressReader.cs
+++ b/src/Tmds.DBus.Protocol/AddressReader.cs
@@ -1,0 +1,194 @@
+namespace Tmds.DBus.Protocol;
+
+static class AddressParser
+{
+    public struct AddressEntry
+    {
+        internal string String { get; }
+        internal int Offset { get; }
+        internal int Count { get; }
+
+        internal AddressEntry(string s, int offset, int count) =>
+            (String, Offset, Count) = (s, offset, count);
+
+        internal ReadOnlySpan<char> AsSpan() => String.AsSpan(Offset, Count);
+
+        public override string ToString() => AsSpan().AsString();
+    }
+
+    public static bool TryGetNextEntry(string addresses, ref AddressEntry address)
+    {
+        if (address.String is null)
+        {
+            address = new AddressEntry(addresses, 0, 0);
+        }
+        ReadOnlySpan<char> span = addresses.AsSpan().Slice(address.Offset + address.Count);
+        if (span.Length == 0)
+        {
+            return false;
+        }
+        int end = addresses.IndexOf(';');
+        if (end == -1)
+        {
+            end = addresses.Length;
+        }
+        address = new AddressEntry(address.String, address.Offset + address.Count, end);
+        return true;
+    }
+
+    public static bool IsType(AddressEntry address, string type)
+    {
+        ReadOnlySpan<char> span = address.AsSpan();
+        return span.Length > type.Length && span[type.Length] == ':' && span.StartsWith(type.AsSpan());
+    }
+
+    public static void ParseTcpProperties(AddressEntry address, out string host, out int? port, out Guid guid)
+    {
+        host = null!;
+        port = null;
+        guid = default;
+        ReadOnlySpan<char> properties = GetProperties(address);
+        while (TryParseProperty(ref properties, out ReadOnlySpan<char> key, out ReadOnlySpan<char> value))
+        {
+            if (key.SequenceEqual("host".AsSpan()))
+            {
+                host = Unescape(value);
+            }
+            else if (key.SequenceEqual("port".AsSpan()))
+            {
+                port = int.Parse(Unescape(value));
+            }
+            else if (key.SequenceEqual("guid".AsSpan()))
+            {
+                guid = Guid.ParseExact(Unescape(value), "N");
+            }
+        }
+        if (host is null)
+        {
+            host = "localhost";
+        }
+    }
+
+    public static void ParseUnixProperties(AddressEntry address, out string path, out Guid guid)
+    {
+        path = null!;
+        bool isAbstract = false;
+        guid = default;
+        ReadOnlySpan<char> properties = GetProperties(address);
+        while (TryParseProperty(ref properties, out ReadOnlySpan<char> key, out ReadOnlySpan<char> value))
+        {
+            if (key.SequenceEqual("path".AsSpan()))
+            {
+                path = Unescape(value);
+            }
+            else if (key.SequenceEqual("abstract".AsSpan()))
+            {
+                isAbstract = true;
+                path = Unescape(value);
+            }
+            else if (key.SequenceEqual("guid".AsSpan()))
+            {
+                guid = Guid.ParseExact(Unescape(value), "N");
+            }
+        }
+        if (string.IsNullOrEmpty(path))
+        {
+            throw new ArgumentException("path");
+        }
+        if (isAbstract)
+        {
+            path = (char)'\0' + path;
+        }
+    }
+
+    private static ReadOnlySpan<char> GetProperties(AddressEntry address)
+    {
+        ReadOnlySpan<char> span = address.AsSpan();
+        int colonPos = span.IndexOf(':');
+        if (colonPos == -1)
+        {
+            throw new FormatException("No colon found.");
+        }
+        return span.Slice(colonPos + 1);
+    }
+
+    public static bool TryParseProperty(ref ReadOnlySpan<char> properties, out ReadOnlySpan<char> key, out ReadOnlySpan<char> value)
+    {
+        if (properties.Length == 0)
+        {
+            key = default;
+            value = default;
+            return false;
+        }
+        int end = properties.IndexOf(',');
+        ReadOnlySpan<char> property;
+        if (end == -1)
+        {
+            property = properties;
+            properties = default;
+        }
+        else
+        {
+            property = properties.Slice(0, end);
+            properties = properties.Slice(end + 1);
+        }
+        int equalPos = property.IndexOf('=');
+        if (equalPos == -1)
+        {
+            throw new FormatException("No equals sign found.");
+        }
+        key = property.Slice(0, equalPos);
+        value = property.Slice(equalPos + 1);
+        return true;
+    }
+
+    private static string Unescape(ReadOnlySpan<char> value)
+    {
+        if (!value.Contains("%".AsSpan(), StringComparison.Ordinal))
+        {
+            return value.AsString();
+        }
+        Span<char> unescaped = stackalloc char[Constants.StackAllocCharThreshold];
+        int pos = 0;
+        for (int i = 0; i < value.Length;)
+        {
+            char c = value[i++];
+            if (c != '%')
+            {
+                unescaped[pos++] = c;
+            }
+            else if (i + 2 < value.Length)
+            {
+                int a = FromHexChar(value[i++]);
+                int b = FromHexChar(value[i++]);
+                if (a == -1 || b == -1)
+                {
+                    throw new FormatException("Invalid hex char.");
+                }
+                unescaped[pos++] = (char)((a << 4) + b);
+            }
+            else
+            {
+                throw new FormatException("Escape sequence is too short.");
+            }
+        }
+        return unescaped.Slice(0, pos).AsString();
+
+        static int FromHexChar(char c)
+        {
+            if (c >= '0' && c <= '9')
+            {
+                return c - '0';
+            }
+            if (c >= 'A' && c <= 'F')
+            {
+                return c - 'A' + 10;
+            }
+            if (c >= 'a' && c <= 'f')
+            {
+                return c - 'a' + 10;
+            }
+            return -1;
+        }
+    }
+}

--- a/src/Tmds.DBus.Protocol/ClientConnectionOptions.cs
+++ b/src/Tmds.DBus.Protocol/ClientConnectionOptions.cs
@@ -1,0 +1,33 @@
+namespace Tmds.DBus.Protocol;
+
+public class ClientConnectionOptions : ConnectionOptions
+{
+    private string _address;
+
+    public ClientConnectionOptions(string address)
+    {
+        if (address == null)
+            throw new ArgumentNullException(nameof(address));
+        _address = address;
+    }
+
+    protected ClientConnectionOptions()
+    {
+        _address = string.Empty;
+    }
+
+    public bool AutoConnect { get; set; }
+
+    protected internal virtual ValueTask<ClientSetupResult> SetupAsync(CancellationToken cancellationToken)
+    {
+        return new ValueTask<ClientSetupResult>(
+            new ClientSetupResult(_address)
+            {
+                SupportsFdPassing = true,
+                UserId = DBusEnvironment.UserId
+            });
+    }
+
+    protected internal virtual void Teardown(object? token)
+    { }
+}

--- a/src/Tmds.DBus.Protocol/ClientSetupResult.cs
+++ b/src/Tmds.DBus.Protocol/ClientSetupResult.cs
@@ -1,0 +1,17 @@
+namespace Tmds.DBus.Protocol;
+
+public class ClientSetupResult
+{
+    public ClientSetupResult(string address)
+    {
+        ConnectionAddress = address ?? throw new ArgumentNullException(nameof(address));
+    }
+
+    public string ConnectionAddress { get;  }
+
+    public object? TeardownToken { get; set; }
+
+    public string? UserId { get; set; }
+
+    public bool SupportsFdPassing { get; set; }
+}

--- a/src/Tmds.DBus.Protocol/ConnectException.cs
+++ b/src/Tmds.DBus.Protocol/ConnectException.cs
@@ -1,0 +1,10 @@
+namespace Tmds.DBus.Protocol;
+
+public class ConnectException : Exception
+{
+    public ConnectException(string message) : base(message)
+    { }
+
+    public ConnectException(string message, Exception innerException) : base(message, innerException)
+    { }
+}

--- a/src/Tmds.DBus.Protocol/Connection.cs
+++ b/src/Tmds.DBus.Protocol/Connection.cs
@@ -1,0 +1,290 @@
+namespace Tmds.DBus.Protocol;
+
+public delegate T MessageValueReader<T>(in Message message, object? state);
+
+public interface IMethodHandler
+{
+    bool TryHandleMethod(Connection connection, in Message message);
+
+    string Path { get; }
+}
+
+public class Connection : IDisposable
+{
+    private static readonly Exception s_disposedSentinel = new ObjectDisposedException(typeof(Connection).FullName);
+    private static Connection? s_systemConnection;
+    private static Connection? s_sessionConnection;
+
+    public static Connection System => s_systemConnection ?? CreateConnection(ref s_systemConnection, Address.System);
+    public static Connection Session => s_sessionConnection ?? CreateConnection(ref s_sessionConnection, Address.Session);
+
+    public string? UniqueName => GetConnection()?.UniqueName;
+
+    enum ConnectionState
+    {
+        Created,
+        Connecting,
+        Connected,
+        Disconnected
+    }
+
+    private readonly object _gate = new object();
+    private readonly ClientConnectionOptions _connectionOptions;
+    private DBusConnection? _connection;
+    private CancellationTokenSource? _connectCts;
+    private Task<DBusConnection>? _connectingTask;
+    private ClientSetupResult? _setupResult;
+    private ConnectionState _state;
+    private bool _disposed;
+    private int _nextSerial;
+
+    public Connection(string address) :
+        this(new ClientConnectionOptions(address))
+    { }
+
+    public Connection(ConnectionOptions connectionOptions)
+    {
+        if (connectionOptions == null)
+            throw new ArgumentNullException(nameof(connectionOptions));
+
+        _connectionOptions = (ClientConnectionOptions)connectionOptions;
+    }
+
+    public async ValueTask ConnectAsync()
+    {
+        await ConnectCoreAsync(autoConnect: false);
+    }
+
+    private ValueTask<DBusConnection> ConnectCoreAsync(bool autoConnect = true)
+    {
+        lock (_gate)
+        {
+            ThrowHelper.ThrowIfDisposed(_disposed, this);
+
+            ConnectionState state = _state;
+
+            if (state == ConnectionState.Connected)
+            {
+                return new ValueTask<DBusConnection>(_connection!);
+            }
+
+            if (!_connectionOptions.AutoConnect)
+            {
+                if (autoConnect || _state != ConnectionState.Created)
+                {
+                    throw new InvalidOperationException("Can only connect once using an explicit call.");
+                }
+            }
+
+            if (state == ConnectionState.Connecting)
+            {
+                return new ValueTask<DBusConnection>(_connectingTask!);
+            }
+
+            _state = ConnectionState.Connecting;
+            _connectingTask = DoConnectAsync();
+
+            return new ValueTask<DBusConnection>(_connectingTask);
+        }
+    }
+
+    private async Task<DBusConnection> DoConnectAsync()
+    {
+        Debug.Assert(Monitor.IsEntered(_gate));
+
+        DBusConnection? connection = null;
+        try
+        {
+            _connectCts = new();
+            _setupResult = await _connectionOptions.SetupAsync(_connectCts.Token);
+            connection = _connection = new DBusConnection(this);
+
+            await connection.ConnectAsync(_setupResult.ConnectionAddress, _setupResult.UserId, _setupResult.SupportsFdPassing, _connectCts.Token);
+
+            lock (_gate)
+            {
+                ThrowHelper.ThrowIfDisposed(_disposed, this);
+
+                if (_connection == connection)
+                {
+                    _connectingTask = null;
+                    _connectCts = null;
+                    _state = ConnectionState.Connected;
+                }
+                else
+                {
+                    throw new DisconnectedException(connection.DisconnectReason);
+                }
+            }
+
+            return connection;
+        }
+        catch (Exception exception)
+        {
+            Disconnect(exception, connection);
+
+            ThrowHelper.ThrowIfDisposed(_disposed, this);
+
+            throw;
+        }
+    }
+
+    public void Dispose()
+    {
+        lock (_gate)
+        {
+            if (_disposed)
+            {
+                return;
+            }
+            _disposed = true;
+        }
+
+        Disconnect(s_disposedSentinel);
+    }
+
+    internal void Disconnect(Exception disconnectReason, DBusConnection? trigger = null)
+    {
+        DBusConnection? connection;
+        ClientSetupResult? setupResult;
+        CancellationTokenSource? connectCts;
+        lock (_gate)
+        {
+            if (trigger is not null && trigger != _connection)
+            {
+                // Already disconnected from this stream.
+                return;
+            }
+
+            ConnectionState state = _state;
+            if (state == ConnectionState.Disconnected)
+            {
+                return;
+            }
+
+            _state = ConnectionState.Disconnected;
+
+            connection = _connection;
+            setupResult = _setupResult;
+            connectCts = _connectCts;
+
+            _connection = null;
+            _connectingTask = null;
+            _setupResult = null;
+            _connectCts = null;
+
+            if (connection is not null)
+            {
+                connection.DisconnectReason = disconnectReason;
+            }
+        }
+
+        connectCts?.Cancel();
+        connection?.Dispose();
+        if (setupResult != null)
+        {
+            _connectionOptions.Teardown(setupResult.TeardownToken);
+        }
+    }
+
+    public async Task CallMethodAsync(MessageBuffer message)
+    {
+        DBusConnection connection;
+        try
+        {
+            connection = await ConnectCoreAsync();
+        }
+        catch
+        {
+            message.ReturnToPool();
+            throw;
+        }
+        await connection.CallMethodAsync(message);
+    }
+
+    public async Task<T> CallMethodAsync<T>(MessageBuffer message, MessageValueReader<T> reader, object? readerState = null)
+    {
+        DBusConnection connection;
+        try
+        {
+            connection = await ConnectCoreAsync();
+        }
+        catch
+        {
+            message.ReturnToPool();
+            throw;
+        }
+        return await connection.CallMethodAsync(message, reader, readerState);
+    }
+
+    public async ValueTask<IDisposable> AddMatchAsync<T>(MatchRule rule, MessageValueReader<T> reader, Action<Exception?, T, object?> handler, object? readerState = null, object? handlerState = null, bool subscribe = true)
+    {
+        DBusConnection connection = await ConnectCoreAsync();
+        return await connection.AddMatchAsync(rule, reader, handler, readerState, handlerState, subscribe);
+    }
+
+    public void AddMethodHandler(IMethodHandler methodHandler)
+        => AddMethodHandlers(new[] { methodHandler });
+
+    public void AddMethodHandlers(IList<IMethodHandler> methodHandlers)
+    {
+        GetConnection()?.AddMethodHandlers(methodHandlers);
+    }
+
+    private static Connection CreateConnection(ref Connection? field, string? address)
+    {
+        address = address ?? "unix:";
+        var connection = Volatile.Read(ref field);
+        if (connection is not null)
+        {
+            return connection;
+        }
+        var newConnection = new Connection(new ClientConnectionOptions(address) { AutoConnect = true });
+        connection = Interlocked.CompareExchange(ref field, newConnection, null);
+        if (connection != null)
+        {
+            newConnection.Dispose();
+            return connection;
+        }
+        return newConnection;
+    }
+
+    public MessageWriter GetMessageWriter() => new MessageWriter(MessagePool.Shared.Rent(), GetNextSerial());
+
+    public bool TrySendMessage(MessageBuffer message)
+    {
+        DBusConnection? connection = GetConnection();
+        if (connection is null)
+        {
+            message.ReturnToPool();
+            return false;
+        }
+        connection.SendMessage(message);
+        return true;
+    }
+
+    private DBusConnection? GetConnection()
+    {
+        lock (_gate)
+        {
+            ThrowHelper.ThrowIfDisposed(_disposed, this);
+
+            if (_connectionOptions.AutoConnect)
+            {
+                throw new InvalidOperationException("Method cannot be used on autoconnect connections.");
+            }
+
+            ConnectionState state = _state;
+
+            if (state == ConnectionState.Created ||
+                state == ConnectionState.Connecting)
+            {
+                throw new InvalidOperationException("Connect before using this method.");
+            }
+
+            return _connection;
+        }
+    }
+
+    internal uint GetNextSerial() => (uint)Interlocked.Increment(ref _nextSerial);
+}

--- a/src/Tmds.DBus.Protocol/ConnectionOptions.cs
+++ b/src/Tmds.DBus.Protocol/ConnectionOptions.cs
@@ -1,0 +1,7 @@
+namespace Tmds.DBus.Protocol;
+
+public abstract class ConnectionOptions
+{
+    internal ConnectionOptions()
+    { }
+}

--- a/src/Tmds.DBus.Protocol/Constants.cs
+++ b/src/Tmds.DBus.Protocol/Constants.cs
@@ -1,0 +1,7 @@
+namespace Tmds.DBus.Protocol;
+
+static class Constants
+{
+    public const int StackAllocByteThreshold = 512;
+    public const int StackAllocCharThreshold = StackAllocByteThreshold / 2;
+}

--- a/src/Tmds.DBus.Protocol/DBusConnection.cs
+++ b/src/Tmds.DBus.Protocol/DBusConnection.cs
@@ -1,0 +1,947 @@
+using System.Net;
+using System.Net.Sockets;
+
+#pragma warning disable VSTHRD100 // Avoid "async void" methods
+
+namespace Tmds.DBus.Protocol;
+
+class DBusConnection : IDisposable
+{
+    private delegate void MessageReceivedHandler(Exception? exception, in Message message, object? state);
+    private static readonly Exception s_disposedSentinel = new ObjectDisposedException(typeof(Connection).FullName);
+
+    enum ConnectionState
+    {
+        Created,
+        Connecting,
+        Connected,
+        Disconnected
+    }
+
+    delegate void MessageHandlerDelegate(Exception? exception, in Message message, object? state1, object? state2, object? state3);
+
+    readonly struct MessageHandler
+    {
+        public MessageHandler(MessageHandlerDelegate handler, object? state1 = null, object? state2 = null, object? state3 = null)
+        {
+            _delegate = handler;
+            _state1 = state1;
+            _state2 = state2;
+            _state3 = state3;
+        }
+
+        public void Invoke(Exception? exception, in Message message)
+        {
+            _delegate(exception, in message, _state1, _state2, _state3);
+        }
+
+        public bool HasValue => _delegate is not null;
+
+        private readonly MessageHandlerDelegate _delegate;
+        private readonly object? _state1;
+        private readonly object? _state2;
+        private readonly object? _state3;
+    }
+
+    delegate void MessageHandlerDelegate4(Exception? exception, in Message message, object? state1, object? state2, object? state3, object? state4);
+
+    readonly struct MessageHandler4
+    {
+        public MessageHandler4(MessageHandlerDelegate4 handler, object? state1 = null, object? state2 = null, object? state3 = null, object? state4 = null)
+        {
+            _delegate = handler;
+            _state1 = state1;
+            _state2 = state2;
+            _state3 = state3;
+            _state4 = state4;
+        }
+
+        public void Invoke(Exception? exception, in Message message)
+        {
+            _delegate(exception, in message, _state1, _state2, _state3, _state4);
+        }
+
+        public bool HasValue => _delegate is not null;
+
+        private readonly MessageHandlerDelegate4 _delegate;
+        private readonly object? _state1;
+        private readonly object? _state2;
+        private readonly object? _state3;
+        private readonly object? _state4;
+    }
+
+    private readonly object _gate = new object();
+    private readonly Connection _parentConnection;
+    private readonly Dictionary<uint, MessageHandler> _pendingCalls;
+    private readonly CancellationTokenSource _connectCts;
+    private readonly Dictionary<string, MatchMaker> _matchMakers;
+    private readonly List<Observer> _matchedObservers;
+    private readonly Dictionary<string, IMethodHandler> _pathHandlers;
+
+    private IMessageStream? _messageStream;
+    private ConnectionState _state;
+    private Exception? _disconnectReason;
+    private string? _localName;
+
+    public string? UniqueName => _localName;
+
+    public Exception DisconnectReason
+    {
+        get => _disconnectReason ?? new ObjectDisposedException(GetType().FullName);
+        set => Interlocked.CompareExchange(ref _disconnectReason, value, null);
+    }
+
+    public bool RemoteIsBus => _localName is not null;
+
+    public DBusConnection(Connection parent)
+    {
+        _parentConnection = parent;
+        _connectCts = new();
+        _pendingCalls = new();
+        _matchMakers = new();
+        _matchedObservers = new();
+        _pathHandlers = new();
+    }
+
+    public async ValueTask ConnectAsync(string address, string? userId, bool supportsFdPassing, CancellationToken cancellationToken)
+    {
+        _state = ConnectionState.Connecting;
+        Exception? firstException = null;
+
+        AddressParser.AddressEntry addr = default;
+        while (AddressParser.TryGetNextEntry(address, ref addr))
+        {
+            Socket? socket = null;
+            EndPoint? endpoint = null;
+            Guid guid = default;
+
+            if (AddressParser.IsType(addr, "unix"))
+            {
+                AddressParser.ParseUnixProperties(addr, out string path, out guid);
+                socket = new Socket(AddressFamily.Unix, SocketType.Stream, ProtocolType.Unspecified);
+                endpoint = new UnixDomainSocketEndPoint(path);
+            }
+            else if (AddressParser.IsType(addr, "tcp"))
+            {
+                AddressParser.ParseTcpProperties(addr, out string host, out int? port, out guid);
+                if (!port.HasValue)
+                {
+                    throw new ArgumentException("port");
+                }
+                socket = new Socket(SocketType.Stream, ProtocolType.Tcp);
+                endpoint = new DnsEndPoint(host, port.Value);
+            }
+
+            if (socket is null)
+            {
+                continue;
+            }
+
+            try
+            {
+                await socket.ConnectAsync(endpoint!, cancellationToken).ConfigureAwait(false);
+
+                MessageStream stream;
+                lock (_gate)
+                {
+                    if (_state != ConnectionState.Connecting)
+                    {
+                        throw new DisconnectedException(DisconnectReason);
+                    }
+                    _messageStream = stream = new MessageStream(socket);
+                }
+
+                await stream.DoClientAuthAsync(guid, userId, supportsFdPassing).ConfigureAwait(false);
+
+                stream.ReceiveMessages(
+                    static (Exception? exception, in Message message, DBusConnection connection) =>
+                        connection.HandleMessages(exception, in message), this);
+
+                lock (_gate)
+                {
+                    if (_state != ConnectionState.Connecting)
+                    {
+                        throw new DisconnectedException(DisconnectReason);
+                    }
+                    _state = ConnectionState.Connected;
+                }
+
+                _localName = await GetLocalNameAsync();
+
+                return;
+            }
+            catch (Exception exception)
+            {
+                socket.Dispose();
+                firstException ??= exception;
+            }
+        }
+
+        if (firstException is not null)
+        {
+            throw firstException;
+        }
+
+        throw new ArgumentException("No addresses were found", nameof(address));
+    }
+
+    private async Task<string?> GetLocalNameAsync()
+    {
+        TaskCompletionSource<string?> tcs = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        await CallMethodAsync(
+            message: CreateHelloMessage(),
+            static (Exception? exception, in Message message, object? state) =>
+            {
+                var tcsState = (TaskCompletionSource<string?>)state!;
+
+                if (exception is not null)
+                {
+                    tcsState.SetException(exception);
+                }
+                else if (message.MessageType == MessageType.MethodReturn)
+                {
+                    tcsState.SetResult(message.GetBodyReader().ReadString().ToString());
+                }
+                else
+                {
+                    tcsState.SetResult(null);
+                }
+            }, tcs);
+
+        return await tcs.Task;
+
+        MessageBuffer CreateHelloMessage()
+        {
+            using var writer = GetMessageWriter();
+
+            writer.WriteMethodCallHeader(
+                destination: "org.freedesktop.DBus",
+                path: "/org/freedesktop/DBus",
+                @interface: "org.freedesktop.DBus",
+                member: "Hello");
+
+            return writer.CreateMessage();
+        }
+    }
+
+    private void HandleMessages(Exception? exception, in Message message)
+    {
+        if (exception is not null)
+        {
+            _parentConnection.Disconnect(exception, this);
+        }
+        else
+        {
+            MessageHandler pendingCall = default;
+            IMethodHandler? messageHandler = null;
+
+            bool isMethodCall = message.MessageType == MessageType.MethodCall;
+
+            lock (_gate)
+            {
+                if (_state == ConnectionState.Disconnected)
+                {
+                    return;
+                }
+
+                if (message.ReplySerial.HasValue)
+                {
+                    _pendingCalls.Remove(message.ReplySerial.Value, out pendingCall);
+                }
+
+                foreach (var matchMaker in _matchMakers.Values)
+                {
+                    if (matchMaker.Matches(message))
+                    {
+                        _matchedObservers.AddRange(matchMaker.Observers);
+                    }
+                }
+
+                if (isMethodCall)
+                {
+                    string path = message.Path.ToString();
+                    if (_pathHandlers.TryGetValue(path, out messageHandler))
+                    {
+
+                    }
+                }
+            }
+
+            foreach (var observer in _matchedObservers)
+            {
+                observer.Emit(in message);
+            }
+            _matchedObservers.Clear();
+
+            if (pendingCall.HasValue)
+            {
+                pendingCall.Invoke(null, in message);
+            }
+
+            if (isMethodCall)
+            {
+                bool handlingMessage = messageHandler is not null && messageHandler.TryHandleMethod(_parentConnection, message);
+
+                if (!handlingMessage)
+                {
+                    SendUnknownMethodError(message);
+                }
+            }
+        }
+
+        void SendUnknownMethodError(in Message methodCall)
+        {
+            if ((methodCall.MessageFlags & MessageFlags.NoReplyExpected) != 0)
+            {
+                return;
+            }
+
+            string errMsg = String.Format("Method \"{0}\" with signature \"{1}\" on interface \"{2}\" doesn't exist",
+                                            methodCall.Member.ToString(),
+                                            methodCall.Signature.ToString(),
+                                            methodCall.Interface.ToString());
+
+            SendErrorReplyMessage(methodCall, "org.freedesktop.DBus.Error.UnknownMethod", errMsg);
+        }
+    }
+
+    public void AddMethodHandlers(IList<IMethodHandler> methodHandlers)
+    {
+        lock (_gate)
+        {
+            int registeredCount = 0;
+
+            try
+            {
+                for (int i = 0; i < methodHandlers.Count; i++)
+                {
+                    IMethodHandler methodHandler = methodHandlers[i];
+
+                    _pathHandlers.Add(methodHandler.Path, methodHandler);
+
+                    registeredCount++;
+                }
+            }
+            catch
+            {
+                for (int i = 0; i < registeredCount; i++)
+                {
+                    IMethodHandler methodHandler = methodHandlers[i];
+
+                    _pathHandlers.Remove(methodHandler.Path);
+                }
+            }
+        }
+    }
+
+    public void Dispose()
+    {
+        lock (_gate)
+        {
+            if (_state == ConnectionState.Disconnected)
+            {
+                return;
+            }
+            _state = ConnectionState.Disconnected;
+        }
+
+        Exception disconnectReason = DisconnectReason;
+
+        _messageStream?.Close(disconnectReason);
+
+        if (_pendingCalls is not null)
+        {
+            Message message = default;
+            foreach (var pendingCall in _pendingCalls.Values)
+            {
+                pendingCall.Invoke(new DisconnectedException(disconnectReason), in message);
+            }
+            _pendingCalls.Clear();
+        }
+
+        if (_matchMakers is not null)
+        {
+            foreach (var matchMaker in _matchMakers.Values)
+            {
+                foreach (var observer in matchMaker.Observers)
+                {
+                    observer.Disconnect(new DisconnectedException(disconnectReason));
+                }
+            }
+            _matchMakers.Clear();
+        }
+    }
+
+    private ValueTask CallMethodAsync(MessageBuffer message, MessageReceivedHandler returnHandler, object? state)
+    {
+        MessageHandlerDelegate fn = static (Exception? exception, in Message message, object? state1, object? state2, object? state3) =>
+        {
+            ((MessageReceivedHandler)state1!)(exception, in message, state2);
+        };
+        MessageHandler handler = new(fn, returnHandler, state);
+
+        return CallMethodAsync(message, handler);
+    }
+
+    private async ValueTask CallMethodAsync(MessageBuffer message, MessageHandler handler)
+    {
+        bool messageSent = false;
+        try
+        {
+            lock (_gate)
+            {
+                if (_state != ConnectionState.Connected)
+                {
+                    throw new DisconnectedException(DisconnectReason!);
+                }
+                // TODO: don't add pending call when NoReplyExpected.
+                _pendingCalls.Add(message.Serial, handler);
+            }
+
+            messageSent = await _messageStream!.TrySendMessageAsync(message);
+        }
+        finally
+        {
+            if (!messageSent)
+            {
+                message.ReturnToPool();
+            }
+        }
+    }
+
+    public async Task<T> CallMethodAsync<T>(MessageBuffer message, MessageValueReader<T> valueReader, object? state = null)
+    {
+        MessageHandlerDelegate fn = static (Exception? exception, in Message message, object? state1, object? state2, object? state3) =>
+        {
+            var valueReaderState = (MessageValueReader<T>)state1!;
+            var tcsState = (TaskCompletionSource<T>)state2!;
+
+            if (exception is not null)
+            {
+                tcsState.SetException(exception);
+            }
+            else if (message.MessageType == MessageType.MethodReturn)
+            {
+                tcsState.SetResult(valueReaderState(in message, state3));
+            }
+            else if (message.MessageType == MessageType.Error)
+            {
+                string errorName = message.ErrorName.ToString();
+                string errMessage = errorName;
+                if (!message.Signature.IsEmpty && (DBusType)message.Signature.Span[0] == DBusType.String)
+                {
+                    errMessage = message.GetBodyReader().ReadString().ToString();
+                }
+                tcsState.SetException(new DBusException(errorName, errMessage));
+            }
+            else
+            {
+                tcsState.SetException(new ProtocolException($"Unexpected reply type: {message.MessageType}."));
+            }
+        };
+
+        TaskCompletionSource<T> tcs = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        MessageHandler handler = new(fn, valueReader, tcs, state);
+
+        await CallMethodAsync(message, handler);
+
+        return await tcs.Task;
+    }
+
+    public async Task CallMethodAsync(MessageBuffer message)
+    {
+        TaskCompletionSource<object?> tcs = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        await CallMethodAsync(message,
+            static (Exception? exception, in Message message, object? state) => CompleteCallTaskCompletionSource(exception, in message, state), tcs);
+
+        await tcs.Task;
+    }
+
+    private static void CompleteCallTaskCompletionSource(Exception? exception, in Message message, object? tcs)
+    {
+        var tcsState = (TaskCompletionSource<object?>)tcs!;
+
+        if (exception is not null)
+        {
+            tcsState.SetException(exception);
+        }
+        else if (message.MessageType == MessageType.MethodReturn)
+        {
+            tcsState.SetResult(null);
+        }
+        else if (message.MessageType == MessageType.Error)
+        {
+            string errorName = message.ErrorName.ToString();
+            string errMessage = errorName;
+            if (!message.Signature.IsEmpty && (DBusType)message.Signature.Span[0] == DBusType.String)
+            {
+                errMessage = message.GetBodyReader().ReadString().ToString();
+            }
+            tcsState.SetException(new DBusException(errorName, errMessage));
+        }
+        else
+        {
+            tcsState.SetException(new ProtocolException($"Unexpected reply type: {message.MessageType}."));
+        }
+    }
+
+    public ValueTask<IDisposable> AddMatchAsync<T>(MatchRule rule, MessageValueReader<T> valueReader, Action<Exception?, T, object?> valueHandler, object? readerState, object? handlerState, bool subscribe)
+    {
+        MessageHandlerDelegate4 fn = static (Exception? exception, in Message message, object? state1, object? state2, object? state3, object? state4) =>
+        {
+            var valueHandlerState = (Action<Exception?, T, object?>)state2!;
+            if (exception is not null)
+            {
+                valueHandlerState(exception, default(T)!, state4);
+            }
+            else
+            {
+                var valueReaderState = (MessageValueReader<T>)state1!;
+                T value = valueReaderState(in message, state3);
+                valueHandlerState(null, value, state4);
+            }
+        };
+
+        return AddMatchAsync(rule, new(fn, valueReader, valueHandler, readerState, handlerState), subscribe);
+    }
+
+    private async ValueTask<IDisposable> AddMatchAsync(MatchRule rule, MessageHandler4 handler, bool subscribe)
+    {
+        MatchRuleData data = rule.Data;
+        MatchMaker? matchMaker;
+        string ruleString;
+        uint nextSerial = 0;
+        bool sendMessage;
+        Observer observer;
+
+        lock (_gate)
+        {
+            if (_state != ConnectionState.Connected)
+            {
+                throw new DisconnectedException(DisconnectReason!);
+            }
+
+            if (!RemoteIsBus)
+            {
+                subscribe = false;
+            }
+
+            ruleString = data.GetRuleString();
+
+            if (!_matchMakers.TryGetValue(ruleString, out matchMaker))
+            {
+                matchMaker = new MatchMaker(this, ruleString, data);
+                _matchMakers.Add(ruleString, matchMaker);
+            }
+
+            observer = new Observer(matchMaker, handler, subscribe);
+            matchMaker.Observers.Add(observer);
+
+            sendMessage = subscribe && matchMaker.AddMatchTcs is null;
+
+            if (sendMessage)
+            {
+                matchMaker.AddMatchTcs = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+                MessageHandlerDelegate fn = static (Exception? exception, in Message message, object? state1, object? state2, object? state3) =>
+                {
+                    var mm = (MatchMaker)state1!;
+                    if (message.MessageType == MessageType.MethodReturn)
+                    {
+                        mm.HasSubscribed = true;
+                    }
+                    CompleteCallTaskCompletionSource(exception, in message, mm.AddMatchTcs!);
+                };
+
+                _pendingCalls.Add(nextSerial, new(fn, matchMaker));
+            }
+        }
+
+        if (subscribe)
+        {
+            if (sendMessage)
+            {
+                var message = CreateAddMatchMessage(matchMaker.RuleString);
+                if (!await _messageStream!.TrySendMessageAsync(message))
+                {
+                    message.ReturnToPool();
+                }
+            }
+
+            try
+            {
+                await matchMaker.AddMatchTcs!.Task;
+            }
+            catch
+            {
+                observer.Dispose();
+
+                throw;
+            }
+        }
+
+        return observer;
+
+        MessageBuffer CreateAddMatchMessage(string ruleString)
+        {
+            using var writer = GetMessageWriter();
+
+            writer.WriteMethodCallHeader(
+                destination: "org.freedesktop.DBus",
+                path: "/org/freedesktop/DBus",
+                @interface: "org.freedesktop.DBus",
+                member: "AddMatch",
+                signature: "s");
+
+            writer.WriteString(ruleString);
+
+            return writer.CreateMessage();
+        }
+    }
+
+    sealed class Observer : IDisposable
+    {
+        private readonly object _gate = new object();
+        private readonly MatchMaker _matchMaker;
+        private readonly MessageHandler4 _messageHandler;
+        private bool _disposed;
+
+        public bool Subscribes { get; }
+
+        public Observer(MatchMaker matchMaker, in MessageHandler4 messageHandler, bool subscribes)
+        {
+            _matchMaker = matchMaker;
+            _messageHandler = messageHandler;
+            Subscribes = subscribes;
+        }
+
+        public void Dispose()
+        {
+            lock (_gate)
+            {
+                if (_disposed)
+                {
+                    return;
+                }
+                _disposed = true;
+
+                Message message = default;
+                // TODO: signal Dispose without allocating an Exception?
+                _messageHandler.Invoke(new ObjectDisposedException(GetType().FullName), in message);
+            }
+
+            _matchMaker.Connection.RemoveObserver(_matchMaker, this);
+        }
+
+        public void Emit(in Message message)
+        {
+            if (Subscribes && !_matchMaker.HasSubscribed)
+            {
+                return;
+            }
+
+            lock (_gate)
+            {
+                if (_disposed)
+                {
+                    return;
+                }
+
+                _messageHandler.Invoke(null, in message);
+            }
+        }
+
+        internal void Disconnect(DisconnectedException disconnectedException)
+        {
+            lock (_gate)
+            {
+                if (_disposed)
+                {
+                    return;
+                }
+                _disposed = true;
+
+                Message message = default;
+                _messageHandler.Invoke(disconnectedException, in message);
+            }
+        }
+    }
+
+    private async void RemoveObserver(MatchMaker matchMaker, Observer observer)
+    {
+        string ruleString = matchMaker.RuleString;
+        bool sendMessage = false;
+
+        lock (_gate)
+        {
+            if (_state == ConnectionState.Disconnected)
+            {
+                return;
+            }
+
+            if (_matchMakers.TryGetValue(ruleString, out _))
+            {
+                matchMaker.Observers.Remove(observer);
+                sendMessage = matchMaker.AddMatchTcs is not null && matchMaker.HasSubscribers;
+                if (sendMessage)
+                {
+                    _matchMakers.Remove(ruleString);
+                }
+            }
+        }
+
+        if (sendMessage)
+        {
+            var message = CreateRemoveMatchMessage();
+            if (!await _messageStream!.TrySendMessageAsync(message))
+            {
+                message.ReturnToPool();
+            }
+        }
+
+        MessageBuffer CreateRemoveMatchMessage()
+        {
+            using var writer = GetMessageWriter();
+
+            writer.WriteMethodCallHeader(
+                destination: "org.freedesktop.DBus",
+                path: "/org/freedesktop/DBus",
+                @interface: "org.freedesktop.DBus",
+                member: "RemoveMatch",
+                signature: "s",
+                flags: MessageFlags.NoReplyExpected);
+
+            writer.WriteString(ruleString);
+
+            return writer.CreateMessage();
+        }
+    }
+
+    sealed class MatchMaker
+    {
+        private readonly MessageType? _type;
+        private readonly byte[]? _sender;
+        private readonly byte[]? _interface;
+        private readonly byte[]? _member;
+        private readonly byte[]? _path;
+        private readonly byte[]? _pathNamespace;
+        private readonly byte[]? _destination;
+        private readonly byte[]? _arg0;
+        private readonly byte[]? _arg0Path;
+        private readonly byte[]? _arg0Namespace;
+        private readonly string _rule;
+
+        public List<Observer> Observers { get; } = new();
+
+        public TaskCompletionSource<object?>? AddMatchTcs { get; set; }
+
+        public bool HasSubscribed { get; set; }
+
+        public DBusConnection Connection { get; }
+
+        public MatchMaker(DBusConnection connection, string rule, in MatchRuleData data)
+        {
+            Connection = connection;
+            _rule = rule;
+
+            _type = data.MessageType;
+
+            if (data.Sender is not null && data.Sender.StartsWith(":"))
+            {
+                _sender = Encoding.UTF8.GetBytes(data.Sender);
+            }
+            if (data.Interface is not null)
+            {
+                _interface = Encoding.UTF8.GetBytes(data.Interface);
+            }
+            if (data.Member is not null)
+            {
+                _member = Encoding.UTF8.GetBytes(data.Member);
+            }
+            if (data.Path is not null)
+            {
+                _path = Encoding.UTF8.GetBytes(data.Path);
+            }
+            if (data.PathNamespace is not null)
+            {
+                _pathNamespace = Encoding.UTF8.GetBytes(data.PathNamespace);
+            }
+            if (data.Destination is not null)
+            {
+                _destination = Encoding.UTF8.GetBytes(data.Destination);
+            }
+            if (data.Arg0 is not null)
+            {
+                _arg0 = Encoding.UTF8.GetBytes(data.Arg0);
+            }
+            if (data.Arg0Path is not null)
+            {
+                _arg0Path = Encoding.UTF8.GetBytes(data.Arg0Path);
+            }
+            if (data.Arg0Namespace is not null)
+            {
+                _arg0Namespace = Encoding.UTF8.GetBytes(data.Arg0Namespace);
+            }
+        }
+
+        public string RuleString => _rule;
+
+        public bool HasSubscribers
+        {
+            get
+            {
+                if (Observers.Count == 0)
+                {
+                    return false;
+                }
+                foreach (var observer in Observers)
+                {
+                    if (observer.Subscribes)
+                    {
+                        return true;
+                    }
+                }
+                return false;
+            }
+        }
+
+        public override string ToString() => _rule;
+
+        internal bool Matches(in Message message) // TODO: 'in' arg
+        {
+            if (_type.HasValue && _type != message.MessageType)
+            {
+                return false;
+            }
+
+            if (_sender is not null && !message.Sender.Span.SequenceEqual(_sender))
+            {
+                return false;
+            }
+
+            if (_interface is not null && !message.Interface.Span.SequenceEqual(_interface))
+            {
+                return false;
+            }
+
+            if (_member is not null && !message.Member.Span.SequenceEqual(_member))
+            {
+                return false;
+            }
+
+            if (_path is not null && !message.Path.Span.SequenceEqual(_path))
+            {
+                return false;
+            }
+
+            if (_destination is not null && !message.Destination.Span.SequenceEqual(_destination))
+            {
+                return false;
+            }
+
+            if (_pathNamespace is not null && !IsEqualOrChildOfPath(message.Path, _pathNamespace))
+            {
+                return false;
+            }
+
+            if (_arg0Namespace is not null ||
+                _arg0 is not null ||
+                _arg0Path is not null)
+            {
+                if (message.Signature.IsEmpty)
+                {
+                    return false;
+                }
+
+                DBusType arg0Type = (DBusType)message.Signature.Span[0];
+
+                if (arg0Type != DBusType.String ||
+                    arg0Type != DBusType.ObjectPath)
+                {
+                    return false;
+                }
+
+                ReadOnlySpan<byte> arg0 = message.GetBodyReader().ReadString();
+
+                if (_arg0Path is not null && !IsEqualParentOrChildOfPath(arg0, _arg0Path))
+                {
+                    return false;
+                }
+
+                if (arg0Type != DBusType.String)
+                {
+                    return false;
+                }
+
+                if (_arg0 is not null && !arg0.SequenceEqual(_arg0))
+                {
+                    return false;
+                }
+
+                if (_arg0Namespace is not null && !IsEqualOrChildOfName(_arg0, _arg0Namespace))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        private static bool IsEqualOrChildOfName(ReadOnlySpan<byte> lhs, ReadOnlySpan<byte> rhs)
+        {
+            return lhs.StartsWith(rhs) && (lhs.Length == rhs.Length || lhs[rhs.Length] == '.');
+        }
+
+        private static bool IsEqualOrChildOfPath(ReadOnlySpan<byte> lhs, ReadOnlySpan<byte> rhs)
+        {
+            return lhs.StartsWith(rhs) && (lhs.Length == rhs.Length || lhs[rhs.Length] == '/');
+        }
+
+        private static bool IsEqualParentOrChildOfPath(ReadOnlySpan<byte> lhs, ReadOnlySpan<byte> rhs)
+        {
+            if (rhs.Length < lhs.Length)
+            {
+                return rhs[rhs.Length - 1] == '/' && lhs.StartsWith(rhs);
+            }
+            else if (lhs.Length < rhs.Length)
+            {
+                return lhs[lhs.Length - 1] == '/' && rhs.StartsWith(lhs);
+            }
+            else
+            {
+                return lhs.SequenceEqual(rhs);
+            }
+        }
+    }
+
+    public MessageWriter GetMessageWriter() => _parentConnection.GetMessageWriter();
+
+    public async void SendMessage(MessageBuffer message)
+    {
+        bool messageSent = await _messageStream!.TrySendMessageAsync(message);
+        if (!messageSent)
+        {
+            message.ReturnToPool();
+        }
+    }
+
+    private void SendErrorReplyMessage(in Message methodCall, string errorName, string errorMsg)
+    {
+        SendMessage(CreateErrorMessage(methodCall, errorName, errorMsg));
+
+        MessageBuffer CreateErrorMessage(Message methodCall, string errorName, string errorMsg)
+        {
+            using var writer = GetMessageWriter();
+
+            writer.WriteError(
+                replySerial: methodCall.Serial,
+                destination: methodCall.Sender,
+                errorName: errorName,
+                errorMsg: errorMsg);
+
+            return writer.CreateMessage();
+        }
+    }
+}

--- a/src/Tmds.DBus.Protocol/DBusEnvironment.cs
+++ b/src/Tmds.DBus.Protocol/DBusEnvironment.cs
@@ -1,0 +1,39 @@
+namespace Tmds.DBus.Protocol;
+
+static class DBusEnvironment
+{
+    public static string? UserId
+    {
+        get
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                return System.Security.Principal.WindowsIdentity.GetCurrent().User?.Value;
+            }
+            else
+            {
+                return geteuid().ToString();
+            }
+        }
+    }
+
+    public static string MachineId
+    {
+        get
+        {
+            const string MachineUuidPath = @"/var/lib/dbus/machine-id";
+
+            if (File.Exists(MachineUuidPath))
+            {
+                return Guid.Parse(File.ReadAllText(MachineUuidPath).Substring(0, 32)).ToString();
+            }
+            else
+            {
+                return Guid.Empty.ToString();
+            }
+        }
+    }
+
+    [DllImport("libc")]
+    internal static extern uint geteuid();
+}

--- a/src/Tmds.DBus.Protocol/DBusException.cs
+++ b/src/Tmds.DBus.Protocol/DBusException.cs
@@ -1,0 +1,15 @@
+namespace Tmds.DBus.Protocol;
+
+public class DBusException : Exception
+{
+    public DBusException(string errorName, string errorMessage) :
+        base($"{errorName}: {errorMessage}")
+    {
+        ErrorName = errorName;
+        ErrorMessage = errorMessage;
+    }
+
+    public string ErrorName { get; }
+
+    public string ErrorMessage { get; }
+}

--- a/src/Tmds.DBus.Protocol/DBusType.cs
+++ b/src/Tmds.DBus.Protocol/DBusType.cs
@@ -1,0 +1,23 @@
+namespace Tmds.DBus.Protocol;
+
+public enum DBusType : byte
+{
+    Invalid = 0,
+    Byte = (byte)'y',
+    Bool = (byte)'b',
+    Int16 = (byte)'n',
+    UInt16 = (byte)'q',
+    Int32 = (byte)'i',
+    UInt32 = (byte)'u',
+    Int64 = (byte)'x',
+    UInt64 = (byte)'t',
+    Double = (byte)'d',
+    String = (byte)'s',
+    ObjectPath = (byte)'o',
+    Signature = (byte)'g',
+    Array = (byte)'a',
+    Struct = (byte)'(',
+    Variant = (byte)'v',
+    DictEntry = (byte)'{',
+    UnixFd = (byte)'h', // TODO: rename to Handle
+}

--- a/src/Tmds.DBus.Protocol/DisconnectedException.cs
+++ b/src/Tmds.DBus.Protocol/DisconnectedException.cs
@@ -1,0 +1,6 @@
+namespace Tmds.DBus.Protocol;
+public class DisconnectedException : Exception
+{
+    internal DisconnectedException(Exception innerException) : base(innerException.Message, innerException)
+    { }
+}

--- a/src/Tmds.DBus.Protocol/GlobalUsings.cs
+++ b/src/Tmds.DBus.Protocol/GlobalUsings.cs
@@ -1,0 +1,13 @@
+global using System;
+global using System.Buffers;
+global using System.Buffers.Binary;
+global using System.Collections.Generic;
+global using System.Diagnostics;
+global using System.IO;
+global using System.Linq;
+global using System.Runtime.CompilerServices;
+global using System.Runtime.InteropServices;
+global using System.Text;
+global using System.Threading;
+global using System.Threading.Tasks;
+global using Nerdbank.Streams;

--- a/src/Tmds.DBus.Protocol/IMessageStream.cs
+++ b/src/Tmds.DBus.Protocol/IMessageStream.cs
@@ -1,0 +1,12 @@
+namespace Tmds.DBus.Protocol;
+
+interface IMessageStream
+{
+    public delegate void MessageReceivedHandler<T>(Exception? closeReason, in Message message, T state);
+
+    void ReceiveMessages<T>(MessageReceivedHandler<T> handler, T state);
+
+    ValueTask<bool> TrySendMessageAsync(MessageBuffer message);
+
+    void Close(Exception closeReason);
+}

--- a/src/Tmds.DBus.Protocol/MatchRule.cs
+++ b/src/Tmds.DBus.Protocol/MatchRule.cs
@@ -1,0 +1,120 @@
+namespace Tmds.DBus.Protocol;
+
+struct MatchRuleData
+{
+    public MessageType? MessageType { get; set; }
+
+    public string? Sender { get; set; }
+
+    public string? Interface { get; set; }
+
+    public string? Member { get; set; }
+
+    public string? Path { get; set; }
+
+    public string? PathNamespace { get; set; }
+
+    public string? Destination { get; set; }
+
+    public string? Arg0 { get; set; }
+
+    public string? Arg0Path { get; set; }
+
+    public string? Arg0Namespace { get; set; }
+
+    public string GetRuleString()
+    {
+        var sb = new StringBuilder(); // TODO: pool
+
+        if (MessageType.HasValue)
+        {
+            string? typeMatch = MessageType switch
+            {
+                Protocol.MessageType.MethodCall => "type=method_call",
+                Protocol.MessageType.MethodReturn => "type=method_return",
+                Protocol.MessageType.Error => "type=error",
+                Protocol.MessageType.Signal => "type=signal",
+                _ => null
+            };
+
+            if (typeMatch is not null)
+            {
+                sb.Append(typeMatch);
+            }
+        }
+
+        Append(sb, "sender", Sender);
+        Append(sb, "interface", Interface);
+        Append(sb, "member", Member);
+        Append(sb, "path", Path);
+        Append(sb, "pathNamespace", PathNamespace);
+        Append(sb, "destination", Destination);
+        Append(sb, "arg0", Arg0);
+        Append(sb, "arg0Path", Arg0Path);
+        Append(sb, "arg0Namespace", Arg0Namespace);
+
+        return sb.ToString();
+
+        static void Append(StringBuilder sb, string key, string? value)
+        {
+            if (value is null)
+            {
+                return;
+            }
+
+            sb.Append($"{(sb.Length > 0 ? ',' : "")}{key}=");
+
+            bool quoting = false;
+
+            ReadOnlySpan<char> span = value.AsSpan();
+            while (!span.IsEmpty)
+            {
+                int specialPos = span.IndexOfAny((ReadOnlySpan<char>)new char[] { ',', '\'' });
+                if (specialPos == -1)
+                {
+                    sb.Append(span);
+                    break;
+                }
+                bool isComma = span[specialPos] == ',';
+                if (isComma && !quoting ||
+                    !isComma && quoting)
+                {
+                    sb.Append("'");
+                    quoting = !quoting;
+                }
+                sb.Append(span.Slice(0, specialPos + (isComma ? 1 : 0)));
+                if (!isComma)
+                {
+                    sb.Append("\\'");
+                }
+                span = span.Slice(specialPos + 1);
+            }
+
+            if (quoting)
+            {
+                sb.Append("'");
+                quoting = false;
+            }
+        }
+    }
+}
+
+public sealed class MatchRule
+{
+    private MatchRuleData _data;
+
+    internal MatchRuleData Data => _data;
+
+    public MessageType? Type { get => _data.MessageType; set => _data.MessageType = value; }
+    public string? Sender { get => _data.Sender; set => _data.Sender = value; }
+    public string? Interface { get => _data.Interface; set => _data.Interface = value; }
+    public string? Member { get => _data.Member; set => _data.Member = value; }
+    public string? Path { get => _data.Path; set => _data.Path = value; }
+    public string? PathNamespace { get => _data.PathNamespace; set => _data.PathNamespace = value; }
+    public string? Destination { get => _data.Destination; set => _data.Destination = value; }
+    public string? Arg0 { get => _data.Arg0; set => _data.Arg0 = value; }
+    public string? Arg0Path { get => _data.Arg0Path; set => _data.Arg0Path = value; }
+    public string? Arg0Namespace { get => _data.Arg0Namespace; set => _data.Arg0Namespace = value; }
+
+    public override string ToString() => _data.GetRuleString();
+}

--- a/src/Tmds.DBus.Protocol/Message.cs
+++ b/src/Tmds.DBus.Protocol/Message.cs
@@ -1,0 +1,148 @@
+namespace Tmds.DBus.Protocol;
+
+public readonly ref struct Message
+{
+    private const int HeaderFieldsLengthOffset = 12;
+
+    private readonly bool _isBigEndian;
+    private readonly UnixFdCollection? _handles;
+    private readonly ReadOnlySequence<byte> _body;
+
+    public MessageType MessageType { get; }
+    public MessageFlags MessageFlags { get; }
+    public uint Serial { get; }
+
+    // Header Fields
+    public Utf8Span Path { get; }
+    public Utf8Span Interface { get; }
+    public Utf8Span Member { get; }
+    public Utf8Span ErrorName { get; }
+    public uint? ReplySerial { get; }
+    public Utf8Span Destination { get; }
+    public Utf8Span Sender { get; }
+    public Utf8Span Signature { get; }
+    public int UnixFdCount { get; }
+
+    public Reader GetBodyReader() => new Reader(_isBigEndian, _body, _handles);
+
+    private Message(ReadOnlySequence<byte> sequence, bool isBigEndian, MessageType type, MessageFlags flags, uint serial, UnixFdCollection? handles)
+    {
+        _isBigEndian = isBigEndian;
+        MessageType = type;
+        MessageFlags = flags;
+        Serial = serial;
+        _handles = handles;
+
+        Path = default;
+        Interface = default;
+        Member = default;
+        ErrorName = default;
+        ReplySerial = default;
+        Destination = default;
+        Sender = default;
+        Signature = default;
+        UnixFdCount = default;
+
+        var reader = new Reader(isBigEndian, sequence, null);
+        reader.Advance(HeaderFieldsLengthOffset);
+
+        ArrayEnd headersEnd = reader.ReadArrayStart(DBusType.Struct);
+        while (reader.HasNext(headersEnd))
+        {
+            MessageHeader hdrType = (MessageHeader)reader.ReadByte();
+            ReadOnlySpan<byte> sig = reader.ReadSignature();
+            switch (hdrType)
+            {
+                case MessageHeader.Path:
+                    Path = reader.ReadObjectPath();
+                    break;
+                case MessageHeader.Interface:
+                    Interface = reader.ReadString();
+                    break;
+                case MessageHeader.Member:
+                    Member = reader.ReadString();
+                    break;
+                case MessageHeader.ErrorName:
+                    ErrorName = reader.ReadString();
+                    break;
+                case MessageHeader.ReplySerial:
+                    ReplySerial = reader.ReadUInt32();
+                    break;
+                case MessageHeader.Destination:
+                    Destination = reader.ReadString();
+                    break;
+                case MessageHeader.Sender:
+                    Sender = reader.ReadString();
+                    break;
+                case MessageHeader.Signature:
+                    Signature = reader.ReadSignature();
+                    break;
+                case MessageHeader.UnixFds:
+                    UnixFdCount = (int)reader.ReadUInt32();
+                    // TODO: throw if handles contains less.
+                    break;
+                default:
+                    throw new NotSupportedException();
+            }
+        }
+        reader.AlignStruct();
+
+        _body = reader.UnreadSequence;
+    }
+
+    internal static bool TryReadMessage(ref ReadOnlySequence<byte> sequence, out Message message, UnixFdCollection? handles = null)
+    {
+        message = default;
+
+        SequenceReader<byte> seqReader = new(sequence);
+        if (!seqReader.TryRead(out byte endianness) ||
+            !seqReader.TryRead(out byte msgType) ||
+            !seqReader.TryRead(out byte flags) ||
+            !seqReader.TryRead(out byte version))
+        {
+            return false;
+        }
+
+        if (version != 1)
+        {
+            throw new NotSupportedException();
+        }
+
+        bool isBigEndian = endianness == 'B';
+
+        if (!TryReadUInt32(ref seqReader, isBigEndian, out uint bodyLength) ||
+            !TryReadUInt32(ref seqReader, isBigEndian, out uint serial) ||
+            !TryReadUInt32(ref seqReader, isBigEndian, out uint headerFieldLength))
+        {
+            return false;
+        }
+
+        headerFieldLength = (uint)ProtocolConstants.Align((int)headerFieldLength, DBusType.Struct);
+
+        long totalLength = seqReader.Consumed + headerFieldLength + bodyLength;
+
+        if (sequence.Length < totalLength)
+        {
+            return false;
+        }
+
+        message = new Message(sequence.Slice(0, totalLength),
+                                    isBigEndian,
+                                    (MessageType)msgType,
+                                    (MessageFlags)flags,
+                                    serial,
+                                    handles);
+
+        sequence = sequence.Slice(totalLength);
+
+        return true;
+
+        static bool TryReadUInt32(ref SequenceReader<byte> seqReader, bool isBigEndian, out uint value)
+        {
+            int v;
+            bool rv = (isBigEndian && seqReader.TryReadBigEndian(out v) || seqReader.TryReadLittleEndian(out v));
+            value = (uint)v;
+            return rv;
+        }
+    }
+}

--- a/src/Tmds.DBus.Protocol/MessageBuffer.cs
+++ b/src/Tmds.DBus.Protocol/MessageBuffer.cs
@@ -1,0 +1,50 @@
+using System.Collections.ObjectModel;
+
+namespace Tmds.DBus.Protocol;
+
+public sealed class MessageBuffer
+{
+    private readonly MessagePool _messagePool;
+    private readonly Sequence<byte> _sequence;
+    private List<SafeHandle>? _handles;
+    private ReadOnlyCollection<SafeHandle>? _readonlyCollection;
+
+    internal int HandleCount => _handles?.Count ?? 0;
+
+    internal uint Serial { get; set; }
+
+    internal long Length => _sequence.Length;
+
+    internal MessageBuffer(MessagePool messagePool, Sequence<byte> sequence)
+    {
+        _messagePool = messagePool;
+        _sequence = sequence;
+    }
+
+    internal void ReturnToPool()
+    {
+        _sequence.Reset();
+        _messagePool.Return(this);
+        // TODO: dispose handles.
+        // TODO: return to pool...
+    }
+
+    internal IBufferWriter<byte> Writer => _sequence;
+
+    internal Span<byte> GetSpan(int sizeHint) => _sequence.GetSpan(sizeHint);
+
+    internal void Advance(int count) => _sequence.Advance(count);
+
+    internal ReadOnlySequence<byte> AsReadOnlySequence() => _sequence.AsReadOnlySequence;
+
+    internal Message GetMessage()
+    {
+        var sequence = AsReadOnlySequence();
+        bool messageRead = Message.TryReadMessage(ref sequence, out Message message, null);
+        Debug.Assert(messageRead);
+        return message;
+    }
+
+    internal IReadOnlyList<SafeHandle>? Handles =>
+        _readonlyCollection ?? (_readonlyCollection = _handles?.AsReadOnly());
+}

--- a/src/Tmds.DBus.Protocol/MessageFlags.cs
+++ b/src/Tmds.DBus.Protocol/MessageFlags.cs
@@ -1,0 +1,10 @@
+namespace Tmds.DBus.Protocol;
+
+[Flags]
+public enum MessageFlags : byte
+{
+    None = 0,
+    NoReplyExpected = 1,
+    NoAutoStart = 2,
+    AllowInteractiveAuthorization = 4
+}

--- a/src/Tmds.DBus.Protocol/MessageFormatter.cs
+++ b/src/Tmds.DBus.Protocol/MessageFormatter.cs
@@ -1,0 +1,159 @@
+namespace Tmds.DBus.Protocol;
+
+class MessageFormatter
+{
+    public static void FormatMessage(in Message msg, StringBuilder sb)
+    {
+        // Header.
+        Append(sb, msg.MessageType);
+        sb.Append(" serial=");
+        sb.Append(msg.Serial);
+        if (msg.ReplySerial.HasValue)
+        {
+            sb.Append(" rserial=");
+            sb.Append(msg.ReplySerial.Value);
+        }
+        Append(sb, " err", msg.ErrorName);
+        Append(sb, " path", msg.Path);
+        Append(sb, " memb", msg.Member);
+        Append(sb, " body", msg.Signature);
+        Append(sb, " src", msg.Sender);
+        Append(sb, " dst", msg.Destination);
+        Append(sb, " ifac", msg.Interface);
+        if (msg.UnixFdCount != 0)
+        {
+            sb.Append(" fds=");
+            sb.Append(msg.UnixFdCount);
+        }
+
+        sb.AppendLine();
+
+        // Body.
+        int indent = 2;
+        Reader reader = msg.GetBodyReader();
+        ReadData(sb, ref reader, msg.Signature, indent);
+
+        // Remove final newline.
+        sb.Remove(sb.Length - Environment.NewLine.Length, Environment.NewLine.Length);
+    }
+
+    private static void ReadData(StringBuilder sb, ref Reader reader, Utf8Span signature, int indent)
+    {
+        var sigReader = new SignatureReader(signature);
+        while (sigReader.TryRead(out DBusType type, out ReadOnlySpan<byte> innerSignature))
+        {
+            if (type == DBusType.Invalid)
+            {
+                // TODO something is wrong, complain loudly.
+                break;
+            }
+            sb.Append(' ', indent);
+            switch (type)
+            {
+                // case DBusType.Byte:
+                //     sb.AppendLine($"byte   {msg.ReadByte()}");
+                //     break;
+                // case DBusType.Bool:
+                //     sb.AppendLine($"bool   {msg.ReadBool()}");
+                //     break;
+                // case DBusType.Int16:
+                //     sb.AppendLine($"int16  {msg.ReadInt16()}");
+                //     break;
+                // case DBusType.UInt16:
+                //     sb.AppendLine($"uint16 {msg.ReadUInt16()}");
+                //     break;
+                // case DBusType.Int32:
+                //     sb.AppendLine($"int32  {msg.ReadInt32()}");
+                //     break;
+                case DBusType.UInt32:
+                    sb.AppendLine($"uint32 {reader.ReadUInt32()}");
+                    break;
+                // case DBusType.Int64:
+                //     sb.Append($"int64  {msg.ReadInt64()}");
+                //     break;
+                // case DBusType.UInt64:
+                //     sb.Append($"uint64 {msg.ReadUInt64()}");
+                //     break;
+                // case DBusType.Double:
+                //     sb.Append($"double {msg.ReadDouble()}");
+                //     break;
+                case DBusType.UnixFd:
+                    sb.AppendLine($"fd     {reader.ReadHandle(own: false)}");
+                    break;
+                case DBusType.String:
+                    sb.Append("string ");
+                    sb.AppendUTF8(reader.ReadString()); // TODO: handle long strings without allocating.
+                    sb.AppendLine();
+                    break;
+                case DBusType.ObjectPath:
+                    sb.Append("path   ");
+                    sb.AppendUTF8(reader.ReadObjectPath()); // TODO: handle long strings without allocating.
+                    sb.AppendLine();
+                    break;
+                case DBusType.Signature:
+                    sb.Append("sig    ");
+                    sb.AppendUTF8(reader.ReadSignature());
+                    sb.AppendLine();
+                    break;
+                case DBusType.Array:
+                    sb.AppendLine("array  [");
+                    ArrayEnd itEnd = reader.ReadArrayStart((DBusType)innerSignature[0]);
+                    while (reader.HasNext(itEnd))
+                    {
+                        ReadData(sb, ref reader, innerSignature, indent + 2);
+                    }
+                    sb.Append(' ', indent);
+                    sb.AppendLine("]");
+                    break;
+                case DBusType.Struct:
+                    sb.AppendLine("struct (");
+                    ReadData(sb, ref reader, innerSignature, indent + 2);
+                    sb.Append(' ', indent);
+                    sb.AppendLine(")");
+                    break;
+                case DBusType.Variant:
+                    sb.AppendLine("var   ("); // TODO: merge with next line
+                    ReadData(sb, ref reader, reader.ReadSignature(), indent + 2);
+                    sb.Append(' ', indent);
+                    sb.AppendLine(")");
+                    break;
+                case DBusType.DictEntry:
+                    sb.AppendLine("dicte (");
+                    ReadData(sb, ref reader, innerSignature, indent + 2);
+                    sb.Append(' ', indent);
+                    sb.AppendLine(")");
+                    break;
+            }
+        }
+        // TODO: complain if there is still data left.
+    }
+
+    private static void Append(StringBuilder sb, MessageType type)
+    {
+        switch (type)
+        {
+            case MessageType.MethodCall:
+                sb.Append("call"); break;
+            case MessageType.MethodReturn:
+                sb.Append("ret "); break;
+            case MessageType.Error:
+                sb.Append("err "); break;
+            case MessageType.Signal:
+                sb.Append("sig "); break;
+            default:
+                sb.Append($"?{type}"); break;
+        }
+    }
+
+    private static void Append(StringBuilder sb, string field, Utf8Span value)
+    {
+        if (value.IsEmpty)
+        {
+            return;
+        }
+
+        sb.Append(field);
+        sb.Append('=');
+        sb.AppendUTF8(value);
+    }
+}

--- a/src/Tmds.DBus.Protocol/MessageHeader.cs
+++ b/src/Tmds.DBus.Protocol/MessageHeader.cs
@@ -1,0 +1,14 @@
+namespace Tmds.DBus.Protocol;
+
+internal enum MessageHeader : byte
+{
+    Path = 1,
+    Interface = 2,
+    Member = 3,
+    ErrorName = 4,
+    ReplySerial = 5,
+    Destination = 6,
+    Sender = 7,
+    Signature = 8,
+    UnixFds = 9
+}

--- a/src/Tmds.DBus.Protocol/MessagePool.cs
+++ b/src/Tmds.DBus.Protocol/MessagePool.cs
@@ -1,0 +1,44 @@
+namespace Tmds.DBus.Protocol;
+
+class MessagePool
+{
+    public static readonly MessagePool Shared = new MessagePool(Environment.ProcessorCount * 2);
+
+    private const int MinimumSpanLength = 512;
+
+    private readonly int _maxSize;
+    private readonly Stack<MessageBuffer> _pool = new Stack<MessageBuffer>();
+
+    private readonly ArrayPool<byte> _arrayPool = ArrayPool<byte>.Create(80 * 1024, 100);
+
+    internal MessagePool(int maxSize)
+    {
+        _maxSize = maxSize;
+    }
+
+    public MessageBuffer Rent()
+    {
+        lock (_pool)
+        {
+            if (_pool.Count > 0)
+            {
+                return _pool.Pop();
+            }
+        }
+
+        var sequence = new Sequence<byte>(_arrayPool) { MinimumSpanLength = MinimumSpanLength };
+
+        return new MessageBuffer(this, sequence);
+    }
+
+    internal void Return(MessageBuffer value)
+    {
+        lock (_pool)
+        {
+            if (_pool.Count < _maxSize)
+            {
+                _pool.Push(value);
+            }
+        }
+    }
+}

--- a/src/Tmds.DBus.Protocol/MessageStream.cs
+++ b/src/Tmds.DBus.Protocol/MessageStream.cs
@@ -1,0 +1,390 @@
+using System.IO.Pipelines;
+using System.Net.Sockets;
+using System.Threading.Channels;
+
+namespace Tmds.DBus.Protocol;
+
+#pragma warning disable VSTHRD100 // Avoid "async void" methods
+
+class MessageStream : IMessageStream
+{
+    private static readonly ReadOnlyMemory<byte> OneByteArray = new[] { (byte)0 };
+    private readonly Socket _socket;
+    private readonly UnixFdCollection? _fdCollection;
+    private bool _supportsFdPassing;
+
+    // Messages going out.
+    private readonly ChannelReader<MessageBuffer> _messageReader;
+    private readonly ChannelWriter<MessageBuffer> _messageWriter;
+
+    // Bytes coming in.
+    private readonly PipeWriter _pipeWriter;
+    private readonly PipeReader _pipeReader;
+
+    private Exception? _completionException;
+
+    public MessageStream(Socket socket)
+    {
+        _socket = socket;
+        Channel<MessageBuffer> channel = Channel.CreateUnbounded<MessageBuffer>(); // TODO: review options.
+        _messageReader = channel.Reader;
+        _messageWriter = channel.Writer;
+        var pipe = new Pipe(); // TODO: review options.
+        _pipeReader = pipe.Reader;
+        _pipeWriter = pipe.Writer;
+        if (_supportsFdPassing)
+        {
+            _fdCollection = new();
+        }
+    }
+
+    private async void ReadFromSocketIntoPipe()
+    {
+        var writer = _pipeWriter;
+        Exception? exception = null;
+        try
+        {
+            while (true)
+            {
+                Memory<byte> memory = writer.GetMemory(1024);
+                int bytesRead = await _socket.ReceiveAsync(memory, _fdCollection);
+                if (bytesRead == 0)
+                {
+                    throw new IOException("Connection closed by peer");
+                }
+                writer.Advance(bytesRead);
+
+                await writer.FlushAsync();
+            }
+        }
+        catch (Exception e)
+        {
+            exception = e;
+        }
+        writer.Complete(exception);
+    }
+
+    private async void ReadMessagesIntoSocket()
+    {
+        while (true)
+        {
+            if (!await _messageReader.WaitToReadAsync())
+            {
+                // No more messages will be coming.
+                return;
+            }
+            var message = await _messageReader.ReadAsync();
+            try
+            {
+                IReadOnlyList<SafeHandle>? handles = _supportsFdPassing ? message.Handles : null;
+                var buffer = message.AsReadOnlySequence();
+                if (buffer.IsSingleSegment)
+                {
+                    await _socket.SendAsync(buffer.First, handles);
+                }
+                else
+                {
+                    SequencePosition position = buffer.Start;
+                    while (buffer.TryGet(ref position, out ReadOnlyMemory<byte> memory))
+                    {
+                        await _socket.SendAsync(buffer.First, handles);
+                        handles = null;
+                    }
+                }
+            }
+            catch (Exception exception)
+            {
+                Close(exception);
+                return;
+            }
+            finally
+            {
+                message.ReturnToPool();
+            }
+        }
+    }
+
+    public async void ReceiveMessages<T>(IMessageStream.MessageReceivedHandler<T> handler, T state)
+    {
+        var reader = _pipeReader;
+        try
+        {
+            while (true)
+            {
+                ReadResult result = await reader.ReadAsync();
+                ReadOnlySequence<byte> buffer = result.Buffer;
+
+                ReadMessages(ref buffer, _fdCollection, handler, state);
+
+                reader.AdvanceTo(buffer.Start, buffer.End);
+            }
+        }
+        catch (Exception exception)
+        {
+            exception = CloseCore(exception);
+            OnException(exception, handler, state);
+        }
+        finally
+        {
+            _fdCollection?.Dispose();
+        }
+
+        static void ReadMessages<TState>(ref ReadOnlySequence<byte> buffer, UnixFdCollection? fdCollection, IMessageStream.MessageReceivedHandler<TState> handler, TState state)
+        {
+            while (Message.TryReadMessage(ref buffer, out Message message, fdCollection))
+            {
+                handler(closeReason: null, in message, state);
+            }
+        }
+
+        static void OnException(Exception exception, IMessageStream.MessageReceivedHandler<T> handler, T state)
+        {
+            Message message = default;
+            handler(exception, in message, state);
+        }
+    }
+
+    private struct AuthenticationResult
+    {
+        public bool IsAuthenticated;
+        public bool SupportsFdPassing;
+        public Guid Guid;
+    }
+
+    public async ValueTask DoClientAuthAsync(Guid guid, string? userId, bool supportsFdPassing)
+    {
+        ReadFromSocketIntoPipe();
+
+        // send 1 byte
+        await _socket.SendAsync(OneByteArray, SocketFlags.None).ConfigureAwait(false);
+        // auth
+        var authenticationResult = await SendAuthCommandsAsync(userId, supportsFdPassing).ConfigureAwait(false);
+        _supportsFdPassing = authenticationResult.SupportsFdPassing;
+        if (guid != Guid.Empty)
+        {
+            if (guid != authenticationResult.Guid)
+            {
+                throw new ConnectException("Authentication failure: Unexpected GUID");
+            }
+        }
+
+        ReadMessagesIntoSocket();
+    }
+
+    private async ValueTask<AuthenticationResult> SendAuthCommandsAsync(string? userId, bool supportsFdPassing)
+    {
+        AuthenticationResult result;
+        if (userId is not null)
+        {
+            string command = CreateAuthExternalCommand(userId);
+
+            result = await SendAuthCommandAsync(command, supportsFdPassing).ConfigureAwait(false);
+
+            if (result.IsAuthenticated)
+            {
+                return result;
+            }
+        }
+
+        result = await SendAuthCommandAsync("AUTH ANONYMOUS\r\n", supportsFdPassing).ConfigureAwait(false);
+        if (result.IsAuthenticated)
+        {
+            return result;
+        }
+
+        throw new ConnectException("Authentication failure");
+    }
+
+    private static string CreateAuthExternalCommand(string userId)
+    {
+        const string AuthExternal = "AUTH EXTERNAL ";
+        const string hexchars = "0123456789abcdef";
+#if NETSTANDARD2_0
+        StringBuilder sb = new();
+        sb.Append(AuthExternal);
+        for (int i = 0; i < userId.Length; i++)
+        {
+            byte b = (byte)userId[i];
+            sb.Append(hexchars[(int)(b >> 4)]);
+            sb.Append(hexchars[(int)(b & 0xF)]);
+        }
+        sb.Append("\r\n");
+        return sb.ToString();
+#else
+        return string.Create<string>(
+            length: AuthExternal.Length + userId.Length * 2 + 2, userId,
+            static (Span<char> span, string userId) =>
+            {
+                AuthExternal.AsSpan().CopyTo(span);
+                span = span.Slice(AuthExternal.Length);
+
+                for (int i = 0; i < userId.Length; i++)
+                {
+                    byte b = (byte)userId[i];
+                    span[i * 2] = hexchars[(int)(b >> 4)];
+                    span[i * 2 + 1] = hexchars[(int)(b & 0xF)];
+                }
+                span = span.Slice(userId.Length * 2);
+
+                span[0] = '\r';
+                span[1] = '\n';
+            });
+#endif
+    }
+
+    private async ValueTask<AuthenticationResult> SendAuthCommandAsync(string command, bool supportsFdPassing)
+    {
+        byte[] lineBuffer = ArrayPool<byte>.Shared.Rent(512);
+        try
+        {
+            AuthenticationResult result = default(AuthenticationResult);
+            await WriteAsync(command, lineBuffer).ConfigureAwait(false);
+            int lineLength = await ReadLineAsync(lineBuffer).ConfigureAwait(false);
+
+            if (StartsWithAscii(lineBuffer, lineLength, "OK"))
+            {
+                result.IsAuthenticated = true;
+                result.Guid = ParseGuid(lineBuffer, lineLength);
+
+                if (supportsFdPassing)
+                {
+                    await WriteAsync("NEGOTIATE_UNIX_FD\r\n", lineBuffer).ConfigureAwait(false);
+
+                    lineLength = await ReadLineAsync(lineBuffer).ConfigureAwait(false);
+
+                    result.SupportsFdPassing = StartsWithAscii(lineBuffer, lineLength, "AGREE_UNIX_FD");
+                }
+
+                await WriteAsync("BEGIN\r\n", lineBuffer).ConfigureAwait(false);
+                return result;
+            }
+            else if (StartsWithAscii(lineBuffer, lineLength, "REJECTED"))
+            {
+                return result;
+            }
+            else
+            {
+                await WriteAsync("ERROR\r\n", lineBuffer).ConfigureAwait(false);
+                return result;
+            }
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(lineBuffer);
+        }
+
+        static bool StartsWithAscii(byte[] line, int length, string expected)
+        {
+            if (length < expected.Length)
+            {
+                return false;
+            }
+            for (int i = 0; i < expected.Length; i++)
+            {
+                if (line[i] != expected[i])
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        static Guid ParseGuid(byte[] line, int length)
+        {
+            Span<byte> span = new Span<byte>(line, 0, length);
+            int spaceIndex = span.IndexOf((byte)' ');
+            if (spaceIndex == -1)
+            {
+                return Guid.Empty;
+            }
+            span = span.Slice(spaceIndex + 1);
+            spaceIndex = span.IndexOf((byte)' ');
+            if (spaceIndex != -1)
+            {
+                span = span.Slice(0, spaceIndex);
+            }
+            Span<char> charBuffer = stackalloc char[span.Length]; // TODO: check length
+            for (int i = 0; i < span.Length; i++)
+            {
+                // TODO: validate char
+                charBuffer[i] = (char)span[i];
+            }
+#if NETSTANDARD2_0
+            return Guid.ParseExact(charBuffer.AsString(), "N");
+#else
+            return Guid.ParseExact(charBuffer, "N");
+#endif
+        }
+    }
+
+    private async ValueTask WriteAsync(string message, Memory<byte> lineBuffer)
+    {
+        int length = Encoding.ASCII.GetBytes(message.AsSpan(), lineBuffer.Span);
+        lineBuffer = lineBuffer.Slice(0, length);
+        await _socket.SendAsync(lineBuffer, SocketFlags.None);
+    }
+
+    private async ValueTask<int> ReadLineAsync(Memory<byte> lineBuffer)
+    {
+        var reader = _pipeReader;
+        while (true)
+        {
+            ReadResult result = await reader.ReadAsync();
+            ReadOnlySequence<byte> buffer = result.Buffer;
+
+            // TODO: check length.
+
+            SequencePosition? position = buffer.PositionOf((byte)'\n');
+
+            if (!position.HasValue)
+            {
+                reader.AdvanceTo(buffer.Start, buffer.End);
+                continue;
+            }
+
+            int length = CopyBuffer(buffer.Slice(0, position.Value), lineBuffer);
+            reader.AdvanceTo(buffer.GetPosition(1, position.Value));
+            return length;
+        }
+
+        int CopyBuffer(ReadOnlySequence<byte> src, Memory<byte> dst)
+        {
+            Span<byte> span = dst.Span;
+            src.CopyTo(span);
+            span = span.Slice(0, (int)src.Length);
+            if (!span.EndsWith((ReadOnlySpan<byte>)new byte[] { (byte)'\r' }))
+            {
+                throw new ProtocolException("Authentication messages from server must end with '\\r\\n'.");
+            }
+            if (span.Length == 1)
+            {
+                throw new ProtocolException("Received empty authentication message from server.");
+            }
+            return span.Length - 1;
+        }
+    }
+
+    public async ValueTask<bool> TrySendMessageAsync(MessageBuffer message)
+    {
+        while (await _messageWriter.WaitToWriteAsync().ConfigureAwait(false))
+        {
+            if (_messageWriter.TryWrite(message))
+                return true;
+        }
+
+        return false;
+    }
+
+    public void Close(Exception closeReason) => CloseCore(closeReason);
+
+    private Exception CloseCore(Exception closeReason)
+    {
+        Exception? previous = Interlocked.CompareExchange(ref _completionException, closeReason, null);
+        if (previous is null)
+        {
+            _socket?.Dispose();
+            _messageWriter.Complete();
+        }
+        return previous ?? closeReason;
+    }
+}

--- a/src/Tmds.DBus.Protocol/MessageType.cs
+++ b/src/Tmds.DBus.Protocol/MessageType.cs
@@ -1,0 +1,9 @@
+namespace Tmds.DBus.Protocol;
+
+public enum MessageType : byte
+{
+    MethodCall = 1,
+    MethodReturn = 2,
+    Error = 3,
+    Signal = 4
+}

--- a/src/Tmds.DBus.Protocol/MessageWriter.Array.cs
+++ b/src/Tmds.DBus.Protocol/MessageWriter.Array.cs
@@ -1,0 +1,83 @@
+using System.Reflection;
+
+namespace Tmds.DBus.Protocol;
+
+public ref partial struct MessageWriter
+{
+    public void WriteArray<T>(IEnumerable<T> value)
+        where T : notnull
+    {
+        ArrayStart arrayStart = WriteArrayStart(TypeModel.GetTypeAlignment<T>());
+        foreach (var item in value)
+        {
+            WriteStructureStart();
+            Write<T>(item);
+        }
+        WriteArrayEnd(ref arrayStart);
+    }
+
+    public void WriteArray<T>(T[] value)
+        where T : notnull
+    {
+        ArrayStart arrayStart = WriteArrayStart(TypeModel.GetTypeAlignment<T>());
+        foreach (var item in value)
+        {
+            WriteStructureStart();
+            Write<T>(item);
+        }
+        WriteArrayEnd(ref arrayStart);
+    }
+
+    public void WriteVariantDictionary<T>(IEnumerable<T> value)
+        where T : notnull
+    {
+        WriteArraySignature<T>(ref this);
+        WriteArray(value);
+    }
+
+    public void WriteVariantDictionary<T>(T[] value)
+        where T : notnull
+    {
+        WriteArraySignature<T>(ref this);
+        WriteArray(value);
+    }
+
+    sealed class ArrayTypeWriter<T> : ITypeWriter<IEnumerable<T>>
+        where T : notnull
+    {
+        public void Write(ref MessageWriter writer, IEnumerable<T> value)
+        {
+            writer.WriteArray(value);
+        }
+
+        public void WriteVariant(ref MessageWriter writer, object value)
+        {
+            WriteArraySignature<T>(ref writer);
+            writer.WriteArray((IEnumerable<T>)value);
+        }
+    }
+
+    public static void AddArrayTypeWriter<T>()
+        where T : notnull
+    {
+        lock (_typeWriters)
+        {
+            Type keyType = typeof(IEnumerable<T>);
+            if (!_typeWriters.ContainsKey(keyType))
+            {
+                _typeWriters.Add(keyType, new ArrayTypeWriter<T>());
+            }
+        }
+    }
+
+    private ITypeWriter CreateArrayTypeWriter(Type elementType)
+    {
+        Type writerType = typeof(ArrayTypeWriter<>).MakeGenericType(new[] { elementType });
+        return (ITypeWriter)Activator.CreateInstance(writerType)!;
+    }
+
+    private static void WriteArraySignature<T>(ref MessageWriter writer)
+    {
+        writer.WriteSignature(TypeModel.GetSignature<T[]>());
+    }
+}

--- a/src/Tmds.DBus.Protocol/MessageWriter.Basic.cs
+++ b/src/Tmds.DBus.Protocol/MessageWriter.Basic.cs
@@ -1,0 +1,172 @@
+namespace Tmds.DBus.Protocol;
+
+public ref partial struct MessageWriter
+{
+    public void WriteBool(bool value) => WriteUInt32(value ? 1u : 0u);
+
+    public void WriteByte(byte value) => WritePrimitiveCore<Int16>(value, DBusType.Byte);
+
+    public void WriteInt16(Int16 value) => WritePrimitiveCore<Int16>(value, DBusType.Int16);
+
+    public void WriteUInt16(UInt16 value) => WritePrimitiveCore<UInt16>(value, DBusType.UInt16);
+
+    public void WriteInt32(Int32 value) => WritePrimitiveCore<Int32>(value, DBusType.Int32);
+
+    public void WriteUInt32(UInt32 value) => WritePrimitiveCore<UInt32>(value, DBusType.UInt32);
+
+    public void WriteInt64(Int64 value) => WritePrimitiveCore<Int64>(value, DBusType.Int64);
+
+    public void WriteUInt64(UInt64 value) => WritePrimitiveCore<UInt64>(value, DBusType.UInt64);
+
+    public void WriteDouble(double value) => WritePrimitiveCore<double>(value, DBusType.Double);
+
+    public void WriteString(Utf8Span value) => WriteStringCore(value);
+
+    public void WriteString(string value) => WriteStringCore(value);
+
+    public void WriteSignature(Utf8Span value)
+    {
+        ReadOnlySpan<byte> span = value;
+        int length = span.Length;
+        WriteByte((byte)length);
+        var dst = GetSpan(length);
+        span.CopyTo(dst);
+        Advance(length);
+        WriteByte((byte)0);
+    }
+
+    public void WriteSignature(string s)
+    {
+        Span<byte> lengthSpan = GetSpan(1);
+        Advance(1);
+        int bytesWritten = (int)Encoding.UTF8.GetBytes(s.AsSpan(), Writer);
+        lengthSpan[0] = (byte)bytesWritten;
+        _offset += bytesWritten;
+        WriteByte(0);
+    }
+
+    public void WriteObjectPath(Utf8Span value) => WriteStringCore(value);
+
+    public void WriteObjectPath(string value) => WriteStringCore(value);
+
+    public void WriteVariantBool(bool value)
+    {
+        WriteSignature(ProtocolConstants.BooleanSignature);
+        WriteBool(value);
+    }
+
+    public void WriteVariantByte(byte value)
+    {
+        WriteSignature(ProtocolConstants.ByteSignature);
+        WriteByte(value);
+    }
+
+    public void WriteVariantInt16(Int16 value)
+    {
+        WriteSignature(ProtocolConstants.Int16Signature);
+        WriteInt16(value);
+    }
+
+    public void WriteVariantUInt16(UInt16 value)
+    {
+        WriteSignature(ProtocolConstants.UInt16Signature);
+        WriteUInt16(value);
+    }
+
+    public void WriteVariantInt32(Int32 value)
+    {
+        WriteSignature(ProtocolConstants.Int32Signature);
+        WriteInt32(value);
+    }
+
+    public void WriteVariantUInt32(UInt32 value)
+    {
+        WriteSignature(ProtocolConstants.UInt32Signature);
+        WriteUInt32(value);
+    }
+
+    public void WriteVariantInt64(Int64 value)
+    {
+        WriteSignature(ProtocolConstants.Int64Signature);
+        WriteInt64(value);
+    }
+
+    public void WriteVariantUInt64(UInt64 value)
+    {
+        WriteSignature(ProtocolConstants.UInt64Signature);
+        WriteUInt64(value);
+    }
+
+    public void WriteVariantDouble(double value)
+    {
+        WriteSignature(ProtocolConstants.DoubleSignature);
+        WriteDouble(value);
+    }
+
+    public void WriteVariantString(Utf8Span value)
+    {
+        WriteSignature(ProtocolConstants.StringSignature);
+        WriteString(value);
+    }
+
+    public void WriteVariantSignature(Utf8Span value)
+    {
+        WriteSignature(ProtocolConstants.SignatureSignature);
+        WriteSignature(value);
+    }
+
+    public void WriteVariantObjectPath(Utf8Span value)
+    {
+        WriteSignature(ProtocolConstants.ObjectPathSignature);
+        WriteObjectPath(value);
+    }
+
+    public void WriteVariantString(string value)
+    {
+        WriteSignature(ProtocolConstants.StringSignature);
+        WriteString(value);
+    }
+
+    public void WriteVariantSignature(string value)
+    {
+        WriteSignature(ProtocolConstants.SignatureSignature);
+        WriteSignature(value);
+    }
+
+    public void WriteVariantObjectPath(string value)
+    {
+        WriteSignature(ProtocolConstants.ObjectPathSignature);
+        WriteObjectPath(value);
+    }
+
+    private void WriteStringCore(ReadOnlySpan<byte> span)
+    {
+        int length = span.Length;
+        WriteUInt32((uint)length);
+        var dst = GetSpan(length);
+        span.CopyTo(dst);
+        Advance(length);
+        WriteByte((byte)0);
+    }
+
+    private void WriteStringCore(string s)
+    {
+        WritePadding(DBusType.UInt32);
+        Span<byte> lengthSpan = GetSpan(4);
+        Advance(4);
+        int bytesWritten = (int)Encoding.UTF8.GetBytes(s.AsSpan(), Writer);
+        Unsafe.WriteUnaligned<uint>(ref MemoryMarshal.GetReference(lengthSpan), (uint)bytesWritten);
+        _offset += bytesWritten;
+        WriteByte(0);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private void WritePrimitiveCore<T>(T value, DBusType type)
+    {
+        WritePadding(type);
+        int length = ProtocolConstants.GetFixedTypeLength(type);
+        var span = GetSpan(length);
+        Unsafe.WriteUnaligned<T>(ref MemoryMarshal.GetReference(span), value);
+        Advance(length);
+    }
+}

--- a/src/Tmds.DBus.Protocol/MessageWriter.Dictionary.cs
+++ b/src/Tmds.DBus.Protocol/MessageWriter.Dictionary.cs
@@ -1,0 +1,124 @@
+namespace Tmds.DBus.Protocol;
+
+public ref partial struct MessageWriter
+{
+    public void WriteDictionary<TKey, TValue>(IEnumerable<KeyValuePair<TKey, TValue>> value)
+        where TKey : notnull
+        where TValue : notnull
+    {
+        ArrayStart arrayStart = WriteArrayStart(DBusType.Struct);
+        foreach (var item in value)
+        {
+            WriteStructureStart();
+            Write<TKey>(item.Key);
+            Write<TValue>(item.Value);
+        }
+        WriteArrayEnd(ref arrayStart);
+    }
+
+    public void WriteDictionary<TKey, TValue>(KeyValuePair<TKey, TValue>[] value)
+        where TKey : notnull
+        where TValue : notnull
+    {
+        ArrayStart arrayStart = WriteArrayStart(DBusType.Struct);
+        foreach (var item in value)
+        {
+            WriteStructureStart();
+            Write<TKey>(item.Key);
+            Write<TValue>(item.Value);
+        }
+        WriteArrayEnd(ref arrayStart);
+    }
+
+    public void WriteDictionary<TKey, TValue>(Dictionary<TKey, TValue> value)
+        where TKey : notnull
+        where TValue : notnull
+    {
+        ArrayStart arrayStart = WriteArrayStart(DBusType.Struct);
+        foreach (var item in value)
+        {
+            WriteStructureStart();
+            Write<TKey>(item.Key);
+            Write<TValue>(item.Value);
+        }
+        WriteArrayEnd(ref arrayStart);
+    }
+
+    public void WriteVariantDictionary<TKey, TValue>(IEnumerable<KeyValuePair<TKey, TValue>> value)
+        where TKey : notnull
+        where TValue : notnull
+    {
+        WriteDictionarySignature<TKey, TValue>(ref this);
+        WriteDictionary(value);
+    }
+
+    public void WriteVariantDictionary<TKey, TValue>(KeyValuePair<TKey, TValue>[] value)
+        where TKey : notnull
+        where TValue : notnull
+    {
+        WriteDictionarySignature<TKey, TValue>(ref this);
+        WriteDictionary(value);
+    }
+
+    public void WriteVariantDictionary<TKey, TValue>(Dictionary<TKey, TValue> value)
+        where TKey : notnull
+        where TValue : notnull
+    {
+        WriteDictionarySignature<TKey, TValue>(ref this);
+        WriteDictionary(value);
+    }
+
+    // This method writes a Dictionary without using generics at the 'cost' of boxing.
+    // private void WriteDictionary(IDictionary value)
+    // {
+    //     ArrayStart arrayStart = WriteArrayStart(DBusType.Struct);
+    //     foreach (System.Collections.DictionaryEntry de in dictionary)
+    //     {
+    //         WriteStructureStart();
+    //         Write(de.Key, asVariant: keyType == typeof(object));
+    //         Write(de.Value, asVariant: valueType == typeof(object));
+    //     }
+    //     WriteArrayEnd(ref arrayStart);
+    // }
+
+    sealed class DictionaryTypeWriter<TKey, TValue> : ITypeWriter<IEnumerable<KeyValuePair<TKey, TValue>>>
+        where TKey : notnull
+        where TValue : notnull
+    {
+        public void Write(ref MessageWriter writer, IEnumerable<KeyValuePair<TKey, TValue>> value)
+        {
+            writer.WriteDictionary(value);
+        }
+
+        public void WriteVariant(ref MessageWriter writer, object value)
+        {
+            WriteDictionarySignature<TKey, TValue>(ref writer);
+            writer.WriteDictionary((IEnumerable<KeyValuePair<TKey, TValue>>)value);
+        }
+    }
+
+    public static void AddDictionaryTypeWriter<TKey, TValue>()
+        where TKey : notnull
+        where TValue : notnull
+    {
+        lock (_typeWriters)
+        {
+            Type keyType = typeof(IEnumerable<KeyValuePair<TKey, TValue>>);
+            if (!_typeWriters.ContainsKey(keyType))
+            {
+                _typeWriters.Add(keyType, new DictionaryTypeWriter<TKey, TValue>());
+            }
+        }
+    }
+
+    private ITypeWriter CreateDictionaryTypeWriter(Type keyType, Type valueType)
+    {
+        Type writerType = typeof(DictionaryTypeWriter<,>).MakeGenericType(new[] { keyType, valueType });
+        return (ITypeWriter)Activator.CreateInstance(writerType)!;
+    }
+
+    private static void WriteDictionarySignature<TKey, TValue>(ref MessageWriter writer)
+    {
+        writer.WriteSignature(TypeModel.GetSignature<IDictionary<TKey, TValue>>());
+    }
+}

--- a/src/Tmds.DBus.Protocol/MessageWriter.Handle.cs
+++ b/src/Tmds.DBus.Protocol/MessageWriter.Handle.cs
@@ -1,0 +1,9 @@
+namespace Tmds.DBus.Protocol;
+
+public ref partial struct MessageWriter
+{
+    public void WriteHandle(SafeHandle value)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/src/Tmds.DBus.Protocol/MessageWriter.Header.cs
+++ b/src/Tmds.DBus.Protocol/MessageWriter.Header.cs
@@ -1,0 +1,213 @@
+namespace Tmds.DBus.Protocol;
+
+public ref partial struct MessageWriter
+{
+    public void WriteMethodCallHeader(
+        string? destination = null,
+        string? path = null,
+        string? @interface = null,
+        string? member = null,
+        string? signature = null,
+        MessageFlags flags = MessageFlags.None)
+    {
+        ArrayStart start = WriteHeaderStart(MessageType.MethodCall, flags);
+
+        // Path.
+        if (path is not null)
+        {
+            WriteStructureStart();
+            WriteByte((byte)MessageHeader.Path);
+            WriteVariantObjectPath(path);
+        }
+
+        // Interface.
+        if (@interface is not null)
+        {
+            WriteStructureStart();
+            WriteByte((byte)MessageHeader.Interface);
+            WriteVariantString(@interface);
+        }
+
+        // Member.
+        if (member is not null)
+        {
+            WriteStructureStart();
+            WriteByte((byte)MessageHeader.Member);
+            WriteVariantString(member);
+        }
+
+        // Destination.
+        if (destination is not null)
+        {
+            WriteStructureStart();
+            WriteByte((byte)MessageHeader.Destination);
+            WriteVariantString(destination);
+        }
+
+        // Signature.
+        if (signature is not null)
+        {
+            WriteStructureStart();
+            WriteByte((byte)MessageHeader.Signature);
+            WriteVariantSignature(signature);
+        }
+
+        WriteHeaderEnd(ref start);
+    }
+
+    public void WriteMethodReturnHeader(
+        uint replySerial,
+        Utf8Span destination = default,
+        string? signature = null)
+    {
+        ArrayStart start = WriteHeaderStart(MessageType.MethodReturn, MessageFlags.None);
+
+        // ReplySerial
+        WriteStructureStart();
+        WriteByte((byte)MessageHeader.ReplySerial);
+        WriteVariantUInt32(replySerial);
+
+        // Destination.
+        if (!destination.IsEmpty)
+        {
+            WriteStructureStart();
+            WriteByte((byte)MessageHeader.Destination);
+            WriteVariantString(destination);
+        }
+
+        // Signature.
+        if (signature is not null)
+        {
+            WriteStructureStart();
+            WriteByte((byte)MessageHeader.Signature);
+            WriteVariantSignature(signature);
+        }
+
+        WriteHeaderEnd(ref start);
+    }
+
+    public void WriteError(
+        uint replySerial,
+        Utf8Span destination = default,
+        string? errorName = null,
+        string? errorMsg = null)
+    {
+        ArrayStart start = WriteHeaderStart(MessageType.Error, MessageFlags.None);
+
+        // ReplySerial
+        WriteStructureStart();
+        WriteByte((byte)MessageHeader.ReplySerial);
+        WriteVariantUInt32(replySerial);
+
+        // Destination.
+        if (!destination.IsEmpty)
+        {
+            WriteStructureStart();
+            WriteByte((byte)MessageHeader.Destination);
+            WriteVariantString(destination);
+        }
+
+        // Error.
+        if (errorName is not null)
+        {
+            WriteStructureStart();
+            WriteByte((byte)MessageHeader.ErrorName);
+            WriteVariantString(errorName);
+        }
+
+        // Signature.
+        if (errorMsg is not null)
+        {
+            WriteStructureStart();
+            WriteByte((byte)MessageHeader.Signature);
+            WriteVariantSignature(ProtocolConstants.StringSignature);
+        }
+
+        WriteHeaderEnd(ref start);
+
+        if (errorMsg is not null)
+        {
+            WriteString(errorMsg);
+        }
+    }
+
+    public void WriteSignalHeader(
+        string? destination = null,
+        string? path = null,
+        string? @interface = null,
+        string? member = null,
+        string? signature = null)
+    {
+        ArrayStart start = WriteHeaderStart(MessageType.Signal, MessageFlags.None);
+
+        // Path.
+        if (path is not null)
+        {
+            WriteStructureStart();
+            WriteByte((byte)MessageHeader.Path);
+            WriteVariantObjectPath(path);
+        }
+
+        // Interface.
+        if (@interface is not null)
+        {
+            WriteStructureStart();
+            WriteByte((byte)MessageHeader.Interface);
+            WriteVariantString(@interface);
+        }
+
+        // Member.
+        if (member is not null)
+        {
+            WriteStructureStart();
+            WriteByte((byte)MessageHeader.Member);
+            WriteVariantString(member);
+        }
+
+        // Destination.
+        if (destination is not null)
+        {
+            WriteStructureStart();
+            WriteByte((byte)MessageHeader.Destination);
+            WriteVariantString(destination);
+        }
+
+        // Signature.
+        if (signature is not null)
+        {
+            WriteStructureStart();
+            WriteByte((byte)MessageHeader.Signature);
+            WriteVariantSignature(signature);
+        }
+
+        WriteHeaderEnd(ref start);
+    }
+
+    private void WriteHeaderEnd(ref ArrayStart start)
+    {
+        WriteArrayEnd(ref start);
+        WritePadding(DBusType.Struct);
+    }
+
+    private ArrayStart WriteHeaderStart(MessageType type, MessageFlags flags)
+    {
+        WriteByte(BitConverter.IsLittleEndian ? (byte)'l' : (byte)'B'); // endianness
+        WriteByte((byte)type);
+        WriteByte((byte)flags);
+        WriteByte((byte)1); // version
+        WriteUInt32((uint)0); // length placeholder
+        Debug.Assert(_offset == LengthOffset + 4);
+        WriteUInt32(_serial);
+        Debug.Assert(_offset == SerialOffset + 4);
+
+        // headers
+        ArrayStart start = WriteArrayStart(DBusType.Struct);
+
+        // UnixFds
+        WriteStructureStart();
+        WriteByte((byte)MessageHeader.UnixFds);
+        WriteVariantUInt32(0); // unix fd length placeholder
+        Debug.Assert(_offset == UnixFdLengthOffset + 4);
+        return start;
+    }
+}

--- a/src/Tmds.DBus.Protocol/MessageWriter.Struct.cs
+++ b/src/Tmds.DBus.Protocol/MessageWriter.Struct.cs
@@ -1,0 +1,514 @@
+using System.Reflection;
+
+namespace Tmds.DBus.Protocol;
+
+public ref partial struct MessageWriter
+{
+    public void WriteStruct<T1>(T1 item1)
+        where T1 : notnull
+    {
+        WriteStructureStart();
+        Write<T1>(item1);
+    }
+
+    public void WriteVariantStruct<T1>(T1 item1)
+        where T1 : notnull
+    {
+        WriteStructSignature<T1>(ref this);
+        WriteStructureStart();
+        Write<T1>(item1);
+    }
+
+    sealed class ValueTupleTypeWriter<T1> : ITypeWriter<ValueTuple<T1>>
+        where T1 : notnull
+    {
+        public void Write(ref MessageWriter writer, ValueTuple<T1> value)
+        {
+            writer.WriteStruct<T1>(value.Item1);
+        }
+
+        public void WriteVariant(ref MessageWriter writer, object value)
+        {
+            WriteStructSignature<T1>(ref writer);
+            Write(ref writer, (ValueTuple<T1>)value);
+        }
+    }
+
+    sealed class TupleTypeWriter<T1> : ITypeWriter<Tuple<T1>>
+        where T1 : notnull
+    {
+        public void Write(ref MessageWriter writer, Tuple<T1> value)
+        {
+            writer.WriteStruct<T1>(value.Item1);
+        }
+
+        public void WriteVariant(ref MessageWriter writer, object value)
+        {
+            WriteStructSignature<T1>(ref writer);
+            Write(ref writer, (Tuple<T1>)value);
+        }
+    }
+
+    public static void AddValueTupleTypeWriter<T1>()
+        where T1 : notnull
+    {
+        lock (_typeWriters)
+        {
+            Type keyType = typeof(ValueTuple<T1>);
+            if (!_typeWriters.ContainsKey(keyType))
+            {
+                _typeWriters.Add(keyType, new ValueTupleTypeWriter<T1>());
+            }
+        }
+    }
+
+    public static void AddTupleTypeWriter<T1>()
+        where T1 : notnull
+    {
+        lock (_typeWriters)
+        {
+            Type keyType = typeof(Tuple<T1>);
+            if (!_typeWriters.ContainsKey(keyType))
+            {
+                _typeWriters.Add(keyType, new TupleTypeWriter<T1>());
+            }
+        }
+    }
+
+    private ITypeWriter CreateValueTupleTypeWriter(Type type1)
+    {
+        Type writerType = typeof(ValueTupleTypeWriter<>).MakeGenericType(new[] { type1 });
+        return (ITypeWriter)Activator.CreateInstance(writerType)!;
+    }
+
+    private ITypeWriter CreateTupleTypeWriter(Type type1)
+    {
+        Type writerType = typeof(TupleTypeWriter<>).MakeGenericType(new[] { type1 });
+        return (ITypeWriter)Activator.CreateInstance(writerType)!;
+    }
+
+    private static void WriteStructSignature<T1>(ref MessageWriter writer)
+    {
+        writer.WriteSignature(TypeModel.GetSignature<ValueTuple<T1>>());
+    }
+
+    public void WriteStruct<T1, T2>(T1 item1, T2 item2)
+        where T1 : notnull
+        where T2 : notnull
+    {
+        WriteStructureStart();
+        Write<T1>(item1);
+        Write<T2>(item2);
+    }
+
+    public void WriteVariantStruct<T1, T2>(T1 item1, T2 item2)
+        where T1 : notnull
+        where T2 : notnull
+    {
+        WriteStructSignature<T1, T2>(ref this);
+        WriteStructureStart();
+        Write<T1>(item1);
+        Write<T2>(item2);
+    }
+
+    sealed class ValueTupleTypeWriter<T1, T2> : ITypeWriter<ValueTuple<T1, T2>>
+        where T1 : notnull
+        where T2 : notnull
+    {
+        public void Write(ref MessageWriter writer, ValueTuple<T1, T2> value)
+        {
+            writer.WriteStruct<T1, T2>(value.Item1, value.Item2);
+        }
+
+        public void WriteVariant(ref MessageWriter writer, object value)
+        {
+            WriteStructSignature<T1, T2>(ref writer);
+            Write(ref writer, (ValueTuple<T1, T2>)value);
+        }
+    }
+
+    sealed class TupleTypeWriter<T1, T2> : ITypeWriter<Tuple<T1, T2>>
+        where T1 : notnull
+        where T2 : notnull
+    {
+        public void Write(ref MessageWriter writer, Tuple<T1, T2> value)
+        {
+            writer.WriteStruct<T1, T2>(value.Item1, value.Item2);
+        }
+
+        public void WriteVariant(ref MessageWriter writer, object value)
+        {
+            WriteStructSignature<T1, T2>(ref writer);
+            Write(ref writer, (Tuple<T1, T2>)value);
+        }
+    }
+
+    public static void AddValueTupleTypeWriter<T1, T2>()
+        where T1 : notnull
+        where T2 : notnull
+    {
+        lock (_typeWriters)
+        {
+            Type keyType = typeof(ValueTuple<T1, T2>);
+            if (!_typeWriters.ContainsKey(keyType))
+            {
+                _typeWriters.Add(keyType, new ValueTupleTypeWriter<T1, T2>());
+            }
+        }
+    }
+
+    public static void AddTupleTypeWriter<T1, T2>()
+        where T1 : notnull
+        where T2 : notnull
+    {
+        lock (_typeWriters)
+        {
+            Type keyType = typeof(Tuple<T1, T2>);
+            if (!_typeWriters.ContainsKey(keyType))
+            {
+                _typeWriters.Add(keyType, new TupleTypeWriter<T1, T2>());
+            }
+        }
+    }
+
+    private ITypeWriter CreateValueTupleTypeWriter(Type type1, Type type2)
+    {
+        Type writerType = typeof(ValueTupleTypeWriter<,>).MakeGenericType(new[] { type1, type2 });
+        return (ITypeWriter)Activator.CreateInstance(writerType)!;
+    }
+
+    private ITypeWriter CreateTupleTypeWriter(Type type1, Type type2)
+    {
+        Type writerType = typeof(TupleTypeWriter<,>).MakeGenericType(new[] { type1, type2 });
+        return (ITypeWriter)Activator.CreateInstance(writerType)!;
+    }
+
+    private static void WriteStructSignature<T1, T2>(ref MessageWriter writer)
+    {
+        writer.WriteSignature(TypeModel.GetSignature<ValueTuple<T1, T2>>());
+    }
+
+    public void WriteStruct<T1, T2, T3>(T1 item1, T2 item2, T3 item3)
+        where T1 : notnull
+        where T2 : notnull
+        where T3 : notnull
+    {
+        WriteStructureStart();
+        Write<T1>(item1);
+        Write<T2>(item2);
+        Write<T3>(item3);
+    }
+
+    public void WriteVariantStruct<T1, T2, T3>(T1 item1, T2 item2, T3 item3)
+        where T1 : notnull
+        where T2 : notnull
+        where T3 : notnull
+    {
+        WriteStructSignature<T1, T2, T3>(ref this);
+        WriteStruct(item1, item2, item3);
+    }
+
+    sealed class ValueTupleTypeWriter<T1, T2, T3> : ITypeWriter<ValueTuple<T1, T2, T3>>
+        where T1 : notnull
+        where T2 : notnull
+        where T3 : notnull
+    {
+        public void Write(ref MessageWriter writer, ValueTuple<T1, T2, T3> value)
+        {
+            writer.WriteStruct<T1, T2, T3>(value.Item1, value.Item2, value.Item3);
+        }
+
+        public void WriteVariant(ref MessageWriter writer, object value)
+        {
+            WriteStructSignature<T1, T2, T3>(ref writer);
+            Write(ref writer, (ValueTuple<T1, T2, T3>)value);
+        }
+    }
+
+    sealed class TupleTypeWriter<T1, T2, T3> : ITypeWriter<Tuple<T1, T2, T3>>
+        where T1 : notnull
+        where T2 : notnull
+        where T3 : notnull
+    {
+        public void Write(ref MessageWriter writer, Tuple<T1, T2, T3> value)
+        {
+            writer.WriteStruct<T1, T2, T3>(value.Item1, value.Item2, value.Item3);
+        }
+
+        public void WriteVariant(ref MessageWriter writer, object value)
+        {
+            WriteStructSignature<T1, T2, T3>(ref writer);
+            Write(ref writer, (Tuple<T1, T2, T3>)value);
+        }
+    }
+
+    public static void AddValueTupleTypeWriter<T1, T2, T3>()
+        where T1 : notnull
+        where T2 : notnull
+        where T3 : notnull
+    {
+        lock (_typeWriters)
+        {
+            Type keyType = typeof(ValueTuple<T1, T2, T3>);
+            if (!_typeWriters.ContainsKey(keyType))
+            {
+                _typeWriters.Add(keyType, new ValueTupleTypeWriter<T1, T2, T3>());
+            }
+        }
+    }
+
+    public static void AddTupleTypeWriter<T1, T2, T3>()
+        where T1 : notnull
+        where T2 : notnull
+        where T3 : notnull
+    {
+        lock (_typeWriters)
+        {
+            Type keyType = typeof(Tuple<T1, T2, T3>);
+            if (!_typeWriters.ContainsKey(keyType))
+            {
+                _typeWriters.Add(keyType, new TupleTypeWriter<T1, T2, T3>());
+            }
+        }
+    }
+
+    private ITypeWriter CreateValueTupleTypeWriter(Type type1, Type type2, Type type3)
+    {
+        Type writerType = typeof(ValueTupleTypeWriter<,,>).MakeGenericType(new[] { type1, type2, type3 });
+        return (ITypeWriter)Activator.CreateInstance(writerType)!;
+    }
+
+    private ITypeWriter CreateTupleTypeWriter(Type type1, Type type2, Type type3)
+    {
+        Type writerType = typeof(TupleTypeWriter<,,>).MakeGenericType(new[] { type1, type2, type3 });
+        return (ITypeWriter)Activator.CreateInstance(writerType)!;
+    }
+
+    private static void WriteStructSignature<T1, T2, T3>(ref MessageWriter writer)
+    {
+        writer.WriteSignature(TypeModel.GetSignature<ValueTuple<T1, T2, T3>>());
+    }
+
+    public void WriteStruct<T1, T2, T3, T4>(T1 item1, T2 item2, T3 item3, T4 item4)
+        where T1 : notnull
+        where T2 : notnull
+        where T3 : notnull
+        where T4 : notnull
+    {
+        WriteStructureStart();
+        Write<T1>(item1);
+        Write<T2>(item2);
+        Write<T3>(item3);
+        Write<T4>(item4);
+    }
+
+    public void WriteVariantStruct<T1, T2, T3, T4>(T1 item1, T2 item2, T3 item3, T4 item4)
+        where T1 : notnull
+        where T2 : notnull
+        where T3 : notnull
+        where T4 : notnull
+    {
+        WriteStructSignature<T1, T2, T3, T4>(ref this);
+        WriteStruct(item1, item2, item3, item4);
+    }
+
+    sealed class ValueTupleTypeWriter<T1, T2, T3, T4> : ITypeWriter<ValueTuple<T1, T2, T3, T4>>
+        where T1 : notnull
+        where T2 : notnull
+        where T3 : notnull
+        where T4 : notnull
+    {
+        public void Write(ref MessageWriter writer, ValueTuple<T1, T2, T3, T4> value)
+        {
+            writer.WriteStruct<T1, T2, T3, T4>(value.Item1, value.Item2, value.Item3, value.Item4);
+        }
+
+        public void WriteVariant(ref MessageWriter writer, object value)
+        {
+            WriteStructSignature<T1, T2, T3, T4>(ref writer);
+            Write(ref writer, (ValueTuple<T1, T2, T3, T4>)value);
+        }
+    }
+
+    sealed class TupleTypeWriter<T1, T2, T3, T4> : ITypeWriter<Tuple<T1, T2, T3, T4>>
+        where T1 : notnull
+        where T2 : notnull
+        where T3 : notnull
+        where T4 : notnull
+    {
+        public void Write(ref MessageWriter writer, Tuple<T1, T2, T3, T4> value)
+        {
+            writer.WriteStruct<T1, T2, T3, T4>(value.Item1, value.Item2, value.Item3, value.Item4);
+        }
+
+        public void WriteVariant(ref MessageWriter writer, object value)
+        {
+            WriteStructSignature<T1, T2, T3, T4>(ref writer);
+            Write(ref writer, (Tuple<T1, T2, T3, T4>)value);
+        }
+    }
+
+    public static void AddValueTupleTypeWriter<T1, T2, T3, T4>()
+        where T1 : notnull
+        where T2 : notnull
+        where T3 : notnull
+        where T4 : notnull
+    {
+        lock (_typeWriters)
+        {
+            Type keyType = typeof(ValueTuple<T1, T2, T3, T4>);
+            if (!_typeWriters.ContainsKey(keyType))
+            {
+                _typeWriters.Add(keyType, new ValueTupleTypeWriter<T1, T2, T3, T4>());
+            }
+        }
+    }
+
+    public static void AddTupleTypeWriter<T1, T2, T3, T4>()
+        where T1 : notnull
+        where T2 : notnull
+        where T3 : notnull
+        where T4 : notnull
+    {
+        lock (_typeWriters)
+        {
+            Type keyType = typeof(Tuple<T1, T2, T3, T4>);
+            if (!_typeWriters.ContainsKey(keyType))
+            {
+                _typeWriters.Add(keyType, new TupleTypeWriter<T1, T2, T3, T4>());
+            }
+        }
+    }
+
+    private ITypeWriter CreateValueTupleTypeWriter(Type type1, Type type2, Type type3, Type type4)
+    {
+        Type writerType = typeof(ValueTupleTypeWriter<,,,>).MakeGenericType(new[] { type1, type2, type3, type4 });
+        return (ITypeWriter)Activator.CreateInstance(writerType)!;
+    }
+
+    private ITypeWriter CreateTupleTypeWriter(Type type1, Type type2, Type type3, Type type4)
+    {
+        Type writerType = typeof(TupleTypeWriter<,,,>).MakeGenericType(new[] { type1, type2, type3, type4 });
+        return (ITypeWriter)Activator.CreateInstance(writerType)!;
+    }
+
+    private static void WriteStructSignature<T1, T2, T3, T4>(ref MessageWriter writer)
+    {
+        writer.WriteSignature(TypeModel.GetSignature<ValueTuple<T1, T2, T3, T4>>());
+    }
+
+    public void WriteStruct<T1, T2, T3, T4, T5>(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5)
+        where T1 : notnull
+        where T2 : notnull
+        where T3 : notnull
+        where T4 : notnull
+        where T5 : notnull
+    {
+        WriteStructureStart();
+        Write<T1>(item1);
+        Write<T2>(item2);
+        Write<T3>(item3);
+        Write<T4>(item4);
+        Write<T5>(item5);
+    }
+
+    public void WriteVariantStruct<T1, T2, T3, T4, T5>(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5)
+        where T1 : notnull
+        where T2 : notnull
+        where T3 : notnull
+        where T4 : notnull
+        where T5 : notnull
+    {
+        WriteStructSignature<T1, T2, T3, T4, T5>(ref this);
+        WriteStruct(item1, item2, item3, item4, item5);
+    }
+
+    sealed class ValueTupleTypeWriter<T1, T2, T3, T4, T5> : ITypeWriter<ValueTuple<T1, T2, T3, T4, T5>>
+        where T1 : notnull
+        where T2 : notnull
+        where T3 : notnull
+        where T4 : notnull
+        where T5 : notnull
+    {
+        public void Write(ref MessageWriter writer, ValueTuple<T1, T2, T3, T4, T5> value)
+        {
+            writer.WriteStruct<T1, T2, T3, T4, T5>(value.Item1, value.Item2, value.Item3, value.Item4, value.Item5);
+        }
+
+        public void WriteVariant(ref MessageWriter writer, object value)
+        {
+            WriteStructSignature<T1, T2, T3, T4, T5>(ref writer);
+            Write(ref writer, (ValueTuple<T1, T2, T3, T4, T5>)value);
+        }
+    }
+
+    sealed class TupleTypeWriter<T1, T2, T3, T4, T5> : ITypeWriter<Tuple<T1, T2, T3, T4, T5>>
+        where T1 : notnull
+        where T2 : notnull
+        where T3 : notnull
+        where T4 : notnull
+        where T5 : notnull
+    {
+        public void Write(ref MessageWriter writer, Tuple<T1, T2, T3, T4, T5> value)
+        {
+            writer.WriteStruct<T1, T2, T3, T4, T5>(value.Item1, value.Item2, value.Item3, value.Item4, value.Item5);
+        }
+
+        public void WriteVariant(ref MessageWriter writer, object value)
+        {
+            WriteStructSignature<T1, T2, T3, T4, T5>(ref writer);
+            Write(ref writer, (Tuple<T1, T2, T3, T4, T5>)value);
+        }
+    }
+
+    public static void AddValueTupleTypeWriter<T1, T2, T3, T4, T5>()
+        where T1 : notnull
+        where T2 : notnull
+        where T3 : notnull
+        where T4 : notnull
+        where T5 : notnull
+    {
+        lock (_typeWriters)
+        {
+            Type keyType = typeof(ValueTuple<T1, T2, T3, T4, T5>);
+            if (!_typeWriters.ContainsKey(keyType))
+            {
+                _typeWriters.Add(keyType, new ValueTupleTypeWriter<T1, T2, T3, T4, T5>());
+            }
+        }
+    }
+
+    public static void AddTupleTypeWriter<T1, T2, T3, T4, T5>()
+        where T1 : notnull
+        where T2 : notnull
+        where T3 : notnull
+        where T4 : notnull
+        where T5 : notnull
+    {
+        lock (_typeWriters)
+        {
+            Type keyType = typeof(Tuple<T1, T2, T3, T4, T5>);
+            if (!_typeWriters.ContainsKey(keyType))
+            {
+                _typeWriters.Add(keyType, new TupleTypeWriter<T1, T2, T3, T4, T5>());
+            }
+        }
+    }
+
+    private ITypeWriter CreateValueTupleTypeWriter(Type type1, Type type2, Type type3, Type type4, Type type5)
+    {
+        Type writerType = typeof(ValueTupleTypeWriter<,,,,>).MakeGenericType(new[] { type1, type2, type3, type4, type5 });
+        return (ITypeWriter)Activator.CreateInstance(writerType)!;
+    }
+
+    private ITypeWriter CreateTupleTypeWriter(Type type1, Type type2, Type type3, Type type4, Type type5)
+    {
+        Type writerType = typeof(TupleTypeWriter<,,,,>).MakeGenericType(new[] { type1, type2, type3, type4, type5 });
+        return (ITypeWriter)Activator.CreateInstance(writerType)!;
+    }
+
+    private static void WriteStructSignature<T1, T2, T3, T4, T5>(ref MessageWriter writer)
+    {
+        writer.WriteSignature(TypeModel.GetSignature<ValueTuple<T1, T2, T3, T4, T5>>());
+    }
+}

--- a/src/Tmds.DBus.Protocol/MessageWriter.Variant.cs
+++ b/src/Tmds.DBus.Protocol/MessageWriter.Variant.cs
@@ -1,0 +1,75 @@
+namespace Tmds.DBus.Protocol;
+
+public ref partial struct MessageWriter
+{
+    public void WriteVariant(object value)
+    {
+        Type type = value.GetType();
+
+        if (type == typeof(byte))
+        {
+            WriteVariantByte((byte)value);
+            return;
+        }
+        else if (type == typeof(bool))
+        {
+            WriteVariantBool((bool)value);
+            return;
+        }
+        else if (type == typeof(Int16))
+        {
+            WriteVariantInt16((Int16)value);
+            return;
+        }
+        else if (type == typeof(UInt16))
+        {
+            WriteVariantUInt16((UInt16)value);
+            return;
+        }
+        else if (type == typeof(Int32))
+        {
+            WriteVariantInt32((Int32)value);
+            return;
+        }
+        else if (type == typeof(UInt32))
+        {
+            WriteVariantUInt32((UInt32)value);
+            return;
+        }
+        else if (type == typeof(Int64))
+        {
+            WriteVariantInt64((Int64)value);
+            return;
+        }
+        else if (type == typeof(UInt64))
+        {
+            WriteVariantUInt64((UInt64)value);
+            return;
+        }
+        else if (type == typeof(Double))
+        {
+            WriteVariantDouble((double)value);
+            return;
+        }
+        else if (type == typeof(string))
+        {
+            WriteVariantString((string)value);
+            return;
+        }
+        else if (type == typeof(ObjectPath))
+        {
+            WriteVariantString(value.ToString()!);
+            return;
+        }
+        else if (type == typeof(Signature))
+        {
+            WriteVariantSignature(value.ToString()!);
+            return;
+        }
+        else
+        {
+            var typeWriter = GetTypeWriter(type);
+            typeWriter.WriteVariant(ref this, value);
+        }
+    }
+}

--- a/src/Tmds.DBus.Protocol/MessageWriter.WriteT.cs
+++ b/src/Tmds.DBus.Protocol/MessageWriter.WriteT.cs
@@ -1,0 +1,208 @@
+using System.Reflection;
+
+namespace Tmds.DBus.Protocol;
+
+public ref partial struct MessageWriter
+{
+    interface ITypeWriter
+    {
+        void WriteVariant(ref MessageWriter writer, object value);
+    }
+
+    interface ITypeWriter<in T> : ITypeWriter
+    {
+        void Write(ref MessageWriter writer, T value);
+    }
+
+    private static readonly Dictionary<Type, ITypeWriter> _typeWriters = new();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private void Write<T>(T value) where T : notnull
+    {
+        Type type = typeof(T);
+
+        if (type == typeof(object))
+        {
+            WriteVariant((object)value);
+            return;
+        }
+
+        if (type == typeof(byte))
+        {
+            WriteByte((byte)(object)value);
+            return;
+        }
+        else if (type == typeof(bool))
+        {
+            WriteBool((bool)(object)value);
+            return;
+        }
+        else if (type == typeof(Int16))
+        {
+            WriteInt16((Int16)(object)value);
+            return;
+        }
+        else if (type == typeof(UInt16))
+        {
+            WriteUInt16((UInt16)(object)value);
+            return;
+        }
+        else if (type == typeof(Int32))
+        {
+            WriteInt32((Int32)(object)value);
+            return;
+        }
+        else if (type == typeof(UInt32))
+        {
+            WriteUInt32((UInt32)(object)value);
+            return;
+        }
+        else if (type == typeof(Int64))
+        {
+            WriteInt64((Int64)(object)value);
+            return;
+        }
+        else if (type == typeof(UInt64))
+        {
+            WriteUInt64((UInt64)(object)value);
+            return;
+        }
+        else if (type == typeof(Double))
+        {
+            WriteDouble((double)(object)value);
+            return;
+        }
+        else if (type == typeof(string))
+        {
+            WriteString((string)(object)value);
+            return;
+        }
+        else if (type == typeof(ObjectPath))
+        {
+            WriteString(((ObjectPath)(object)value).ToString());
+            return;
+        }
+        else if (type == typeof(Signature))
+        {
+            WriteSignature(((Signature)(object)value).ToString());
+            return;
+        }
+        else
+        {
+            var typeWriter = (ITypeWriter<T>)GetTypeWriter(type);
+            typeWriter.Write(ref this, value);
+        }
+    }
+
+    private ITypeWriter GetTypeWriter(Type type)
+    {
+        lock (_typeWriters)
+        {
+            if (_typeWriters.TryGetValue(type, out ITypeWriter? writer))
+            {
+                return writer;
+            }
+            writer = CreateWriterForType(type);
+            _typeWriters.Add(type, writer);
+            return writer;
+        }
+    }
+
+    private ITypeWriter CreateWriterForType(Type type)
+    {
+        // Struct (ValueTuple)
+        if (type.IsGenericType && type.FullName!.StartsWith("System.ValueTuple"))
+        {
+            switch (type.GenericTypeArguments.Length)
+            {
+                case 1: return CreateValueTupleTypeWriter(type.GenericTypeArguments[0]);
+                case 2:
+                    return CreateValueTupleTypeWriter(type.GenericTypeArguments[0],
+                                                      type.GenericTypeArguments[1]);
+                case 3:
+                    return CreateValueTupleTypeWriter(type.GenericTypeArguments[0],
+                                                      type.GenericTypeArguments[1],
+                                                      type.GenericTypeArguments[2]);
+                case 4:
+                    return CreateValueTupleTypeWriter(type.GenericTypeArguments[0],
+                                                      type.GenericTypeArguments[1],
+                                                      type.GenericTypeArguments[2],
+                                                      type.GenericTypeArguments[3]);
+                case 5:
+                    return CreateValueTupleTypeWriter(type.GenericTypeArguments[0],
+                                                      type.GenericTypeArguments[1],
+                                                      type.GenericTypeArguments[2],
+                                                      type.GenericTypeArguments[3],
+                                                      type.GenericTypeArguments[4]);
+            }
+        }
+        // Struct (ValueTuple)
+        if (type.IsGenericType && type.FullName!.StartsWith("System.Tuple"))
+        {
+            switch (type.GenericTypeArguments.Length)
+            {
+                case 1: return CreateTupleTypeWriter(type.GenericTypeArguments[0]);
+                case 2:
+                    return CreateTupleTypeWriter(type.GenericTypeArguments[0],
+                                                 type.GenericTypeArguments[1]);
+                case 3:
+                    return CreateTupleTypeWriter(type.GenericTypeArguments[0],
+                                                 type.GenericTypeArguments[1],
+                                                 type.GenericTypeArguments[2]);
+                case 4:
+                    return CreateTupleTypeWriter(type.GenericTypeArguments[0],
+                                                 type.GenericTypeArguments[1],
+                                                 type.GenericTypeArguments[2],
+                                                 type.GenericTypeArguments[3]);
+                case 5:
+                    return CreateTupleTypeWriter(type.GenericTypeArguments[0],
+                                                 type.GenericTypeArguments[1],
+                                                 type.GenericTypeArguments[2],
+                                                 type.GenericTypeArguments[3],
+                                                 type.GenericTypeArguments[4]);
+            }
+        }
+
+        // Array/Dictionary type (IEnumerable<>/IEnumerable<KeyValuePair<,>>)
+        Type? extractedType = TypeModel.ExtractGenericInterface(type, typeof(IEnumerable<>));
+        if (extractedType != null)
+        {
+            if (_typeWriters.TryGetValue(extractedType, out ITypeWriter? writer))
+            {
+                return writer;
+            }
+
+            Type elementType = extractedType.GenericTypeArguments[0];
+            if (elementType.IsGenericType && elementType.GetGenericTypeDefinition() == typeof(KeyValuePair<,>))
+            {
+                Type keyType = elementType.GenericTypeArguments[0];
+                Type valueType = elementType.GenericTypeArguments[1];
+                writer = CreateDictionaryTypeWriter(keyType, valueType);
+            }
+            else
+            {
+                writer = CreateArrayTypeWriter(elementType);
+            }
+
+            if (type != extractedType)
+            {
+                _typeWriters.Add(extractedType, writer);
+            }
+
+            return writer;
+        }
+
+        ThrowNotSupportedType(type);
+        return default!;
+    }
+
+    private static void ThrowNotSupportedType(Type type)
+    {
+        throw new NotSupportedException($"Cannot write type {type.FullName}");
+    }
+
+    // private void Write(object value, bool asVariant)
+    // {
+
+    // }
+}

--- a/src/Tmds.DBus.Protocol/MessageWriter.cs
+++ b/src/Tmds.DBus.Protocol/MessageWriter.cs
@@ -1,0 +1,174 @@
+namespace Tmds.DBus.Protocol;
+
+public ref partial struct MessageWriter
+{
+    private const int LengthOffset = 4;
+    private const int SerialOffset = 8;
+    private const int HeaderFieldsLengthOffset = 12;
+    private const int UnixFdLengthOffset = 20;
+
+    private readonly MessageBuffer _message;
+    private readonly uint _serial;
+    private Span<byte> _firstSpan;
+    private Span<byte> _span;
+    private int _offset;
+    private int _buffered;
+
+    public MessageBuffer CreateMessage()
+    {
+        Flush();
+
+        CompleteMessage();
+
+        return _message;
+    }
+
+    private void CompleteMessage()
+    {
+        Span<byte> span = _firstSpan;
+
+        // Length
+        uint headerFieldsLength = Unsafe.ReadUnaligned<uint>(ref MemoryMarshal.GetReference(span.Slice(HeaderFieldsLengthOffset)));
+        uint pad = headerFieldsLength % 8;
+        if (pad != 0)
+        {
+            headerFieldsLength += (8 - pad);
+        }
+        uint length = (uint)_message.Length             // Total length
+                      - headerFieldsLength               // Header fields
+                      - 4                                // Header fields length
+                      - (uint)HeaderFieldsLengthOffset;  // Preceeding header fields
+        Unsafe.WriteUnaligned<uint>(ref MemoryMarshal.GetReference(span.Slice(LengthOffset)), length);
+
+        // UnixFdLength
+        Unsafe.WriteUnaligned<uint>(ref MemoryMarshal.GetReference(span.Slice(UnixFdLengthOffset)), (uint)_message.HandleCount);
+
+        _message.Serial = _serial;
+    }
+
+    private IBufferWriter<byte> Writer
+    {
+        get
+        {
+            Flush();
+            return _message.Writer;
+        }
+    }
+
+    internal MessageWriter(MessageBuffer message, uint serial)
+    {
+        _message = message;
+        _offset = 0;
+        _buffered = 0;
+        _serial = serial;
+        _firstSpan = _span = _message.GetSpan(sizeHint: 0);
+    }
+
+    public ArrayStart WriteArrayStart(DBusType elementType)
+    {
+        // Array length.
+        WritePadding(DBusType.UInt32);
+        Span<byte> lengthSpan = GetSpan(4);
+        Advance(4);
+
+        WritePadding(elementType);
+
+        return new ArrayStart(lengthSpan, _offset);
+    }
+
+    public void WriteArrayEnd(ref ArrayStart start) // TODO?: remove 'ref'
+    {
+        start.WriteLength(_offset);
+    }
+
+    public void WriteStructureStart()
+    {
+        WritePadding(DBusType.Struct);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private void Advance(int count)
+    {
+        _buffered += count;
+        _offset += count;
+        _span = _span.Slice(count);
+    }
+
+    private void WritePadding(DBusType type)
+    {
+        int pad = ProtocolConstants.GetPadding(_offset, type);
+        if (pad != 0)
+        {
+            GetSpan(pad).Slice(0, pad).Fill(0);
+            Advance(pad);
+        }
+    }
+
+    private Span<byte> GetSpan(int sizeHint)
+    {
+        Ensure(sizeHint);
+        return _span;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private void Ensure(int count = 1)
+    {
+        if (_span.Length < count)
+        {
+            EnsureMore(count);
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void EnsureMore(int count = 0)
+    {
+        if (_buffered > 0)
+        {
+            Flush();
+        }
+
+        _span = _message.GetSpan(count);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private void Flush()
+    {
+        var buffered = _buffered;
+        if (buffered > 0)
+        {
+            _buffered = 0;
+            _message.Advance(buffered);
+            _span = default;
+        }
+    }
+
+    public void Dispose()
+    {
+        // TODO:
+        // _message must be set to null in CreateMessage.
+        // return _message to pool if not null.
+    }
+}
+
+public ref struct ArrayStart
+{
+    private Span<byte> _span;
+    private int _offset;
+
+    internal ArrayStart(Span<byte> lengthSpan, int offset)
+    {
+        _span = lengthSpan;
+        _offset = offset;
+    }
+
+    internal void WriteLength(int offset)
+    {
+        if (_span.IsEmpty)
+        {
+            return;
+        }
+        uint length = (uint)(offset - _offset);
+        Unsafe.WriteUnaligned<uint>(ref MemoryMarshal.GetReference(_span), length);
+        _span = default;
+    }
+}

--- a/src/Tmds.DBus.Protocol/Netstandard2_0Extensions.cs
+++ b/src/Tmds.DBus.Protocol/Netstandard2_0Extensions.cs
@@ -1,0 +1,199 @@
+using System.Net;
+using System.Net.Sockets;
+
+namespace Tmds.DBus.Protocol;
+
+#if NETSTANDARD2_0
+static partial class NetstandardExtensions
+{
+    public static bool Remove<TKey, TValue>(this Dictionary<TKey, TValue> dictionary, TKey key, out TValue value)
+    {
+        if (dictionary.TryGetValue(key, out value))
+        {
+            dictionary.Remove(key);
+            return true;
+        }
+        return false;
+    }
+
+    public static unsafe int GetBytes(this Encoding encoding, ReadOnlySpan<char> chars, Span<byte> bytes)
+    {
+        fixed (char* pChars = chars)
+        fixed (byte* pBytes = bytes)
+        {
+            return encoding.GetBytes(pChars, chars.Length, pBytes, bytes.Length);
+        }
+    }
+
+    public static unsafe int GetChars(this Encoding encoding, ReadOnlySpan<byte> bytes, Span<char> chars)
+    {
+        fixed (char* pChars = chars)
+        fixed (byte* pBytes = bytes)
+        {
+            return encoding.GetChars(pBytes, bytes.Length, pChars, chars.Length);
+        }
+    }
+
+    public static unsafe string GetString(this Encoding encoding, ReadOnlySpan<byte> bytes)
+    {
+        fixed (byte* pBytes = bytes)
+        {
+            return encoding.GetString(pBytes, bytes.Length);
+        }
+    }
+
+    public static unsafe int GetCharCount(this Encoding encoding, ReadOnlySpan<byte> bytes)
+    {
+        fixed (byte* pBytes = bytes)
+        {
+            return encoding.GetCharCount(pBytes, bytes.Length);
+        }
+    }
+
+    public static unsafe int GetByteCount(this Encoding encoding, ReadOnlySpan<char> chars)
+    {
+        fixed (char* pChars = chars)
+        {
+            return encoding.GetByteCount(pChars, chars.Length);
+        }
+    }
+
+    public static unsafe int GetByteCount(this Encoder encoder, ReadOnlySpan<char> chars, bool flush)
+    {
+        fixed (char* pChars = chars)
+        {
+            return encoder.GetByteCount(pChars, chars.Length, flush);
+        }
+    }
+
+    public static unsafe void Convert(this Encoder encoder, ReadOnlySpan<char> chars, Span<byte> bytes, bool flush, out int charsUsed, out int bytesUsed, out bool completed)
+    {
+        fixed (char* pChars = chars)
+        fixed (byte* pBytes = bytes)
+        {
+            encoder.Convert(pChars, chars.Length, pBytes, bytes.Length, flush, out charsUsed, out bytesUsed, out completed);
+        }
+    }
+
+    public static unsafe void Append(this StringBuilder sb, ReadOnlySpan<char> value)
+    {
+        fixed (char* ptr = value)
+        {
+            sb.Append(ptr, value.Length);
+        }
+    }
+
+    public static unsafe string AsString(this ReadOnlySpan<char> chars)
+    {
+        fixed (char* ptr = chars)
+        {
+            return new string(ptr, 0, chars.Length);
+        }
+    }
+
+    public static unsafe string AsString(this Span<char> chars)
+        => AsString((ReadOnlySpan<char>)chars);
+
+    public static async ValueTask<int> ReceiveAsync(this Socket socket, Memory<byte> buffer, SocketFlags socketFlags)
+    {
+        if (MemoryMarshal.TryGetArray((ReadOnlyMemory<byte>)buffer, out var segment))
+            return await SocketTaskExtensions.ReceiveAsync(socket, segment, socketFlags);
+
+        throw new NotSupportedException();
+    }
+
+    public static async ValueTask<int> SendAsync(this Socket socket, ReadOnlyMemory<byte> buffer, SocketFlags socketFlags)
+    {
+        if (MemoryMarshal.TryGetArray(buffer, out var segment))
+            return await SocketTaskExtensions.SendAsync(socket, segment, socketFlags);
+
+        throw new NotSupportedException();
+    }
+}
+internal sealed class UnixDomainSocketEndPoint : EndPoint
+{
+    private const AddressFamily EndPointAddressFamily = AddressFamily.Unix;
+
+    private static readonly Encoding s_pathEncoding = Encoding.UTF8;
+    private const int s_nativePathOffset = 2;
+
+    private readonly string _path;
+    private readonly byte[] _encodedPath;
+
+    public UnixDomainSocketEndPoint(string path)
+    {
+        if (path == null)
+        {
+            throw new ArgumentNullException(nameof(path));
+        }
+
+        _path = path;
+        _encodedPath = s_pathEncoding.GetBytes(_path);
+
+        if (path.Length == 0)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(path), path,
+                string.Format("The path '{0}' is of an invalid length for use with domain sockets on this platform. The length must be at least 1 characters.", path));
+        }
+    }
+
+    internal UnixDomainSocketEndPoint(SocketAddress socketAddress)
+    {
+        if (socketAddress == null)
+        {
+            throw new ArgumentNullException(nameof(socketAddress));
+        }
+
+        if (socketAddress.Family != EndPointAddressFamily)
+        {
+            throw new ArgumentOutOfRangeException(nameof(socketAddress));
+        }
+
+        if (socketAddress.Size > s_nativePathOffset)
+        {
+            _encodedPath = new byte[socketAddress.Size - s_nativePathOffset];
+            for (int i = 0; i < _encodedPath.Length; i++)
+            {
+                _encodedPath[i] = socketAddress[s_nativePathOffset + i];
+            }
+
+            _path = s_pathEncoding.GetString(_encodedPath, 0, _encodedPath.Length);
+        }
+        else
+        {
+            _encodedPath = Array.Empty<byte>();
+            _path = string.Empty;
+        }
+    }
+
+    public override SocketAddress Serialize()
+    {
+        var result = new SocketAddress(AddressFamily.Unix, _encodedPath.Length + s_nativePathOffset);
+
+        for (int index = 0; index < _encodedPath.Length; index++)
+        {
+            result[s_nativePathOffset + index] = _encodedPath[index];
+        }
+
+        return result;
+    }
+
+    public override EndPoint Create(SocketAddress socketAddress) => new UnixDomainSocketEndPoint(socketAddress);
+
+    public override AddressFamily AddressFamily => EndPointAddressFamily;
+
+    public string Path => _path;
+
+    public override string ToString() => _path;
+}
+#else
+static partial class NetstandardExtensions
+{
+    public static string AsString(this ReadOnlySpan<char> chars)
+        => new string(chars);
+
+    public static unsafe string AsString(this Span<char> chars)
+        => AsString((ReadOnlySpan<char>)chars);
+}
+#endif

--- a/src/Tmds.DBus.Protocol/Netstandard2_1Extensions.cs
+++ b/src/Tmds.DBus.Protocol/Netstandard2_1Extensions.cs
@@ -1,0 +1,84 @@
+using System.Net;
+using System.Net.Sockets;
+using System.Reflection;
+
+namespace Tmds.DBus.Protocol;
+
+#if NETSTANDARD2_0 || NETSTANDARD2_1
+static partial class NetstandardExtensions
+{
+
+    private static PropertyInfo s_safehandleProperty = typeof(Socket).GetTypeInfo().GetDeclaredProperty("SafeHandle");
+
+    private const int MaxInputElementsPerIteration = 1 * 1024 * 1024;
+
+    public static bool IsAssignableTo(this Type type, Type? targetType)
+        => targetType?.IsAssignableFrom(type) ?? false;
+
+    public static SafeHandle GetSafeHandle(this Socket socket)
+    {
+        if (s_safehandleProperty != null)
+        {
+            return (SafeHandle)s_safehandleProperty.GetValue(socket, null);
+        }
+        // TODO: return m_Handle for NetFX.
+        ThrowHelper.ThrowNotSupportedException();
+        return null!;
+    }
+
+    public static long GetBytes(this Encoding encoding, ReadOnlySpan<char> chars, IBufferWriter<byte> writer)
+    {
+        if (chars.Length <= MaxInputElementsPerIteration)
+        {
+            int byteCount = encoding.GetByteCount(chars);
+            Span<byte> scratchBuffer = writer.GetSpan(byteCount);
+
+            int actualBytesWritten = encoding.GetBytes(chars, scratchBuffer);
+
+            writer.Advance(actualBytesWritten);
+            return actualBytesWritten;
+        }
+        else
+        {
+            Convert(encoding.GetEncoder(), chars, writer, flush: true, out long totalBytesWritten, out bool completed);
+            return totalBytesWritten;
+        }
+    }
+
+    public static void Convert(this Encoder encoder, ReadOnlySpan<char> chars, IBufferWriter<byte> writer, bool flush, out long bytesUsed, out bool completed)
+    {
+        long totalBytesWritten = 0;
+        do
+        {
+            int byteCountForThisSlice = (chars.Length <= MaxInputElementsPerIteration)
+              ? encoder.GetByteCount(chars, flush)
+              : encoder.GetByteCount(chars.Slice(0, MaxInputElementsPerIteration), flush: false);
+
+            Span<byte> scratchBuffer = writer.GetSpan(byteCountForThisSlice);
+
+            encoder.Convert(chars, scratchBuffer, flush, out int charsUsedJustNow, out int bytesWrittenJustNow, out completed);
+
+            chars = chars.Slice(charsUsedJustNow);
+            writer.Advance(bytesWrittenJustNow);
+            totalBytesWritten += bytesWrittenJustNow;
+        } while (!chars.IsEmpty);
+
+        bytesUsed = totalBytesWritten;
+    }
+
+    public static Task ConnectAsync(this Socket socket, EndPoint remoteEP, CancellationToken cancellationToken /* TODO */)
+    {
+        return Task.Factory.FromAsync(
+            (targetEndPoint, callback, state) => ((Socket)state).BeginConnect(targetEndPoint, callback, state),
+            asyncResult => ((Socket)asyncResult.AsyncState).EndConnect(asyncResult),
+            remoteEP,
+            state: socket);
+    }
+}
+#else
+static partial class NetstandardExtensions
+{
+    public static SafeHandle GetSafeHandle(this Socket socket)
+        => socket.SafeHandle;
+}
+#endif

--- a/src/Tmds.DBus.Protocol/ObjectPath.cs
+++ b/src/Tmds.DBus.Protocol/ObjectPath.cs
@@ -1,0 +1,9 @@
+// Strongly-typed signature string for writing a variant with an object path.
+struct ObjectPath
+{
+    private string _value;
+
+    public ObjectPath(string value) => _value = value;
+
+    public override string ToString() => _value ?? "";
+}

--- a/src/Tmds.DBus.Protocol/ProtocolConstants.cs
+++ b/src/Tmds.DBus.Protocol/ProtocolConstants.cs
@@ -1,0 +1,78 @@
+namespace Tmds.DBus.Protocol;
+
+static class ProtocolConstants
+{
+    // note: C# compiler treats these as static data.
+    public static ReadOnlySpan<byte> ByteSignature => new byte[] { (byte)'y' };
+    public static ReadOnlySpan<byte> BooleanSignature => new byte[] { (byte)'b' };
+    public static ReadOnlySpan<byte> Int16Signature => new byte[] { (byte)'n' };
+    public static ReadOnlySpan<byte> UInt16Signature => new byte[] { (byte)'q' };
+    public static ReadOnlySpan<byte> Int32Signature => new byte[] { (byte)'i' };
+    public static ReadOnlySpan<byte> UInt32Signature => new byte[] { (byte)'u' };
+    public static ReadOnlySpan<byte> Int64Signature => new byte[] { (byte)'x' };
+    public static ReadOnlySpan<byte> UInt64Signature => new byte[] { (byte)'t' };
+    public static ReadOnlySpan<byte> DoubleSignature => new byte[] { (byte)'d' };
+    public static ReadOnlySpan<byte> UnixFdSignature => new byte[] { (byte)'h' };
+    public static ReadOnlySpan<byte> StringSignature => new byte[] { (byte)'s' };
+    public static ReadOnlySpan<byte> ObjectPathSignature => new byte[] { (byte)'o' };
+    public static ReadOnlySpan<byte> SignatureSignature => new byte[] { (byte)'g' };
+
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static int GetTypeAlignment(DBusType type)
+    {
+        switch (type)
+        {
+            case DBusType.Byte: return 1;
+            case DBusType.Bool: return 4;
+            case DBusType.Int16: return 2;
+            case DBusType.UInt16: return 2;
+            case DBusType.Int32: return 4;
+            case DBusType.UInt32: return 4;
+            case DBusType.Int64: return 8;
+            case DBusType.UInt64: return 8;
+            case DBusType.Double: return 8;
+            case DBusType.String: return 4;
+            case DBusType.ObjectPath: return 4;
+            case DBusType.Signature: return 4;
+            case DBusType.Array: return 4;
+            case DBusType.Struct: return 8;
+            case DBusType.Variant: return 1;
+            case DBusType.DictEntry: return 8;
+            case DBusType.UnixFd: return 4;
+            default: return 1;
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static int GetFixedTypeLength(DBusType type)
+    {
+        switch (type)
+        {
+            case DBusType.Byte: return 1;
+            case DBusType.Bool: return 4;
+            case DBusType.Int16: return 2;
+            case DBusType.UInt16: return 2;
+            case DBusType.Int32: return 4;
+            case DBusType.UInt32: return 4;
+            case DBusType.Int64: return 8;
+            case DBusType.UInt64: return 8;
+            case DBusType.Double: return 8;
+            case DBusType.UnixFd: return 4;
+            default: return 0;
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static int Align(int offset, DBusType type)
+    {
+        return offset + GetPadding(offset, type);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static int GetPadding(int offset, DBusType type)
+    {
+        int alignment = GetTypeAlignment(type);
+        return (~offset + 1) & (alignment - 1);
+    }
+}

--- a/src/Tmds.DBus.Protocol/ProtocolException.cs
+++ b/src/Tmds.DBus.Protocol/ProtocolException.cs
@@ -1,0 +1,7 @@
+namespace Tmds.DBus.Protocol;
+
+public class ProtocolException : Exception
+{
+    public ProtocolException(string message) : base(message)
+    { }
+}

--- a/src/Tmds.DBus.Protocol/Reader.Array.cs
+++ b/src/Tmds.DBus.Protocol/Reader.Array.cs
@@ -1,0 +1,92 @@
+using System.Reflection;
+
+namespace Tmds.DBus.Protocol;
+
+public ref partial struct Reader
+{
+    public T[] ReadArray<T>()
+    {
+        List<T> items = new();
+        ArrayEnd headersEnd = ReadArrayStart(TypeModel.GetTypeAlignment<T>());
+        while (HasNext(headersEnd))
+        {
+            items.Add(Read<T>());
+        }
+        return items.ToArray();
+    }
+
+    private KeyValuePair<TKey, TValue>[] ReadKeyValueArray<TKey, TValue>()
+    {
+        List<KeyValuePair<TKey, TValue>> items = new();
+        ArrayEnd headersEnd = ReadArrayStart(DBusType.Struct);
+        while (HasNext(headersEnd))
+        {
+            TKey key = Read<TKey>();
+            TValue value = Read<TValue>();
+            items.Add(new KeyValuePair<TKey, TValue>(key, value));
+        }
+        return items.ToArray();
+    }
+
+    sealed class KeyValueArrayTypeReader<TKey, TValue> : ITypeReader<KeyValuePair<TKey, TValue>[]>
+        where TKey : notnull
+        where TValue : notnull
+    {
+        public KeyValuePair<TKey, TValue>[] Read(ref Reader reader)
+        {
+            return reader.ReadKeyValueArray<TKey, TValue>();
+        }
+    }
+
+    sealed class ArrayTypeReader<T> : ITypeReader<T[]>
+        where T : notnull
+    {
+        public T[] Read(ref Reader reader)
+        {
+            return reader.ReadArray<T>();
+        }
+    }
+
+    public static void AddArrayTypeReader<T>()
+        where T : notnull
+    {
+        lock (_typeReaders)
+        {
+            Type keyType = typeof(T[]);
+            if (!_typeReaders.ContainsKey(keyType))
+            {
+                _typeReaders.Add(keyType, new ArrayTypeReader<T>());
+            }
+        }
+    }
+
+    public static void AddKeyValueArrayTypeReader<TKey, TValue>()
+        where TKey : notnull
+        where TValue : notnull
+    {
+        lock (_typeReaders)
+        {
+            Type keyType = typeof(KeyValuePair<TKey, TValue>[]);
+            if (!_typeReaders.ContainsKey(keyType))
+            {
+                _typeReaders.Add(keyType, new KeyValueArrayTypeReader<TKey, TValue>());
+            }
+        }
+    }
+
+    private ITypeReader CreateArrayTypeReader(Type elementType)
+    {
+        Type readerType;
+        if (elementType.IsGenericType && elementType.GetGenericTypeDefinition() == typeof(KeyValuePair<,>))
+        {
+            Type keyType = elementType.GenericTypeArguments[0];
+            Type valueType = elementType.GenericTypeArguments[1];
+            readerType = typeof(KeyValueArrayTypeReader<,>).MakeGenericType(new[] { keyType, valueType });
+        }
+        else
+        {
+            readerType = typeof(ArrayTypeReader<>).MakeGenericType(new[] { elementType });
+        }
+        return (ITypeReader)Activator.CreateInstance(readerType)!;
+    }
+}

--- a/src/Tmds.DBus.Protocol/Reader.Basic.cs
+++ b/src/Tmds.DBus.Protocol/Reader.Basic.cs
@@ -1,0 +1,105 @@
+using System.Reflection;
+
+namespace Tmds.DBus.Protocol;
+
+public ref partial struct Reader
+{
+    public byte ReadByte()
+    {
+        if (!_reader.TryRead(out byte b))
+        {
+            ThrowHelper.ThrowIndexOutOfRange();
+        }
+        return b;
+    }
+
+    public bool ReadBool()
+    {
+        return ReadInt32() != 0;
+    }
+
+    public UInt16 ReadUInt16()
+        => (UInt16)ReadInt16();
+
+    public Int16 ReadInt16()
+    {
+        AlignReader(DBusType.Int16);
+        bool dataRead = _isBigEndian ? _reader.TryReadBigEndian(out Int16 rv) : _reader.TryReadLittleEndian(out rv);
+        if (!dataRead)
+        {
+            ThrowHelper.ThrowIndexOutOfRange();
+        }
+        return rv;
+    }
+
+    public uint ReadUInt32()
+        => (uint)ReadInt32();
+
+    public int ReadInt32()
+    {
+        AlignReader(DBusType.Int32);
+        bool dataRead = _isBigEndian ? _reader.TryReadBigEndian(out int rv) : _reader.TryReadLittleEndian(out rv);
+        if (!dataRead)
+        {
+            ThrowHelper.ThrowIndexOutOfRange();
+        }
+        return rv;
+    }
+
+    public UInt64 ReadUInt64()
+        => (UInt64)ReadInt64();
+
+    public Int64 ReadInt64()
+    {
+        AlignReader(DBusType.Int64);
+        bool dataRead = _isBigEndian ? _reader.TryReadBigEndian(out Int64 rv) : _reader.TryReadLittleEndian(out rv);
+        if (!dataRead)
+        {
+            ThrowHelper.ThrowIndexOutOfRange();
+        }
+        return rv;
+    }
+
+    public unsafe double ReadDouble()
+    {
+        double value;
+        *(Int64*)&value = ReadInt64();
+        return value;
+    }
+
+    public Utf8Span ReadSignature()
+    {
+        int length = ReadByte();
+        return ReadSpan(length);
+    }
+
+    public Utf8Span ReadObjectPath() => ReadSpan();
+
+    public Utf8Span ReadString() => ReadSpan();
+
+    private ReadOnlySpan<byte> ReadSpan()
+    {
+        int length = (int)ReadUInt32();
+        return ReadSpan(length);
+    }
+
+    private ReadOnlySpan<byte> ReadSpan(int length)
+    {
+        var span = _reader.UnreadSpan;
+        if (span.Length <= length)
+        {
+            _reader.Advance(length + 1);
+            return span.Slice(length);
+        }
+        else
+        {
+            var buffer = new byte[length];
+            if (!_reader.TryCopyTo(buffer))
+            {
+                ThrowHelper.ThrowIndexOutOfRange();
+            }
+            _reader.Advance(length + 1);
+            return new ReadOnlySpan<byte>(buffer);
+        }
+    }
+}

--- a/src/Tmds.DBus.Protocol/Reader.Dictionary.cs
+++ b/src/Tmds.DBus.Protocol/Reader.Dictionary.cs
@@ -1,0 +1,51 @@
+using System.Reflection;
+
+namespace Tmds.DBus.Protocol;
+
+public ref partial struct Reader
+{
+    public Dictionary<TKey, TValue> ReadDictionary<TKey, TValue>()
+        where TKey : notnull
+        where TValue : notnull
+    {
+        Dictionary<TKey, TValue> dictionary = new();
+        ArrayEnd headersEnd = ReadArrayStart(DBusType.Struct);
+        while (HasNext(headersEnd))
+        {
+            var key = Read<TKey>();
+            var value = Read<TValue>();
+            dictionary.Add(key, value);
+        }
+        return dictionary;
+    }
+
+    sealed class DictionaryTypeReader<TKey, TValue> : ITypeReader<Dictionary<TKey, TValue>>
+        where TKey : notnull
+        where TValue : notnull
+    {
+        public Dictionary<TKey, TValue> Read(ref Reader reader)
+        {
+            return reader.ReadDictionary<TKey, TValue>();
+        }
+    }
+
+    public static void AddDictionaryTypeReader<TKey, TValue>()
+        where TKey : notnull
+        where TValue : notnull
+    {
+        lock (_typeReaders)
+        {
+            Type keyType = typeof(Dictionary<TKey, TValue>);
+            if (!_typeReaders.ContainsKey(keyType))
+            {
+                _typeReaders.Add(keyType, new DictionaryTypeReader<TKey, TValue>());
+            }
+        }
+    }
+
+    private ITypeReader CreateDictionaryTypeReader(Type keyType, Type valueType)
+    {
+        Type readerType = typeof(DictionaryTypeReader<,>).MakeGenericType(new[] { keyType, valueType });
+        return (ITypeReader)Activator.CreateInstance(readerType)!;
+    }
+}

--- a/src/Tmds.DBus.Protocol/Reader.Handle.cs
+++ b/src/Tmds.DBus.Protocol/Reader.Handle.cs
@@ -1,0 +1,27 @@
+using System.Reflection;
+
+namespace Tmds.DBus.Protocol;
+
+public ref partial struct Reader
+{
+    public T ReadHandle<T>() where T : notnull
+    {
+        throw new NotImplementedException();
+    }
+
+    public IntPtr ReadHandle(bool own)
+    {
+        throw new NotImplementedException();
+        // int idx = (int)ReadUInt32();
+        // IntPtr handle = (IntPtr)(-1);
+        // if (_handles is not null)
+        // {
+        //     (handle, bool dispose) = _handles[idx];
+        //     if (own)
+        //     {
+        //         _handles[idx] = (handle, false);
+        //     }
+        // }
+        // return handle;
+    }
+}

--- a/src/Tmds.DBus.Protocol/Reader.ReadT.cs
+++ b/src/Tmds.DBus.Protocol/Reader.ReadT.cs
@@ -1,0 +1,168 @@
+using System.Reflection;
+
+namespace Tmds.DBus.Protocol;
+
+public ref partial struct Reader
+{
+    interface ITypeReader
+    { }
+
+    interface ITypeReader<T> : ITypeReader
+    {
+        T Read(ref Reader reader);
+    }
+
+    private static readonly Dictionary<Type, ITypeReader> _typeReaders = new();
+
+    public object ReadVariant() => Read<object>();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private T Read<T>()
+    {
+        Type type = typeof(T);
+
+        if (type == typeof(object))
+        {
+            Utf8Span signature = ReadSignature();
+            type = TypeModel.DetermineVariantType(signature);
+        }
+
+        if (type == typeof(byte))
+        {
+            return (T)(object)ReadByte();
+        }
+        else if (type == typeof(bool))
+        {
+            return (T)(object)ReadBool();
+        }
+        else if (type == typeof(Int16))
+        {
+            return (T)(object)ReadInt16();
+        }
+        else if (type == typeof(UInt16))
+        {
+            return (T)(object)ReadUInt16();
+        }
+        else if (type == typeof(Int32))
+        {
+            return (T)(object)ReadInt32();
+        }
+        else if (type == typeof(UInt32))
+        {
+            return (T)(object)ReadUInt32();
+        }
+        else if (type == typeof(Int64))
+        {
+            return (T)(object)ReadInt64();
+        }
+        else if (type == typeof(UInt64))
+        {
+            return (T)(object)ReadUInt64();
+        }
+        else if (type == typeof(Double))
+        {
+            return (T)(object)ReadDouble();
+        }
+        else if (type == typeof(string))
+        {
+            return (T)(object)ReadString().ToString();
+        }
+        else
+        {
+            var typeReader = (ITypeReader<T>)GetTypeReader(type);
+            return typeReader.Read(ref this);
+        }
+    }
+
+    private ITypeReader GetTypeReader(Type type)
+    {
+        lock (_typeReaders)
+        {
+            if (_typeReaders.TryGetValue(type, out ITypeReader? reader))
+            {
+                return reader;
+            }
+            reader = CreateReaderForType(type);
+            _typeReaders.Add(type, reader);
+            return reader;
+        }
+    }
+
+    private ITypeReader CreateReaderForType(Type type)
+    {
+        // Array
+        if (type.IsArray)
+        {
+            return CreateArrayTypeReader(type.GetElementType()!);
+        }
+
+        // Dictionary<.>
+        if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(Dictionary<,>))
+        {
+            Type keyType = type.GenericTypeArguments[0];
+            Type valueType = type.GenericTypeArguments[1];
+            return CreateDictionaryTypeReader(keyType, valueType);
+        }
+
+        // Struct (ValueTuple)
+        if (type.IsGenericType && type.FullName!.StartsWith("System.ValueTuple"))
+        {
+            switch (type.GenericTypeArguments.Length)
+            {
+                case 1: return CreateValueTupleTypeReader(type.GenericTypeArguments[0]);
+                case 2:
+                    return CreateValueTupleTypeReader(type.GenericTypeArguments[0],
+                                                      type.GenericTypeArguments[1]);
+                case 3:
+                    return CreateValueTupleTypeReader(type.GenericTypeArguments[0],
+                                                      type.GenericTypeArguments[1],
+                                                      type.GenericTypeArguments[2]);
+                case 4:
+                    return CreateValueTupleTypeReader(type.GenericTypeArguments[0],
+                                                      type.GenericTypeArguments[1],
+                                                      type.GenericTypeArguments[2],
+                                                      type.GenericTypeArguments[3]);
+                case 5:
+                    return CreateValueTupleTypeReader(type.GenericTypeArguments[0],
+                                                      type.GenericTypeArguments[1],
+                                                      type.GenericTypeArguments[2],
+                                                      type.GenericTypeArguments[3],
+                                                      type.GenericTypeArguments[4]);
+            }
+        }
+        // Struct (ValueTuple)
+        if (type.IsGenericType && type.FullName!.StartsWith("System.Tuple"))
+        {
+            switch (type.GenericTypeArguments.Length)
+            {
+                case 1: return CreateTupleTypeReader(type.GenericTypeArguments[0]);
+                case 2:
+                    return CreateTupleTypeReader(type.GenericTypeArguments[0],
+                                                 type.GenericTypeArguments[1]);
+                case 3:
+                    return CreateTupleTypeReader(type.GenericTypeArguments[0],
+                                                 type.GenericTypeArguments[1],
+                                                 type.GenericTypeArguments[2]);
+                case 4:
+                    return CreateTupleTypeReader(type.GenericTypeArguments[0],
+                                                 type.GenericTypeArguments[1],
+                                                 type.GenericTypeArguments[2],
+                                                 type.GenericTypeArguments[3]);
+                case 5:
+                    return CreateTupleTypeReader(type.GenericTypeArguments[0],
+                                                 type.GenericTypeArguments[1],
+                                                 type.GenericTypeArguments[2],
+                                                 type.GenericTypeArguments[3],
+                                                 type.GenericTypeArguments[4]);
+            }
+        }
+
+        ThrowNotSupportedType(type);
+        return default!;
+    }
+
+    private static void ThrowNotSupportedType(Type type)
+    {
+        throw new NotSupportedException($"Cannot read type {type.FullName}");
+    }
+}

--- a/src/Tmds.DBus.Protocol/Reader.Struct.cs
+++ b/src/Tmds.DBus.Protocol/Reader.Struct.cs
@@ -1,0 +1,401 @@
+using System.Reflection;
+
+namespace Tmds.DBus.Protocol;
+
+public ref partial struct Reader
+{
+    public ValueTuple<T1> ReadStruct<T1>()
+    {
+        AlignStruct();
+        return ValueTuple.Create(Read<T1>());
+    }
+
+    private Tuple<T1> ReadStructAsTuple<T1>()
+    {
+        AlignStruct();
+        return Tuple.Create(Read<T1>());
+    }
+
+    sealed class ValueTupleTypeReader<T1> : ITypeReader<ValueTuple<T1>>
+        where T1 : notnull
+    {
+        public ValueTuple<T1> Read(ref Reader reader)
+        {
+            return reader.ReadStruct<T1>();
+        }
+    }
+
+    sealed class TupleTypeReader<T1> : ITypeReader<Tuple<T1>>
+        where T1 : notnull
+    {
+        public Tuple<T1> Read(ref Reader reader)
+        {
+            return reader.ReadStructAsTuple<T1>();
+        }
+    }
+
+    public static void AddValueTupleTypeReader<T1>()
+        where T1 : notnull
+    {
+        lock (_typeReaders)
+        {
+            Type keyType = typeof(ValueTuple<T1>);
+            if (!_typeReaders.ContainsKey(keyType))
+            {
+                _typeReaders.Add(keyType, new ValueTupleTypeReader<T1>());
+            }
+        }
+    }
+
+    public static void AddTupleTypeReader<T1>()
+        where T1 : notnull
+    {
+        lock (_typeReaders)
+        {
+            Type keyType = typeof(Tuple<T1>);
+            if (!_typeReaders.ContainsKey(keyType))
+            {
+                _typeReaders.Add(keyType, new TupleTypeReader<T1>());
+            }
+        }
+    }
+
+    private ITypeReader CreateValueTupleTypeReader(Type type1)
+    {
+        Type readerType = typeof(ValueTupleTypeReader<>).MakeGenericType(new[] { type1 });
+        return (ITypeReader)Activator.CreateInstance(readerType)!;
+    }
+
+    private ITypeReader CreateTupleTypeReader(Type type1)
+    {
+        Type readerType = typeof(TupleTypeReader<>).MakeGenericType(new[] { type1 });
+        return (ITypeReader)Activator.CreateInstance(readerType)!;
+    }
+
+    public ValueTuple<T1, T2> ReadStruct<T1, T2>()
+        where T1 : notnull
+        where T2 : notnull
+    {
+        AlignStruct();
+        return ValueTuple.Create(Read<T1>(), Read<T2>());
+    }
+
+    private Tuple<T1, T2> ReadStructAsTuple<T1, T2>()
+        where T1 : notnull
+        where T2 : notnull
+    {
+        AlignStruct();
+        return Tuple.Create(Read<T1>(), Read<T2>());
+    }
+
+    sealed class ValueTupleTypeReader<T1, T2> : ITypeReader<ValueTuple<T1, T2>>
+        where T1 : notnull
+        where T2 : notnull
+    {
+        public ValueTuple<T1, T2> Read(ref Reader reader)
+        {
+            return reader.ReadStruct<T1, T2>();
+        }
+    }
+
+    sealed class TupleTypeReader<T1, T2> : ITypeReader<Tuple<T1, T2>>
+        where T1 : notnull
+        where T2 : notnull
+    {
+        public Tuple<T1, T2> Read(ref Reader reader)
+        {
+            return reader.ReadStructAsTuple<T1, T2>();
+        }
+    }
+
+    public static void AddValueTupleTypeReader<T1, T2>()
+        where T1 : notnull
+        where T2 : notnull
+    {
+        lock (_typeReaders)
+        {
+            Type keyType = typeof(ValueTuple<T1, T2>);
+            if (!_typeReaders.ContainsKey(keyType))
+            {
+                _typeReaders.Add(keyType, new ValueTupleTypeReader<T1, T2>());
+            }
+        }
+    }
+
+    public static void AddTupleTypeReader<T1, T2>()
+        where T1 : notnull
+        where T2 : notnull
+    {
+        lock (_typeReaders)
+        {
+            Type keyType = typeof(Tuple<T1, T2>);
+            if (!_typeReaders.ContainsKey(keyType))
+            {
+                _typeReaders.Add(keyType, new TupleTypeReader<T1, T2>());
+            }
+        }
+    }
+
+    private ITypeReader CreateValueTupleTypeReader(Type type1, Type type2)
+    {
+        Type readerType = typeof(ValueTupleTypeReader<,>).MakeGenericType(new[] { type1, type2 });
+        return (ITypeReader)Activator.CreateInstance(readerType)!;
+    }
+
+    private ITypeReader CreateTupleTypeReader(Type type1, Type type2)
+    {
+        Type readerType = typeof(TupleTypeReader<,>).MakeGenericType(new[] { type1, type2 });
+        return (ITypeReader)Activator.CreateInstance(readerType)!;
+    }
+
+    public ValueTuple<T1, T2, T3> ReadStruct<T1, T2, T3>()
+        where T1 : notnull
+        where T2 : notnull
+        where T3 : notnull
+    {
+        AlignStruct();
+        return ValueTuple.Create(Read<T1>(), Read<T2>(), Read<T3>());
+    }
+
+    private Tuple<T1, T2, T3> ReadStructAsTuple<T1, T2, T3>()
+    {
+        AlignStruct();
+        return Tuple.Create(Read<T1>(), Read<T2>(), Read<T3>());
+    }
+
+    sealed class ValueTupleTypeReader<T1, T2, T3> : ITypeReader<ValueTuple<T1, T2, T3>>
+        where T1 : notnull
+        where T2 : notnull
+        where T3 : notnull
+    {
+        public ValueTuple<T1, T2, T3> Read(ref Reader reader)
+        {
+            return reader.ReadStruct<T1, T2, T3>();
+        }
+    }
+
+    sealed class TupleTypeReader<T1, T2, T3> : ITypeReader<Tuple<T1, T2, T3>>
+        where T1 : notnull
+        where T2 : notnull
+        where T3 : notnull
+    {
+        public Tuple<T1, T2, T3> Read(ref Reader reader)
+        {
+            return reader.ReadStructAsTuple<T1, T2, T3>();
+        }
+    }
+
+    public static void AddValueTupleTypeReader<T1, T2, T3>()
+        where T1 : notnull
+        where T2 : notnull
+        where T3 : notnull
+    {
+        lock (_typeReaders)
+        {
+            Type keyType = typeof(ValueTuple<T1, T2, T3>);
+            if (!_typeReaders.ContainsKey(keyType))
+            {
+                _typeReaders.Add(keyType, new ValueTupleTypeReader<T1, T2, T3>());
+            }
+        }
+    }
+
+    public static void AddTupleTypeReader<T1, T2, T3>()
+        where T1 : notnull
+        where T2 : notnull
+        where T3 : notnull
+    {
+        lock (_typeReaders)
+        {
+            Type keyType = typeof(Tuple<T1, T2, T3>);
+            if (!_typeReaders.ContainsKey(keyType))
+            {
+                _typeReaders.Add(keyType, new TupleTypeReader<T1, T2, T3>());
+            }
+        }
+    }
+
+    private ITypeReader CreateValueTupleTypeReader(Type type1, Type type2, Type type3)
+    {
+        Type readerType = typeof(ValueTupleTypeReader<,,>).MakeGenericType(new[] { type1, type2, type3 });
+        return (ITypeReader)Activator.CreateInstance(readerType)!;
+    }
+
+    private ITypeReader CreateTupleTypeReader(Type type1, Type type2, Type type3)
+    {
+        Type readerType = typeof(TupleTypeReader<,,>).MakeGenericType(new[] { type1, type2, type3 });
+        return (ITypeReader)Activator.CreateInstance(readerType)!;
+    }
+
+    public ValueTuple<T1, T2, T3, T4> ReadStruct<T1, T2, T3, T4>()
+        where T1 : notnull
+        where T2 : notnull
+        where T3 : notnull
+        where T4 : notnull
+    {
+        AlignStruct();
+        return ValueTuple.Create(Read<T1>(), Read<T2>(), Read<T3>(), Read<T4>());
+    }
+
+    private Tuple<T1, T2, T3, T4> ReadStructAsTuple<T1, T2, T3, T4>()
+        where T1 : notnull
+        where T2 : notnull
+        where T3 : notnull
+        where T4 : notnull
+    {
+        AlignStruct();
+        return Tuple.Create(Read<T1>(), Read<T2>(), Read<T3>(), Read<T4>());
+    }
+
+    sealed class ValueTupleTypeReader<T1, T2, T3, T4> : ITypeReader<ValueTuple<T1, T2, T3, T4>>
+        where T1 : notnull
+        where T2 : notnull
+        where T3 : notnull
+        where T4 : notnull
+    {
+        public ValueTuple<T1, T2, T3, T4> Read(ref Reader reader)
+        {
+            return reader.ReadStruct<T1, T2, T3, T4>();
+        }
+    }
+
+    sealed class TupleTypeReader<T1, T2, T3, T4> : ITypeReader<Tuple<T1, T2, T3, T4>>
+        where T1 : notnull
+        where T2 : notnull
+        where T3 : notnull
+        where T4 : notnull
+    {
+        public Tuple<T1, T2, T3, T4> Read(ref Reader reader)
+        {
+            return reader.ReadStructAsTuple<T1, T2, T3, T4>();
+        }
+    }
+
+    public static void AddValueTupleTypeReader<T1, T2, T3, T4>()
+        where T1 : notnull
+        where T2 : notnull
+        where T3 : notnull
+        where T4 : notnull
+    {
+        lock (_typeReaders)
+        {
+            Type keyType = typeof(ValueTuple<T1, T2, T3, T4>);
+            if (!_typeReaders.ContainsKey(keyType))
+            {
+                _typeReaders.Add(keyType, new ValueTupleTypeReader<T1, T2, T3, T4>());
+            }
+        }
+    }
+
+    public static void AddTupleTypeReader<T1, T2, T3, T4>()
+        where T1 : notnull
+        where T2 : notnull
+        where T3 : notnull
+        where T4 : notnull
+    {
+        lock (_typeReaders)
+        {
+            Type keyType = typeof(Tuple<T1, T2, T3, T4>);
+            if (!_typeReaders.ContainsKey(keyType))
+            {
+                _typeReaders.Add(keyType, new TupleTypeReader<T1, T2, T3, T4>());
+            }
+        }
+    }
+
+    private ITypeReader CreateValueTupleTypeReader(Type type1, Type type2, Type type3, Type type4)
+    {
+        Type readerType = typeof(ValueTupleTypeReader<,,,>).MakeGenericType(new[] { type1, type2, type3, type4 });
+        return (ITypeReader)Activator.CreateInstance(readerType)!;
+    }
+
+    private ITypeReader CreateTupleTypeReader(Type type1, Type type2, Type type3, Type type4)
+    {
+        Type readerType = typeof(TupleTypeReader<,,,>).MakeGenericType(new[] { type1, type2, type3, type4 });
+        return (ITypeReader)Activator.CreateInstance(readerType)!;
+    }
+
+    public ValueTuple<T1, T2, T3, T4, T5> ReadStruct<T1, T2, T3, T4, T5>()
+    {
+        AlignStruct();
+        return ValueTuple.Create(Read<T1>(), Read<T2>(), Read<T3>(), Read<T4>(), Read<T5>());
+    }
+
+    private Tuple<T1, T2, T3, T4, T5> ReadStructAsTuple<T1, T2, T3, T4, T5>()
+    {
+        AlignStruct();
+        return Tuple.Create(Read<T1>(), Read<T2>(), Read<T3>(), Read<T4>(), Read<T5>());
+    }
+
+    sealed class ValueTupleTypeReader<T1, T2, T3, T4, T5> : ITypeReader<ValueTuple<T1, T2, T3, T4, T5>>
+        where T1 : notnull
+        where T2 : notnull
+        where T3 : notnull
+        where T4 : notnull
+        where T5 : notnull
+    {
+        public ValueTuple<T1, T2, T3, T4, T5> Read(ref Reader reader)
+        {
+            return reader.ReadStruct<T1, T2, T3, T4, T5>();
+        }
+    }
+
+    sealed class TupleTypeReader<T1, T2, T3, T4, T5> : ITypeReader<Tuple<T1, T2, T3, T4, T5>>
+        where T1 : notnull
+        where T2 : notnull
+        where T3 : notnull
+        where T4 : notnull
+        where T5 : notnull
+    {
+        public Tuple<T1, T2, T3, T4, T5> Read(ref Reader reader)
+        {
+            return reader.ReadStructAsTuple<T1, T2, T3, T4, T5>();
+        }
+    }
+
+    public static void AddValueTupleTypeReader<T1, T2, T3, T4, T5>()
+        where T1 : notnull
+        where T2 : notnull
+        where T3 : notnull
+        where T4 : notnull
+        where T5 : notnull
+    {
+        lock (_typeReaders)
+        {
+            Type keyType = typeof(ValueTuple<T1, T2, T3, T4, T5>);
+            if (!_typeReaders.ContainsKey(keyType))
+            {
+                _typeReaders.Add(keyType, new ValueTupleTypeReader<T1, T2, T3, T4, T5>());
+            }
+        }
+    }
+
+    public static void AddTupleTypeReader<T1, T2, T3, T4, T5>()
+        where T1 : notnull
+        where T2 : notnull
+        where T3 : notnull
+        where T4 : notnull
+        where T5 : notnull
+    {
+        lock (_typeReaders)
+        {
+            Type keyType = typeof(Tuple<T1, T2, T3, T4, T5>);
+            if (!_typeReaders.ContainsKey(keyType))
+            {
+                _typeReaders.Add(keyType, new TupleTypeReader<T1, T2, T3, T4, T5>());
+            }
+        }
+    }
+
+    private ITypeReader CreateValueTupleTypeReader(Type type1, Type type2, Type type3, Type type4, Type type5)
+    {
+        Type readerType = typeof(ValueTupleTypeReader<,,,,>).MakeGenericType(new[] { type1, type2, type3, type4 });
+        return (ITypeReader)Activator.CreateInstance(readerType)!;
+    }
+
+    private ITypeReader CreateTupleTypeReader(Type type1, Type type2, Type type3, Type type4, Type type5)
+    {
+        Type readerType = typeof(TupleTypeReader<,,,,>).MakeGenericType(new[] { type1, type2, type3, type4, type5 });
+        return (ITypeReader)Activator.CreateInstance(readerType)!;
+    }
+}

--- a/src/Tmds.DBus.Protocol/Reader.cs
+++ b/src/Tmds.DBus.Protocol/Reader.cs
@@ -1,0 +1,71 @@
+using System.Reflection;
+
+namespace Tmds.DBus.Protocol;
+
+public ref partial struct Reader
+{
+    private delegate object ValueReader(ref Reader reader);
+
+    private readonly bool _isBigEndian;
+    private UnixFdCollection? _handles;
+    private SequenceReader<byte> _reader;
+
+    internal ReadOnlySequence<byte> UnreadSequence => _reader.Sequence.Slice(_reader.Position);
+
+    internal void Advance(long count) => _reader.Advance(count);
+
+    internal Reader(bool isBigEndian, ReadOnlySequence<byte> sequence, UnixFdCollection? handles)
+    {
+        _reader = new(sequence);
+
+        _isBigEndian = isBigEndian;
+        _handles = handles;
+    }
+
+    public void AlignStruct() => AlignReader(DBusType.Struct);
+
+    private void AlignReader(DBusType type)
+    {
+        long pad = ProtocolConstants.GetPadding((int)_reader.Consumed, type);
+        if (pad != 0)
+        {
+            _reader.Advance(pad);
+        }
+    }
+
+    public ArrayEnd ReadArrayStart(DBusType elementType)
+    {
+        uint arrayLength = ReadUInt32();
+        AlignReader(elementType);
+        int endOfArray = (int)(_reader.Consumed + arrayLength);
+        return new ArrayEnd(elementType, endOfArray);
+    }
+
+    public bool HasNext(ArrayEnd iterator)
+    {
+        int consumed = (int)_reader.Consumed;
+        int nextElement = ProtocolConstants.Align(consumed, iterator.Type);
+        if (nextElement >= iterator.EndOfArray)
+        {
+            return false;
+        }
+        int advance = nextElement - consumed;
+        if (advance != 0)
+        {
+            _reader.Advance(advance);
+        }
+        return true;
+    }
+}
+
+public ref struct ArrayEnd
+{
+    internal readonly DBusType Type;
+    internal readonly int EndOfArray;
+
+    internal ArrayEnd(DBusType type, int endOfArray)
+    {
+        Type = type;
+        EndOfArray = endOfArray;
+    }
+}

--- a/src/Tmds.DBus.Protocol/Signature.cs
+++ b/src/Tmds.DBus.Protocol/Signature.cs
@@ -1,0 +1,9 @@
+// Strongly-typed signature string for writing a variant with a signature.
+struct Signature
+{
+    private string _value;
+
+    public Signature(string value) => _value = value;
+
+    public override string ToString() => _value ?? "";
+}

--- a/src/Tmds.DBus.Protocol/SignatureReader.cs
+++ b/src/Tmds.DBus.Protocol/SignatureReader.cs
@@ -1,0 +1,228 @@
+namespace Tmds.DBus.Protocol;
+
+ref struct SignatureReader
+{
+    private ReadOnlySpan<byte> _signature;
+
+    public ReadOnlySpan<byte> Signature => _signature;
+
+    public SignatureReader(ReadOnlySpan<byte> signature)
+    {
+        _signature = signature;
+    }
+
+    public bool TryRead(out DBusType type, out ReadOnlySpan<byte> innerSignature)
+    {
+        innerSignature = default;
+
+        if (_signature.IsEmpty)
+        {
+            type = DBusType.Invalid;
+            return false;
+        }
+
+        type = ReadSingleType(_signature, out int length);
+
+        if (length > 1)
+        {
+            switch (type)
+            {
+                case DBusType.Array:
+                    innerSignature = _signature.Slice(1, length - 1);
+                    break;
+                case DBusType.Struct:
+                case DBusType.DictEntry:
+                    innerSignature = _signature.Slice(1, length - 2);
+                    break;
+            }
+        }
+
+        _signature = _signature.Slice(length);
+
+        return true;
+    }
+
+    private static DBusType ReadSingleType(ReadOnlySpan<byte> signature, out int length)
+    {
+        length = 0;
+
+        if (signature.IsEmpty)
+        {
+            return DBusType.Invalid;
+        }
+
+        DBusType type = (DBusType)signature[0];
+
+        if (IsBasicType(type))
+        {
+            length = 1;
+        }
+        else if (type == DBusType.Variant)
+        {
+            length = 1;
+        }
+        else if (type == DBusType.Array)
+        {
+            if (ReadSingleType(signature.Slice(1), out int elementLength) != DBusType.Invalid)
+            {
+                type = DBusType.Array;
+                length = elementLength + 1;
+            }
+            else
+            {
+                type = DBusType.Invalid;
+            }
+        }
+        else if (type == DBusType.Struct)
+        {
+            length = DetermineLength(signature.Slice(1), (byte)'(', (byte)')');
+            if (length == 0)
+            {
+                type = DBusType.Invalid;
+            }
+        }
+        else if (type == DBusType.DictEntry)
+        {
+            length = DetermineLength(signature.Slice(1), (byte)'{', (byte)'}');
+            if (length < 4 ||
+                !IsBasicType((DBusType)signature[1]) ||
+                ReadSingleType(signature.Slice(2), out int valueTypeLength) == DBusType.Invalid ||
+                length != valueTypeLength + 3)
+            {
+                type = DBusType.Invalid;
+            }
+        }
+        else
+        {
+            type = DBusType.Invalid;
+        }
+
+        return type;
+    }
+
+    static int DetermineLength(ReadOnlySpan<byte> span, byte startChar, byte endChar)
+    {
+        int length = 1;
+        int count = 1;
+        do
+        {
+            int offset = span.IndexOfAny(startChar, endChar);
+            if (offset == -1)
+            {
+                return 0;
+            }
+
+            if (span[offset] == startChar)
+            {
+                count++;
+            }
+            else
+            {
+                count--;
+            }
+
+            length += offset + 1;
+            span = span.Slice(offset + 1);
+
+        } while (count > 0);
+
+        return length;
+    }
+
+    private static bool IsBasicType(DBusType type)
+    {
+        return BasicTypes.IndexOf((byte)type) != -1;
+    }
+
+    private static ReadOnlySpan<byte> BasicTypes => new byte[] {
+        (byte)DBusType.Byte,
+        (byte)DBusType.Bool,
+        (byte)DBusType.Int16,
+        (byte)DBusType.UInt16,
+        (byte)DBusType.Int32,
+        (byte)DBusType.UInt32,
+        (byte)DBusType.Int64,
+        (byte)DBusType.UInt64,
+        (byte)DBusType.Double,
+        (byte)DBusType.String,
+        (byte)DBusType.ObjectPath,
+        (byte)DBusType.Signature,
+        (byte)DBusType.UnixFd };
+
+    public static ReadOnlySpan<byte> ReadSingleType(ref ReadOnlySpan<byte> signature)
+    {
+        if (signature.Length == 0)
+        {
+            return default;
+        }
+
+        int length;
+        DBusType type = (DBusType)signature[0];
+        if (type == DBusType.Struct)
+        {
+            length = DetermineLength(signature.Slice(1), (byte)'(', (byte)')');
+        }
+        else if (type == DBusType.DictEntry)
+        {
+            length = DetermineLength(signature.Slice(1), (byte)'{', (byte)'}');
+        }
+        else if (type == DBusType.Array)
+        {
+            ReadOnlySpan<byte> remainder = signature.Slice(1);
+            length = 1 + ReadSingleType(ref remainder).Length;
+        }
+        else
+        {
+            length = 1;
+        }
+
+        ReadOnlySpan<byte> rv = signature.Slice(0, length);
+        signature = signature.Slice(length);
+        return rv;
+    }
+
+    public static int CountTypes(ReadOnlySpan<byte> signature)
+    {
+        if (signature.Length == 0)
+        {
+            return 0;
+        }
+
+        if (signature.Length == 1)
+        {
+            return 1;
+        }
+
+        DBusType type = (DBusType)signature[0];
+        signature = signature.Slice(1);
+
+        if (type == DBusType.Struct)
+        {
+            ReadToEnd(ref signature, (byte)'(', (byte)')');
+        }
+        else if (type == DBusType.DictEntry)
+        {
+            ReadToEnd(ref signature, (byte)'{', (byte)'}');
+        }
+
+        return (type == DBusType.Array ? 0 : 1) + CountTypes(signature);
+
+        static void ReadToEnd(ref ReadOnlySpan<byte> span, byte startChar, byte endChar)
+        {
+            int count = 1;
+            do
+            {
+                int offset = span.IndexOfAny(startChar, endChar);
+                if (span[offset] == startChar)
+                {
+                    count++;
+                }
+                else
+                {
+                    count--;
+                }
+                span = span.Slice(offset + 1);
+            } while (count > 0);
+        }
+    }
+}

--- a/src/Tmds.DBus.Protocol/SocketExtensions.cs
+++ b/src/Tmds.DBus.Protocol/SocketExtensions.cs
@@ -1,0 +1,232 @@
+using System.Net.Sockets;
+
+namespace Tmds.DBus.Protocol;
+
+using SizeT = System.UIntPtr;
+using SSizeT = System.IntPtr;
+
+static class SocketExtensions
+{
+    public static ValueTask<int> ReceiveAsync(this Socket socket, Memory<byte> memory, UnixFdCollection? fdCollection)
+    {
+        if (fdCollection is null)
+        {
+            return socket.ReceiveAsync(memory, SocketFlags.None);
+        }
+        else
+        {
+            return socket.ReceiveWithHandlesAsync(memory, fdCollection);
+        }
+    }
+
+    private async static ValueTask<int> ReceiveWithHandlesAsync(this Socket socket, Memory<byte> memory, UnixFdCollection fdCollection)
+    {
+        while (true)
+        {
+            await socket.ReceiveAsync(new Memory<byte>(), SocketFlags.None);
+
+            int rv = recvmsg(socket, memory, fdCollection);
+
+            if (rv >= 0)
+            {
+                return rv;
+            }
+            else
+            {
+                int errno = Marshal.GetLastWin32Error();
+                if (errno == EAGAIN || errno == EINTR)
+                {
+                    continue;
+                }
+
+                throw new SocketException(errno);
+            }
+        }
+    }
+
+    public static ValueTask SendAsync(this Socket socket, ReadOnlyMemory<byte> buffer, IReadOnlyList<SafeHandle>? handles)
+    {
+        if (handles is null || handles.Count == 0)
+        {
+            return socket.SendAsync(buffer);
+        }
+        else
+        {
+            return socket.SendAsyncWithHandlesAsync(buffer, handles);
+        }
+    }
+
+    private static async ValueTask SendAsync(this Socket socket, ReadOnlyMemory<byte> buffer)
+    {
+        while (buffer.Length > 0)
+        {
+            int sent = await socket.SendAsync(buffer, SocketFlags.None);
+            buffer = buffer.Slice(sent);
+        }
+    }
+
+    private static ValueTask SendAsyncWithHandlesAsync(this Socket socket, ReadOnlyMemory<byte> buffer, IReadOnlyList<SafeHandle> handles)
+    {
+        socket.Blocking = false;
+        do
+        {
+            int rv = sendmsg(socket, buffer, handles);
+            if (rv > 0)
+            {
+                if (buffer.Length == rv)
+                {
+                    return default;
+                }
+                return socket.SendAsync(buffer.Slice(rv));
+            }
+            else
+            {
+                int errno = Marshal.GetLastWin32Error();
+                if (errno == EINTR)
+                {
+                    continue;
+                }
+                // TODO: handle EAGAIN.
+                return new ValueTask(Task.FromException(new SocketException(errno)));
+            }
+        } while (true);
+    }
+
+    private static unsafe int sendmsg(Socket socket, ReadOnlyMemory<byte> buffer, IReadOnlyList<SafeHandle> handles)
+    {
+        fixed (byte* ptr = buffer.Span)
+        {
+            IOVector* iovs = stackalloc IOVector[1];
+            iovs[0].Base = ptr;
+            iovs[0].Length = (SizeT)buffer.Length;
+
+            msghdr msg = new msghdr();
+            msg.msg_iov = iovs;
+            msg.msg_iovlen = (SizeT)1;
+
+            var fdm = new cmsg_fd();
+            int size = sizeof(cmsghdr) + 4 * handles.Count;
+            msg.msg_control = &fdm;
+            msg.msg_controllen = (SizeT)size;
+            fdm.hdr.cmsg_len = (SizeT)size;
+            fdm.hdr.cmsg_level = SOL_SOCKET;
+            fdm.hdr.cmsg_type = SCM_RIGHTS;
+
+            SafeHandle handle = socket.GetSafeHandle();
+            int handleRefsAdded = 0;
+            bool refAdded = false;
+            try
+            {
+                handle.DangerousAddRef(ref refAdded);
+                for (int i = 0, j = 0; i < handles.Count; i++)
+                {
+                    bool added = false;
+                    SafeHandle h = handles[i];
+                    h.DangerousAddRef(ref added);
+                    handleRefsAdded++;
+                    fdm.fds[j++] = h.DangerousGetHandle().ToInt32();
+                }
+
+                return (int)sendmsg(handle.DangerousGetHandle().ToInt32(), new IntPtr(&msg), 0);
+            }
+            finally
+            {
+                for (int i = 0; i < handleRefsAdded; i++)
+                {
+                    SafeHandle h = handles[i];
+                    h.DangerousRelease();
+                }
+
+                if (refAdded)
+                    handle.DangerousRelease();
+            }
+        }
+    }
+
+    private static unsafe int recvmsg(Socket socket, Memory<byte> buffer, UnixFdCollection handles)
+    {
+        fixed (byte* buf = buffer.Span)
+        {
+            IOVector iov = new IOVector();
+            iov.Base = buf;
+            iov.Length = (SizeT)buffer.Length;
+
+            msghdr msg = new msghdr();
+            msg.msg_iov = &iov;
+            msg.msg_iovlen = (SizeT)1;
+
+            cmsg_fd cm = new cmsg_fd();
+            msg.msg_control = &cm;
+            msg.msg_controllen = (SizeT)sizeof(cmsg_fd);
+
+            var handle = socket.GetSafeHandle();
+            bool refAdded = false;
+            try
+            {
+                handle.DangerousAddRef(ref refAdded);
+
+                int rv = (int)recvmsg(handle.DangerousGetHandle().ToInt32(), new IntPtr(&msg), 0);
+
+                if (rv >= 0)
+                {
+                    if (cm.hdr.cmsg_level == SOL_SOCKET && cm.hdr.cmsg_type == SCM_RIGHTS)
+                    {
+                        int msgFdCount = ((int)cm.hdr.cmsg_len - sizeof(cmsghdr)) / sizeof(int);
+                        for (int i = 0; i < msgFdCount; i++)
+                        {
+                            handles.Add((new IntPtr(cm.fds[i]), true));
+                        }
+                    }
+                }
+                return rv;
+            }
+            finally
+            {
+                if (refAdded)
+                    handle.DangerousRelease();
+            }
+        }
+    }
+
+    const int SOL_SOCKET = 1;
+    const int EINTR = 4;
+    const int EBADF = 9;
+    const int EAGAIN = 11;
+    const int SCM_RIGHTS = 1;
+
+    private unsafe struct msghdr
+    {
+        public IntPtr msg_name; //optional address
+        public uint msg_namelen; //size of address
+        public IOVector* msg_iov; //scatter/gather array
+        public SizeT msg_iovlen; //# elements in msg_iov
+        public void* msg_control; //ancillary data, see below
+        public SizeT msg_controllen; //ancillary data buffer len
+        public int msg_flags; //flags on received message
+    }
+
+    private unsafe struct IOVector
+    {
+        public void* Base;
+        public SizeT Length;
+    }
+
+    private struct cmsghdr
+    {
+        public SizeT cmsg_len; //data byte count, including header
+        public int cmsg_level; //originating protocol
+        public int cmsg_type; //protocol-specific type
+    }
+
+    private unsafe struct cmsg_fd
+    {
+        public cmsghdr hdr;
+        public fixed int fds[64];
+    }
+
+    [DllImport("libc", SetLastError = true)]
+    public static extern SSizeT sendmsg(int sockfd, IntPtr msg, int flags);
+
+    [DllImport("libc", SetLastError = true)]
+    public static extern SSizeT recvmsg(int sockfd, IntPtr msg, int flags);
+}

--- a/src/Tmds.DBus.Protocol/StringBuilderExtensions.cs
+++ b/src/Tmds.DBus.Protocol/StringBuilderExtensions.cs
@@ -1,0 +1,24 @@
+namespace Tmds.DBus.Protocol;
+
+static class StringBuilderExtensions
+{
+    public static void AppendUTF8(this StringBuilder sb, ReadOnlySpan<byte> value)
+    {
+        char[]? valueArray = null;
+
+        int length = Encoding.UTF8.GetCharCount(value);
+
+        Span<char> charBuffer = length <= Constants.StackAllocCharThreshold ?
+            stackalloc char[length] :
+            (valueArray = ArrayPool<char>.Shared.Rent(length));
+
+        int charsWritten = Encoding.UTF8.GetChars(value, charBuffer);
+
+        sb.Append(charBuffer.Slice(0, charsWritten));
+
+        if (valueArray is not null)
+        {
+            ArrayPool<char>.Shared.Return(valueArray);
+        }
+    }
+}

--- a/src/Tmds.DBus.Protocol/ThrowHelper.cs
+++ b/src/Tmds.DBus.Protocol/ThrowHelper.cs
@@ -1,0 +1,27 @@
+using System.Diagnostics.CodeAnalysis;
+
+static class ThrowHelper
+{
+    public static void ThrowIfDisposed(bool condition, object instance)
+    {
+        if (condition)
+        {
+            ThrowObjectDisposedException(instance);
+        }
+    }
+
+    private static void ThrowObjectDisposedException(object instance)
+    {
+        throw new ObjectDisposedException(instance?.GetType().FullName);
+    }
+
+    public static void ThrowIndexOutOfRange()
+    {
+        throw new IndexOutOfRangeException();
+    }
+
+    public static void ThrowNotSupportedException()
+    {
+        throw new NotSupportedException();
+    }
+}

--- a/src/Tmds.DBus.Protocol/Tmds.DBus.Protocol.csproj
+++ b/src/Tmds.DBus.Protocol/Tmds.DBus.Protocol.csproj
@@ -1,0 +1,32 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+    <Nullable>enable</Nullable>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <LangVersion>10</LangVersion>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <Description>Tmds.DBus.Protocol Library</Description>
+    <Authors>Tom Deseyn</Authors>
+    <PackageTags>dbus</PackageTags>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <Copyright>Tom Deseyn</Copyright>
+    <SignAssembly>true</SignAssembly>
+    <AssemblyOriginatorKeyFile>..\..\sign.snk</AssemblyOriginatorKeyFile>
+    <PublicSign>true</PublicSign>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Include="..\..\sign.snk" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Nerdbank.Streams" Version="2.9.45-alpha" />
+    <PackageReference Include="System.IO.Pipelines" Version="6.0.1" />
+    <PackageReference Include="System.Threading.Channels" Version="6.0.0" />
+    <PackageReference Include="System.Security.Principal.Windows" Version="5.0.0" />
+  </ItemGroup>
+
+</Project>

--- a/src/Tmds.DBus.Protocol/TypeModel.cs
+++ b/src/Tmds.DBus.Protocol/TypeModel.cs
@@ -1,0 +1,315 @@
+namespace Tmds.DBus.Protocol;
+
+static class TypeModel
+{
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static DBusType GetTypeAlignment<T>()
+    {
+        // TODO: add caching.
+        if (typeof(T) == typeof(object))
+        {
+            return DBusType.Variant;
+        }
+        else if (typeof(T) == typeof(byte))
+        {
+            return DBusType.Byte;
+        }
+        else if (typeof(T) == typeof(bool))
+        {
+            return DBusType.Bool;
+        }
+        else if (typeof(T) == typeof(Int16))
+        {
+            return DBusType.Int16;
+        }
+        else if (typeof(T) == typeof(UInt16))
+        {
+            return DBusType.UInt16;
+        }
+        else if (typeof(T) == typeof(Int32))
+        {
+            return DBusType.Int32;
+        }
+        else if (typeof(T) == typeof(UInt32))
+        {
+            return DBusType.UInt32;
+        }
+        else if (typeof(T) == typeof(Int64))
+        {
+            return DBusType.Int64;
+        }
+        else if (typeof(T) == typeof(UInt64))
+        {
+            return DBusType.UInt64;
+        }
+        else if (typeof(T) == typeof(Double))
+        {
+            return DBusType.Double;
+        }
+        else if (typeof(T) == typeof(string))
+        {
+            return DBusType.String;
+        }
+        else if (typeof(T) == typeof(ObjectPath))
+        {
+            return DBusType.ObjectPath;
+        }
+        else if (typeof(T) == typeof(Signature))
+        {
+            return DBusType.Signature;
+        }
+        else if (typeof(T).IsArray)
+        {
+            return DBusType.Array;
+        }
+        else if (ExtractGenericInterface(typeof(T), typeof(System.Collections.Generic.IEnumerable<>)) != null)
+        {
+            return DBusType.Array;
+        }
+        else if (typeof(T).IsAssignableTo(typeof(SafeHandle)))
+        {
+            return DBusType.UnixFd;
+        }
+        return DBusType.Struct;
+    }
+
+    public static Type? ExtractGenericInterface(Type queryType, Type interfaceType)
+    {
+        if (IsGenericInstantiation(queryType, interfaceType))
+        {
+            return queryType;
+        }
+
+        return GetGenericInstantiation(queryType, interfaceType);
+    }
+
+    public static Type DetermineVariantType(Utf8Span signature)
+    {
+        // TODO: add caching.
+        switch ((DBusType)signature.Span[0])
+        {
+            case DBusType.Byte:
+                return typeof(byte);
+            case DBusType.Bool:
+                return typeof(bool);
+            case DBusType.Int16:
+                return typeof(Int16);
+            case DBusType.UInt16:
+                return typeof(UInt16);
+            case DBusType.Int32:
+                return typeof(Int32);
+            case DBusType.UInt32:
+                return typeof(UInt32);
+            case DBusType.Int64:
+                return typeof(Int64);
+            case DBusType.UInt64:
+                return typeof(UInt64);
+            case DBusType.Double:
+                return typeof(double);
+            case DBusType.String:
+                return typeof(string);
+            case DBusType.ObjectPath:
+                return typeof(string);
+            case DBusType.Signature:
+                return typeof(string);
+            case DBusType.UnixFd:
+                return typeof(SafeHandle);
+
+            case DBusType.Array:
+                if ((DBusType)signature.Span[1] == DBusType.DictEntry)
+                {
+                    Type keyType = DetermineVariantType(signature.Span.Slice(2));
+                    Type valueType = DetermineVariantType(signature.Span.Slice(3));
+                    return typeof(Dictionary<,>).MakeGenericType(new[] { keyType, valueType });
+                }
+                return DetermineVariantType(signature.Span.Slice(1)).MakeArrayType();
+
+            case DBusType.Struct:
+                ReadOnlySpan<byte> structTypeSignatures = signature.Span.Slice(1, signature.Span.Length - 2);
+                int typeCount = SignatureReader.CountTypes(structTypeSignatures);
+                SignatureReader reader = new(structTypeSignatures);
+                Type[] types = new Type[typeCount];
+                for (int i = 0; i < typeCount; i++)
+                {
+                    types[i] = DetermineVariantType(SignatureReader.ReadSingleType(ref structTypeSignatures));
+                }
+                switch (typeCount)
+                {
+                    case 1:
+                        return typeof(ValueTuple<>).MakeGenericType(types);
+                    case 2:
+                        return typeof(ValueTuple<,>).MakeGenericType(types);
+                    case 3:
+                        return typeof(ValueTuple<,,>).MakeGenericType(types);
+                    case 4:
+                        return typeof(ValueTuple<,,,>).MakeGenericType(types);
+                    case 5:
+                        return typeof(ValueTuple<,,,,>).MakeGenericType(types);
+                }
+                break;
+        }
+        return typeof(object);
+    }
+
+    private static bool IsGenericInstantiation(Type candidate, Type interfaceType)
+    {
+        return
+            candidate.IsGenericType &&
+            candidate.GetGenericTypeDefinition() == interfaceType;
+    }
+
+    private static Type? GetGenericInstantiation(Type queryType, Type interfaceType)
+    {
+        Type? bestMatch = null;
+        var interfaces = queryType.GetInterfaces();
+        foreach (var @interface in interfaces)
+        {
+            if (IsGenericInstantiation(@interface, interfaceType))
+            {
+                if (bestMatch == null)
+                {
+                    bestMatch = @interface;
+                }
+                else if (StringComparer.Ordinal.Compare(@interface.FullName, bestMatch.FullName) < 0)
+                {
+                    bestMatch = @interface;
+                }
+            }
+        }
+
+        if (bestMatch != null)
+        {
+            return bestMatch;
+        }
+
+        var baseType = queryType?.BaseType;
+        if (baseType == null)
+        {
+            return null;
+        }
+        else
+        {
+            return GetGenericInstantiation(baseType, interfaceType);
+        }
+    }
+
+    private static int AppendTypeSignature(Type type, Span<byte> signature)
+    {
+        Type? extractedType;
+        if (type == typeof(object))
+        {
+            signature[0] = (byte)DBusType.Variant;
+            return 1;
+        }
+        else if (type == typeof(byte))
+        {
+            signature[0] = (byte)DBusType.Byte;
+            return 1;
+        }
+        else if (type == typeof(bool))
+        {
+            signature[0] = (byte)DBusType.Bool;
+            return 1;
+        }
+        else if (type == typeof(Int16))
+        {
+            signature[0] = (byte)DBusType.Int16;
+            return 1;
+        }
+        else if (type == typeof(UInt16))
+        {
+            signature[0] = (byte)DBusType.UInt16;
+            return 1;
+        }
+        else if (type == typeof(Int32))
+        {
+            signature[0] = (byte)DBusType.Int32;
+            return 1;
+        }
+        else if (type == typeof(UInt32))
+        {
+            signature[0] = (byte)DBusType.UInt32;
+            return 1;
+        }
+        else if (type == typeof(Int64))
+        {
+            signature[0] = (byte)DBusType.Int64;
+            return 1;
+        }
+        else if (type == typeof(UInt64))
+        {
+            signature[0] = (byte)DBusType.UInt64;
+            return 1;
+        }
+        else if (type == typeof(Double))
+        {
+            signature[0] = (byte)DBusType.Double;
+            return 1;
+        }
+        else if (type == typeof(string))
+        {
+            signature[0] = (byte)DBusType.String;
+            return 1;
+        }
+        else if (type == typeof(ObjectPath))
+        {
+            signature[0] = (byte)DBusType.ObjectPath;
+            return 1;
+        }
+        else if (type == typeof(Signature))
+        {
+            signature[0] = (byte)DBusType.Signature;
+            return 1;
+        }
+        else if (type.IsArray)
+        {
+            int bytesWritten = 0;
+            signature[bytesWritten++] = (byte)DBusType.Array;
+            bytesWritten += AppendTypeSignature(type.GetElementType()!, signature.Slice(bytesWritten));
+            return bytesWritten;
+        }
+        else if (type.FullName!.StartsWith("System.ValueTuple"))
+        {
+            int bytesWritten = 0;
+            signature[bytesWritten++] = (byte)'(';
+            foreach (var itemType in type.GenericTypeArguments)
+            {
+                bytesWritten += AppendTypeSignature(itemType, signature.Slice(bytesWritten));
+            }
+            signature[bytesWritten++] = (byte)')';
+            return bytesWritten;
+        }
+        else if ((extractedType = TypeModel.ExtractGenericInterface(type, typeof(IDictionary<,>))) != null)
+        {
+            int bytesWritten = 0;
+            signature[bytesWritten++] = (byte)'a';
+            signature[bytesWritten++] = (byte)'{';
+            bytesWritten += AppendTypeSignature(extractedType.GenericTypeArguments[0], signature.Slice(bytesWritten));
+            bytesWritten += AppendTypeSignature(extractedType.GenericTypeArguments[1], signature.Slice(bytesWritten));
+            signature[bytesWritten++] = (byte)'}';
+            return bytesWritten;
+        }
+        else if (type.IsAssignableTo(typeof(SafeHandle)))
+        {
+            signature[0] = (byte)DBusType.UnixFd;
+            return 1;
+        }
+        return 0;
+    }
+
+    public static ReadOnlySpan<byte> GetSignature<T>() => SignatureCache<T>.Signature;
+
+    static class SignatureCache<T>
+    {
+        private static readonly byte[] s_signature = GetSignature(typeof(T));
+
+        public static ReadOnlySpan<byte> Signature => s_signature;
+
+        private static byte[] GetSignature(Type type)
+        {
+            Span<byte> buffer = stackalloc byte[256];
+            int bytesWritten = TypeModel.AppendTypeSignature(type, buffer);
+            return buffer.Slice(0, bytesWritten).ToArray();
+        }
+    }
+}

--- a/src/Tmds.DBus.Protocol/UnixFdCollection.cs
+++ b/src/Tmds.DBus.Protocol/UnixFdCollection.cs
@@ -1,0 +1,31 @@
+namespace Tmds.DBus.Protocol;
+
+sealed class UnixFdCollection : List<(IntPtr, bool)>, IDisposable
+{
+    public void Dispose()
+    {
+        DisposeHandles(Count);
+        GC.SuppressFinalize(this);
+    }
+
+    ~UnixFdCollection()
+    {
+        DisposeHandles(Count);
+    }
+
+    public void DisposeHandles(int count)
+    {
+        for (int i = 0; i < count; i++)
+        {
+            (IntPtr handle, bool dispose) = this[i];
+            if (dispose)
+            {
+                close(handle.ToInt32());
+            }
+        }
+        RemoveRange(0, count);
+    }
+
+    [DllImport("libc")]
+    private static extern void close(int fd);
+}

--- a/src/Tmds.DBus.Protocol/Utf8Span.cs
+++ b/src/Tmds.DBus.Protocol/Utf8Span.cs
@@ -1,0 +1,20 @@
+namespace Tmds.DBus.Protocol;
+
+public ref struct Utf8Span
+{
+    private ReadOnlySpan<byte> _buffer;
+
+    public ReadOnlySpan<byte> Span => _buffer;
+
+    public bool IsEmpty => _buffer.IsEmpty;
+
+    public Utf8Span(ReadOnlySpan<byte> value) => _buffer = value;
+
+    public static implicit operator Utf8Span(ReadOnlySpan<byte> value) => new Utf8Span(value);
+
+    public static implicit operator Utf8Span(Span<byte> value) => new Utf8Span(value);
+
+    public static implicit operator ReadOnlySpan<byte>(Utf8Span value) => value._buffer;
+
+    public override string ToString() => Encoding.UTF8.GetString(_buffer);
+}

--- a/src/Tmds.DBus.Tool/Tmds.DBus.Tool.csproj
+++ b/src/Tmds.DBus.Tool/Tmds.DBus.Tool.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>dotnet-dbus</ToolCommandName>
     <AssemblyName>dotnet-dbus</AssemblyName>

--- a/src/Tmds.DBus.Tool/Tmds.DBus.Tool.csproj
+++ b/src/Tmds.DBus.Tool/Tmds.DBus.Tool.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>dotnet-dbus</ToolCommandName>
     <AssemblyName>dotnet-dbus</AssemblyName>

--- a/test/Tmds.DBus.Tests/Tmds.DBus.Tests.csproj
+++ b/test/Tmds.DBus.Tests/Tmds.DBus.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\sign.snk</AssemblyOriginatorKeyFile>
     <PublicSign>true</PublicSign>


### PR DESCRIPTION
It's worth noting that .NET 6.0 will complain about the age of netcoreapp2.1 when building;

`/opt/dotnet-sdk-bin-6.0/sdk/6.0.101/Sdks/Microsoft.NET.Sdk/targets/Microsoft.NET.EolTargetFrameworks.targets(28,5): warning NETSDK1138: The target framework 'netcoreapp2.1' is out of support and will not receive security updates in the future. Please refer to https://aka.ms/dotnet-core-support for more information about the support policy. [/home/ace/Projects/dotNet/Tmds.DBus/src/Tmds.DBus.Tool/Tmds.DBus.Tool.csproj]`