### PR TITLE
Fix sending multiple segment messages

### DIFF
--- a/src/Tmds.DBus.Protocol/MessageStream.cs
+++ b/src/Tmds.DBus.Protocol/MessageStream.cs
@@ -94,7 +94,7 @@ class MessageStream : IMessageStream
                     SequencePosition position = buffer.Start;
                     while (buffer.TryGet(ref position, out ReadOnlyMemory<byte> memory))
                     {
-                        await _socket.SendAsync(buffer.First, handles).ConfigureAwait(false);
+                        await _socket.SendAsync(memory, handles).ConfigureAwait(false);
                         handles = null;
                     }
                 }

--- a/src/Tmds.DBus.Protocol/SignatureReader.cs
+++ b/src/Tmds.DBus.Protocol/SignatureReader.cs
@@ -1,8 +1,6 @@
-[assembly: InternalsVisibleTo("dotnet-dbus, PublicKey=002400000480000094000000060200000024000052534131000400000100010071a8770f460cce31df0feb6f94b328aebd55bffeb5c69504593df097fdd9b29586dbd155419031834411c8919516cc565dee6b813c033676218496edcbe7939c0dd1f919f3d1a228ebe83b05a3bbdbae53ce11bcf4c04a42d8df1a83c2d06cb4ebb0b447e3963f48a1ca968996f3f0db8ab0e840a89d0a5d5a237e2f09189ed3")]
-
 namespace Tmds.DBus.Protocol;
 
-internal ref struct SignatureReader
+public ref struct SignatureReader
 {
     private ReadOnlySpan<byte> _signature;
 

--- a/src/Tmds.DBus.Protocol/SignatureReader.cs
+++ b/src/Tmds.DBus.Protocol/SignatureReader.cs
@@ -1,6 +1,8 @@
+[assembly: InternalsVisibleTo("dotnet-dbus, PublicKey=002400000480000094000000060200000024000052534131000400000100010071a8770f460cce31df0feb6f94b328aebd55bffeb5c69504593df097fdd9b29586dbd155419031834411c8919516cc565dee6b813c033676218496edcbe7939c0dd1f919f3d1a228ebe83b05a3bbdbae53ce11bcf4c04a42d8df1a83c2d06cb4ebb0b447e3963f48a1ca968996f3f0db8ab0e840a89d0a5d5a237e2f09189ed3")]
+
 namespace Tmds.DBus.Protocol;
 
-public ref struct SignatureReader
+internal ref struct SignatureReader
 {
     private ReadOnlySpan<byte> _signature;
 


### PR DESCRIPTION
When sending non-single-segmented buffers, only the first segment was incorrectly sent over and over again.