### PR TITLE
SignalHandlerRegistration/WrappedDisposable: avoid Dispose deadlock.

### DIFF
--- a/src/Tmds.DBus/WrappedDisposable.cs
+++ b/src/Tmds.DBus/WrappedDisposable.cs
@@ -91,17 +91,20 @@ namespace Tmds.DBus
 
         public void Dispose()
         {
+            IDisposable disposable;
             lock (_gate)
             {
                 _disposed = true;
-                _disposable?.Dispose();
+                disposable = _disposable;
             }
+            _disposable?.Dispose();
         }
 
         public IDisposable Disposable
         {
             set
             {
+                bool dispose = false;
                 lock (_gate)
                 {
                     if (_disposable != null)
@@ -109,10 +112,11 @@ namespace Tmds.DBus
                         throw new InvalidOperationException("Already set");
                     }
                     _disposable = value;
-                    if (_disposed)
-                    {
-                        _disposable.Dispose();
-                    }
+                    dispose = _disposed;
+                }
+                if (dispose)
+                {
+                    value.Dispose();
                 }
             }
         }


### PR DESCRIPTION
Emitting signals takes the connection lock and then the WrappedDisposable lock.

On dispose, we'd take the locks in the opposite order: WrappedDisposable lock and then connection lock through the SignalHandlerRegistration.Dispose.

This changes WrappedDisposable so it no longer holds its lock while calling SignalHandlerRegistration.Dispose.

Fixes https://github.com/tmds/Tmds.DBus/issues/279.