### PR TITLE
Don't throw ObjectDisposedException when disposing Observer for the first time

### DIFF
--- a/src/Tmds.DBus.Protocol/DBusConnection.cs
+++ b/src/Tmds.DBus.Protocol/DBusConnection.cs
@@ -857,7 +857,7 @@ class DBusConnection : IDisposable
             Subscribes = subscribes;
         }
 
-        public void Dispose() => Dispose(s_objectDisposedException);
+        public void Dispose() => Dispose(null);
 
         public void Dispose(Exception? exception, bool removeObserver = true)
         {
@@ -865,8 +865,10 @@ class DBusConnection : IDisposable
             {
                 if (_disposed)
                 {
+                    Emit(s_objectDisposedException);
                     return;
                 }
+
                 _disposed = true;
             }
 
@@ -930,6 +932,7 @@ class DBusConnection : IDisposable
             {
                 if (_disposed)
                 {
+                    Emit(s_objectDisposedException);
                     return;
                 }
 

--- a/src/Tmds.DBus.Protocol/DBusConnection.cs
+++ b/src/Tmds.DBus.Protocol/DBusConnection.cs
@@ -865,7 +865,6 @@ class DBusConnection : IDisposable
             {
                 if (_disposed)
                 {
-                    Emit(s_objectDisposedException);
                     return;
                 }
 
@@ -897,8 +896,7 @@ class DBusConnection : IDisposable
 
         private void Emit(Exception exception)
         {
-            if (_synchronizationContext is null ||
-                SynchronizationContext.Current == _synchronizationContext)
+            if (_synchronizationContext is null || SynchronizationContext.Current == _synchronizationContext)
             {
                 _messageHandler.Invoke(exception, null!);
             }


### PR DESCRIPTION
When disposing Observers, an ObjectDisposedException was thrown event though it was the first time disposing said observer. This PR fixes the  behavior to only throw an exception when trying to dispose multiple times.