### PR TITLE
Make Variant(double) public

### DIFF
--- a/src/Tmds.DBus.Protocol/Variant.cs
+++ b/src/Tmds.DBus.Protocol/Variant.cs
@@ -59,7 +59,7 @@ public readonly struct Variant
         _l = (long)value;
         _o = UInt64Type;
     }
-    internal unsafe Variant(double value)
+    public unsafe Variant(double value)
     {
         _l = *(long*)&value;
         _o = DoubleType;


### PR DESCRIPTION
Probably and oversight since every other constructor is also public.
Currently, the implicit operator is already public, so there is no functionality missing, it's just a matter of taste if one prefers explicit constructors or implicit conversions.