### PR TITLE
Tmds.DBus: MessageReader: while reading '[Dictionary]' also consider camel-case fields.

### DIFF
--- a/src/Tmds.DBus.Tool/Generator.cs
+++ b/src/Tmds.DBus.Tool/Generator.cs
@@ -217,8 +217,8 @@ namespace Tmds.DBus.Tool
         private SyntaxNode[] PropertyToDeclarations(XElement propertyXml)
         {
             string name = propertyXml.Attribute("name").Value;
-            var fieldName = $"_{name.Replace('-', '_')}";
-            fieldName = CamelCase(fieldName);
+            var fieldName = name.Replace('-', '_');
+            fieldName = $"_{char.ToLowerInvariant(fieldName[0])}{fieldName.Substring(1)}";
             string dbusType = propertyXml.Attribute("type").Value;
             SyntaxNode type = ParseType(dbusType);
             var field = _generator.FieldDeclaration(fieldName, type, Accessibility.Private, DeclarationModifiers.None, _generator.DefaultExpression(type));
@@ -402,27 +402,6 @@ namespace Tmds.DBus.Tool
             }
 
             return token;
-        }
-
-        private static string CamelCase(string name)
-        {
-            var sb = new StringBuilder(name.Length);
-            var done = false;
-
-            foreach (char c in name)
-            {
-                if (c == '_' || done)
-                {
-                    sb.Append(c);
-                }
-                else
-                {
-                    sb.Append(char.ToLower(c));
-                    done = true;
-                }
-            }
-
-            return sb.ToString();
         }
 
         public static string Prettify(string name, bool startWithUpper = true)

--- a/test/Tmds.DBus.Tests/ReaderTests.cs
+++ b/test/Tmds.DBus.Tests/ReaderTests.cs
@@ -279,8 +279,8 @@ namespace Tmds.DBus.Tests
         [Dictionary]
         public class PersonProperties
         {
-            public string Name;
-            public int? Age;
+            public string _Name; // The serialized key is 'Name'. It field may be prefixed with an underscore.
+            public int? _age;    // The serialized key is 'Age'. It field may be prefixed with an underscore, and the first letter a lower case.
             public Gender? Gender;
             public bool IsMarried;
             public override bool Equals(object rhs)
@@ -290,13 +290,13 @@ namespace Tmds.DBus.Tests
                 {
                     return false;
                 }
-                return (Name == other.Name) &&
-                       (Age == other.Age) &&
+                return (_Name == other._Name) &&
+                       (_age == other._age) &&
                        (Gender == other.Gender);
             }
             public override int GetHashCode()
             {
-                return Name?.GetHashCode() ?? 0;
+                return _Name?.GetHashCode() ?? 0;
             }
         }
 
@@ -361,14 +361,14 @@ namespace Tmds.DBus.Tests
                 var myArray = myDictionary.ToArray();
                 var john = new PersonProperties()
                 {
-                    Name = "John",
-                    Age = 32,
+                    _Name = "John",
+                    _age = 32,
                     Gender = Gender.Male,
                     IsMarried = true
                 };
                 var john2 = new PersonProperties2()
                 {
-                    Name = john.Name,
+                    Name = john._Name,
                     City = null
                 };
                 return new []


### PR DESCRIPTION
Fixes https://github.com/tmds/Tmds.DBus/issues/190.

This was missing since we've updated the Tool in 0.12.0 to generate camel-case fields in https://github.com/tmds/Tmds.DBus/pull/171.

cc @Echoseven2020