### PR TITLE
use correct element type for read/write dictionaries

### DIFF
--- a/src/Tmds.DBus.Protocol/MessageWriter.Dictionary.cs
+++ b/src/Tmds.DBus.Protocol/MessageWriter.Dictionary.cs
@@ -6,13 +6,13 @@ namespace Tmds.DBus.Protocol;
 public ref partial struct MessageWriter
 {
     public ArrayStart WriteDictionaryStart()
-        => WriteArrayStart(DBusType.Struct);
+        => WriteArrayStart(DBusType.DictEntry);
 
     public void WriteDictionaryEnd(ArrayStart start)
         => WriteArrayEnd(start);
 
     public void WriteDictionaryEntryStart()
-        => WriteStructureStart();
+        => WritePadding(DBusType.DictEntry);
 
     // Write method for the common 'a{sv}' type.
     [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026")] // It's safe to call WriteDictionary with these types.

--- a/src/Tmds.DBus.Protocol/Reader.Dictionary.cs
+++ b/src/Tmds.DBus.Protocol/Reader.Dictionary.cs
@@ -7,7 +7,7 @@ namespace Tmds.DBus.Protocol;
 public ref partial struct Reader
 {
     public ArrayEnd ReadDictionaryStart()
-        => ReadArrayStart(DBusType.Struct);
+        => ReadArrayStart(DBusType.DictEntry);
 
     // Read method for the common 'a{sv}' type.
     [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026")] // It's safe to call ReadDictionary with these types.


### PR DESCRIPTION
This is not a bug, but it is confusing to see `DBusType.Struct` as array element type for dictionaries.