### PR TITLE
Protocol: write byte as byte.

### DIFF
--- a/src/Tmds.DBus.Protocol/MessageWriter.Basic.cs
+++ b/src/Tmds.DBus.Protocol/MessageWriter.Basic.cs
@@ -4,7 +4,7 @@ public ref partial struct MessageWriter
 {
     public void WriteBool(bool value) => WriteUInt32(value ? 1u : 0u);
 
-    public void WriteByte(byte value) => WritePrimitiveCore<short>(value, DBusType.Byte);
+    public void WriteByte(byte value) => WritePrimitiveCore<byte>(value, DBusType.Byte);
 
     public void WriteInt16(short value) => WritePrimitiveCore<Int16>(value, DBusType.Int16);
 


### PR DESCRIPTION
Bytes were erroneously written as a short.

On little endian systems this error is masked because the first byte of the short matches the byte that is written.