### PR TITLE
add .NET 6.0 target

### DIFF
--- a/src/Tmds.DBus/Address.cs
+++ b/src/Tmds.DBus/Address.cs
@@ -6,6 +6,9 @@
 using System;
 using System.IO.MemoryMappedFiles;
 using System.Runtime.InteropServices;
+#if NET6_0_OR_GREATER
+using System.Runtime.Versioning;
+#endif
 
 namespace Tmds.DBus
 {
@@ -141,6 +144,9 @@ namespace Tmds.DBus
             }
         }
 
+#if NET6_0_OR_GREATER
+        [SupportedOSPlatform("Windows")]
+#endif
         private static string GetSessionBusAddressFromSharedMemory()
         {
             string result = ReadSharedMemoryString("DBusDaemonAddressInfo", 255);
@@ -149,6 +155,9 @@ namespace Tmds.DBus
             return result;
         }
 
+#if NET6_0_OR_GREATER
+        [SupportedOSPlatform("Windows")]
+#endif
         private static string ReadSharedMemoryString(string id, long maxlen = -1)
         {
             MemoryMappedFile shmem;

--- a/src/Tmds.DBus/Environment.cs
+++ b/src/Tmds.DBus/Environment.cs
@@ -6,6 +6,9 @@
 using System;
 using System.IO;
 using System.Runtime.InteropServices;
+#if NET6_0_OR_GREATER
+using System.Runtime.Versioning;
+#endif
 using Tmds.DBus.Protocol;
 
 namespace Tmds.DBus
@@ -15,6 +18,10 @@ namespace Tmds.DBus
         private const string MachineUuidPath = @"/var/lib/dbus/machine-id";
 
         public static readonly EndianFlag NativeEndianness;
+
+#if NET6_0_OR_GREATER
+        [SupportedOSPlatformGuard("Windows")]
+#endif
         public static readonly bool IsWindows;
 
         static Environment()

--- a/src/Tmds.DBus/Tmds.DBus.csproj
+++ b/src/Tmds.DBus/Tmds.DBus.csproj
@@ -4,7 +4,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Tmds.DBus Library</Description>
     <Authors>Tom Deseyn</Authors>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <PackageTags>dbus</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
@@ -13,7 +13,7 @@
     <AssemblyOriginatorKeyFile>..\..\sign.snk</AssemblyOriginatorKeyFile>
     <PublicSign>true</PublicSign>
   </PropertyGroup>
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETStandard'">
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
     <PackageReference Include="System.Reflection.Emit" Version="4.7.0" />
     <PackageReference Include="System.Security.Principal.Windows" Version="4.7.0" />


### PR DESCRIPTION
This removes the need for the package references when using .NET 6.0 or newer target frameworks.