### PR TITLE
Tool: use Protocol only.

### DIFF
--- a/src/Tmds.DBus.Protocol/Connection.DBus.cs
+++ b/src/Tmds.DBus.Protocol/Connection.DBus.cs
@@ -23,6 +23,21 @@ public partial class Connection
         }
     }
 
+    public Task<string[]> ListActivatableServicesAsync()
+    {
+        return CallMethodAsync(CreateMessage(), (Message m, object? s) => m.GetBodyReader().ReadArray<string>());
+        MessageBuffer CreateMessage()
+        {
+            using var writer = GetMessageWriter();
+            writer.WriteMethodCallHeader(
+                destination: DBusServiceName,
+                path: DBusObjectPath,
+                @interface: DBusInterface,
+                member: "ListActivatableNames");
+            return writer.CreateMessage();
+        }
+    }
+
     public async Task BecomeMonitorAsync(Action<Exception?, DisposableMessage> handler, IEnumerable<MatchRule>? rules = null)
     {
         if (_connectionOptions.IsShared)

--- a/src/Tmds.DBus.Tool/CodeGenCommand.cs
+++ b/src/Tmds.DBus.Tool/CodeGenCommand.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using System.Xml.Linq;
 using Microsoft.Extensions.CommandLineUtils;
 using Microsoft.CodeAnalysis;
+using Tmds.DBus.Protocol;
 
 namespace Tmds.DBus.Tool
 {

--- a/src/Tmds.DBus.Tool/Command.cs
+++ b/src/Tmds.DBus.Tool/Command.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.CommandLineUtils;
+using Tmds.DBus.Protocol;
 
 namespace Tmds.DBus.Tool
 {

--- a/src/Tmds.DBus.Tool/ListCommand.cs
+++ b/src/Tmds.DBus.Tool/ListCommand.cs
@@ -1,10 +1,10 @@
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Xml.Linq;
 using Microsoft.Extensions.CommandLineUtils;
+using Tmds.DBus.Protocol;
 
 namespace Tmds.DBus.Tool
 {

--- a/src/Tmds.DBus.Tool/Tmds.DBus.Tool.csproj
+++ b/src/Tmds.DBus.Tool/Tmds.DBus.Tool.csproj
@@ -22,7 +22,6 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" />
     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" />
     <PackageReference Include="Microsoft.Extensions.CommandLineUtils" />
-    <ProjectReference Include="../Tmds.DBus/Tmds.DBus.csproj" />
     <ProjectReference Include="../Tmds.DBus.Protocol/Tmds.DBus.Protocol.csproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This eliminates the 'Tmds.DBus' dependency and uses 'Tmds.DBus.Protocol' for all D-Bus operations.