### PR TITLE
[Tmds.DBus.Protocol] Don't respond on any method_call

### DIFF
--- a/src/Tmds.DBus.Protocol/DBusConnection.cs
+++ b/src/Tmds.DBus.Protocol/DBusConnection.cs
@@ -348,10 +348,6 @@ class DBusConnection : IDisposable
                             RunMethodHandler(methodHandler, context);
                         }
                     }
-                    else
-                    {
-                        SendUnknownMethodErrorIfNoReplySent(context);
-                    }
                 }
 
                 if (returnMessageToPool)
@@ -1144,3 +1140,4 @@ class DBusConnection : IDisposable
         }
     }
 }
+


### PR DESCRIPTION
Mostly for a use case of working as a monitor after calling [BecomeMonitor](https://dbus.freedesktop.org/doc/dbus-specification.html#bus-messages-become-monitor).

Responding for these messages as a monitor isn't allowed and causes the dbus service to disconnect us