### PR TITLE
Implement introspection support

### DIFF
--- a/src/Tmds.DBus.Protocol/IntrospectionWriter.cs
+++ b/src/Tmds.DBus.Protocol/IntrospectionWriter.cs
@@ -1,0 +1,69 @@
+namespace Tmds.DBus.Protocol
+{
+    internal class IntrospectionWriter
+    {
+        private readonly StringBuilder _sb = new();
+
+        public void WriteDocType()
+        {
+            _sb.Append("<!DOCTYPE node PUBLIC \"-//freedesktop//DTD D-BUS Object Introspection 1.0//EN\"\n");
+            _sb.Append("\"http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd\">\n");
+        }
+
+        public void WriteIntrospectableInterface()
+        {
+            WriteInterfaceStart("org.freedesktop.DBus.Introspectable");
+
+            WriteMethodStart("Introspect");
+            WriteOutArg("data", new Signature("s"));
+            WriteMethodEnd();
+
+            WriteInterfaceEnd();
+        }
+
+        public void WriteInterfaceStart(string name)
+        {
+            _sb.AppendFormat("  <interface name=\"{0}\">\n", name);
+        }
+
+        public void WriteInterfaceEnd()
+        {
+            _sb.Append("  </interface>\n");
+        }
+
+        public void WriteMethodStart(string name)
+        {
+            _sb.AppendFormat("    <method name=\"{0}\">\n", name);
+        }
+
+        public void WriteMethodEnd()
+        {
+            _sb.Append("    </method>\n");
+        }
+
+        public void WriteOutArg(string name, Signature signature)
+        {
+            _sb.AppendFormat("      <arg direction=\"out\" name=\"{0}\" type=\"{1}\"/>\n", name, signature);
+        }
+
+        public void WriteNodeStart(string name)
+        {
+            _sb.AppendFormat("<node name=\"{0}\">\n", name);
+        }
+
+        public void WriteNodeEnd()
+        {
+            _sb.Append("</node>\n");
+        }
+
+        public void WriteChildNode(string name)
+        {
+            _sb.AppendFormat("  <node name=\"{0}\"/>\n", name);
+        }
+
+        public override string ToString()
+        {
+            return _sb.ToString();
+        }
+    }
+}


### PR DESCRIPTION
Currently, introspection is only available directly on the handler objects (using Tmds.DBus.SourceGenerator) which is used by e.g. dbus-python.
With this patch ported from the old Tmds.DBus library, in combination with the source generator introspection works completely, for example with qdbusviewer or similar tools.
See https://github.com/affederaffe/Tmds.DBus.SourceGenerator/issues/7