### PR TITLE
Support net7.0

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,5 +1,5 @@
 name: Build
-on: [push, pull_request ]
+on: [push, pull_request]
 jobs:
   build:
     runs-on: ubuntu-20.04
@@ -9,48 +9,47 @@ jobs:
       DOTNET_CLI_TELEMETRY_OPTOUT: 1
 
     steps:
-    - name: Install .NET
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: '6.0.x'
+      - name: Install .NET
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: "7.0.x"
 
-    - name: Install reportgenerator tool
-      run: dotnet tool install --global dotnet-reportgenerator-globaltool
+      - name: Install reportgenerator tool
+        run: dotnet tool install --global dotnet-reportgenerator-globaltool
 
-    - name: Fetch sources
-      uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
+      - name: Fetch sources
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
-    - name: Run tests
-      run: |
-        pushd test/Tmds.DBus.Tests && dotnet test && popd
-        pushd test/Tmds.DBus.Protocol.Tests && dotnet test --collect:"XPlat Code Coverage" && popd
+      - name: Run tests
+        run: |
+          pushd test/Tmds.DBus.Tests && dotnet test && popd
+          pushd test/Tmds.DBus.Protocol.Tests && dotnet test --collect:"XPlat Code Coverage" && popd
 
-    - name: Build tool
-      run: |
-        pushd src/Tmds.DBus.Tool && dotnet build && popd
+      - name: Build tool
+        run: |
+          pushd src/Tmds.DBus.Tool && dotnet build && popd
 
-    - name: Build packages
-      run: |
-        VERSION_SUFFIX="${{ github.run_number }}-${{ github.sha }}"
-        dotnet pack src/Tmds.DBus --configuration Release --output src/Tmds.DBus /p:VersionSuffix="$VERSION_SUFFIX" 
-        dotnet pack src/Tmds.DBus.Protocol --configuration Release --output src/Tmds.DBus.Protocol /p:VersionSuffix="$VERSION_SUFFIX" 
-        dotnet pack src/Tmds.DBus.Tool --configuration Release --output src/Tmds.DBus.Tool /p:VersionSuffix="$VERSION_SUFFIX" 
+      - name: Build packages
+        run: |
+          VERSION_SUFFIX="${{ github.run_number }}-${{ github.sha }}"
+          dotnet pack src/Tmds.DBus --configuration Release --output src/Tmds.DBus /p:VersionSuffix="$VERSION_SUFFIX" 
+          dotnet pack src/Tmds.DBus.Protocol --configuration Release --output src/Tmds.DBus.Protocol /p:VersionSuffix="$VERSION_SUFFIX" 
+          dotnet pack src/Tmds.DBus.Tool --configuration Release --output src/Tmds.DBus.Tool /p:VersionSuffix="$VERSION_SUFFIX"
 
-    - name: Publish packages
-      run: |
-        dotnet nuget push -s https://www.myget.org/F/tmds/api/v2/package -k "${{ secrets.NUGET_APIKEY }}" src/Tmds.DBus/*.nupkg
-        dotnet nuget push -s https://www.myget.org/F/tmds/api/v2/package -k "${{ secrets.NUGET_APIKEY }}" src/Tmds.DBus.Protocol/*.nupkg
-        dotnet nuget push -s https://www.myget.org/F/tmds/api/v2/package -k "${{ secrets.NUGET_APIKEY }}" src/Tmds.DBus.Tool/*.nupkg
-      if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+      - name: Publish packages
+        run: |
+          dotnet nuget push -s https://www.myget.org/F/tmds/api/v2/package -k "${{ secrets.NUGET_APIKEY }}" src/Tmds.DBus/*.nupkg
+          dotnet nuget push -s https://www.myget.org/F/tmds/api/v2/package -k "${{ secrets.NUGET_APIKEY }}" src/Tmds.DBus.Protocol/*.nupkg
+          dotnet nuget push -s https://www.myget.org/F/tmds/api/v2/package -k "${{ secrets.NUGET_APIKEY }}" src/Tmds.DBus.Tool/*.nupkg
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
 
-    - name: Generate coverage report
-      run: ~/.dotnet/tools/reportgenerator -reports:test/Tmds.DBus.Protocol.Tests/TestResults/*/coverage.cobertura.xml -targetdir:coverage-reports
+      - name: Generate coverage report
+        run: ~/.dotnet/tools/reportgenerator -reports:test/Tmds.DBus.Protocol.Tests/TestResults/*/coverage.cobertura.xml -targetdir:coverage-reports
 
-    - name: Upload coverage reports to artifacts
-      uses: actions/upload-artifact@v2
-      with:
-        name: coverage-reports
-        path: coverage-reports
-
+      - name: Upload coverage reports to artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: coverage-reports
+          path: coverage-reports

--- a/src/Tmds.DBus.Tool/Tmds.DBus.Tool.csproj
+++ b/src/Tmds.DBus.Tool/Tmds.DBus.Tool.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net6.0;net7.0</TargetFrameworks>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>dotnet-dbus</ToolCommandName>
     <AssemblyName>dotnet-dbus</AssemblyName>

--- a/src/Tmds.DBus.Tool/Tmds.DBus.Tool.csproj
+++ b/src/Tmds.DBus.Tool/Tmds.DBus.Tool.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp3.1;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>dotnet-dbus</ToolCommandName>
     <AssemblyName>dotnet-dbus</AssemblyName>

--- a/test/Tmds.DBus.Protocol.Tests/Tmds.DBus.Protocol.Tests.csproj
+++ b/test/Tmds.DBus.Protocol.Tests/Tmds.DBus.Protocol.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <Nullable>enable</Nullable>
 
     <IsPackable>false</IsPackable>

--- a/test/Tmds.DBus.Tests/Tmds.DBus.Tests.csproj
+++ b/test/Tmds.DBus.Tests/Tmds.DBus.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\sign.snk</AssemblyOriginatorKeyFile>
     <PublicSign>true</PublicSign>


### PR DESCRIPTION
This PR adds net7.0 to the TargetTrameworks of Tmds.Dbus.Tool to fix https://github.com/tmds/Tmds.DBus/issues/176

It also updates the GitHub Workflow and the tests projects.