### PR TITLE
VariantValue: track nested variants and signatures for empty arrays/dictionaries. [breaking]

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -2,7 +2,7 @@
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
   <PropertyGroup>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
-    <VersionPrefix>0.20.0</VersionPrefix>
+    <VersionPrefix>0.21.0</VersionPrefix>
     <DeterministicSourcePaths Condition="'$(Configuration)' == 'Release'">true</DeterministicSourcePaths>
   </PropertyGroup>
 </Project>

--- a/src/Tmds.DBus.Protocol/VariantValue.cs
+++ b/src/Tmds.DBus.Protocol/VariantValue.cs
@@ -2,85 +2,212 @@ namespace Tmds.DBus.Protocol;
 
 public readonly struct VariantValue : IEquatable<VariantValue>
 {
-    private static readonly object Int64Type = VariantValueType.Int64;
-    private static readonly object UInt64Type = VariantValueType.UInt64;
-    private static readonly object DoubleType = VariantValueType.Double;
     private readonly object? _o;
     private readonly long    _l;
 
-    private const int TypeShift = 8 * 7;
-    private const int ArrayItemTypeShift = 8 * 0;
-    private const int DictionaryKeyTypeShift = 8 * 0;
-    private const int DictionaryValueTypeShift = 8 * 1;
-    private const long StripTypeMask = ~(0xffL << TypeShift);
+    // The top four bytes are used as follows (highest to lowest):
+    // - Nesting as a byte.
+    // - Type as a VariantValueType
+    // - ArrayItemType/DictionaryKeyType as a VariantValueType
+    // - DictionaryValueTypeShift as a VariantValueType
+    // For Structs, the lowest of these 4 bytes are used to track if the corresponding field is a Variant.
+    private const int NestingShift = 8 * 7;
+    private const int TypeShift = 8 * 6;
+    private const int ArrayItemTypeShift = 8 * 5;
+    private const int DictionaryKeyTypeShift = 8 * 5;
+    private const int DictionaryValueTypeShift = 8 * 4;
+    private const long StripMetadataMask = 0xffffffffL;
+    private const long StructVariantMask = 0xffffL;
+    private const int StructVariantMaskShift = 8 * 4;
+    internal const int MaxStructFields = 2 * 8;
 
-    private const long ArrayOfByte = ((long)VariantValueType.Array << TypeShift) | ((long)VariantValueType.Byte << ArrayItemTypeShift);
-    private const long ArrayOfInt16 = ((long)VariantValueType.Array << TypeShift) | ((long)VariantValueType.Int16 << ArrayItemTypeShift);
-    private const long ArrayOfUInt16 = ((long)VariantValueType.Array << TypeShift) | ((long)VariantValueType.UInt16 << ArrayItemTypeShift);
-    private const long ArrayOfInt32 = ((long)VariantValueType.Array << TypeShift) | ((long)VariantValueType.Int32 << ArrayItemTypeShift);
-    private const long ArrayOfUInt32 = ((long)VariantValueType.Array << TypeShift) | ((long)VariantValueType.UInt32 << ArrayItemTypeShift);
-    private const long ArrayOfInt64 = ((long)VariantValueType.Array << TypeShift) | ((long)VariantValueType.Int64 << ArrayItemTypeShift);
-    private const long ArrayOfUInt64 = ((long)VariantValueType.Array << TypeShift) | ((long)VariantValueType.UInt64 << ArrayItemTypeShift);
-    private const long ArrayOfDouble = ((long)VariantValueType.Array << TypeShift) | ((long)VariantValueType.Double << ArrayItemTypeShift);
-    private const long ArrayOfString = ((long)VariantValueType.Array << TypeShift) | ((long)VariantValueType.String << ArrayItemTypeShift);
-    private const long ArrayOfObjectPath = ((long)VariantValueType.Array << TypeShift) | ((long)VariantValueType.ObjectPath << ArrayItemTypeShift);
+    private bool UnsafeIsStructFieldVariant(int index)
+        => (_l & (1L << (index + StructVariantMaskShift))) != 0;
+
+    private static long GetTypeMetadata(VariantValueType type, byte nesting)
+        => ((long)nesting << NestingShift) | ((long)type << TypeShift);
+
+    private static long GetStructMetadata(long variantMask, int count, byte nesting)
+        => GetTypeMetadata(VariantValueType.Struct, nesting) | (variantMask << StructVariantMaskShift) | (long)count;
+
+    private static long GetArrayTypeMetadata(VariantValueType itemType, int count, byte nesting)
+        => ((long)nesting << NestingShift) | ((long)VariantValueType.Array << TypeShift) | ((long)itemType << ArrayItemTypeShift) | ((long)count);
+
+    private static long GetDictionaryTypeMetadata(VariantValueType keyType, VariantValueType valueType, int count, byte nesting)
+        => ((long)nesting << NestingShift) | ((long)VariantValueType.Dictionary << TypeShift) | ((long)keyType << DictionaryKeyTypeShift) | ((long)valueType << DictionaryValueTypeShift) | ((long)count);
+
+    // For most types, we store the type information in the highest bytes of the long.
+    // Except for some types (Int64, UInt64, Double) for which we store the value allocation free
+    // in the long, and use the object field to store the type.
+    readonly struct TypeData
+    {
+        public TypeData(long l)
+        {
+            L = l;
+        }
+
+        public readonly long L { get; }
+    }
+    private const long Int64 = ((long)VariantValueType.Int64) << TypeShift;
+    private const long UInt64 = ((long)VariantValueType.UInt64) << TypeShift;
+    private const long Double = ((long)VariantValueType.Double) << TypeShift;
+    private const long VariantOfInt64 = (1L << NestingShift) | Int64;
+    private const long VariantOfUInt64 = (1L << NestingShift) | UInt64;
+    private const long VariantOfDouble = (1L << NestingShift) | Double;
+    private static readonly object Int64TypeDescriptor = new TypeData(Int64);
+    private static readonly object UInt64TypeDescriptor = new TypeData(UInt64);
+    private static readonly object DoubleTypeDescriptor = new TypeData(Double);
+    private static readonly object VariantOfInt64TypeDescriptor = new TypeData(VariantOfInt64);
+    private static readonly object VariantOfUInt64TypeDescriptor = new TypeData(VariantOfUInt64);
+    private static readonly object VariantOfDoubleTypeDescriptor = new TypeData(VariantOfDouble);
+
+    private static long UpdateNesting(long l, int change)
+    {
+        long nesting = l >> NestingShift;
+        Debug.Assert(nesting >= 0);
+        nesting = nesting + change;
+        Debug.Assert(nesting >= 0);
+        l = (nesting << NestingShift) | (l & ~(0xffL << NestingShift));
+        return l;
+    }
+
+    private static object UpdateNesting(TypeData metadata, int change)
+    {
+        long l = metadata.L;
+        l = UpdateNesting(l, change);
+        return l switch
+        {
+            Int64 => Int64TypeDescriptor,
+            UInt64 => UInt64TypeDescriptor,
+            Double => DoubleTypeDescriptor,
+            VariantOfInt64 => VariantOfInt64TypeDescriptor,
+            VariantOfUInt64 => VariantOfUInt64TypeDescriptor,
+            VariantOfDouble => VariantOfDoubleTypeDescriptor,
+            _ => new TypeData(l)
+        };
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static object? GetSignatureObject(int count, ReadOnlySpan<byte> signature)
+    {
+        // When there are items, the signature is determined based on the first.
+        // If the signature length is 1, we determine it on the metadata.
+        if (count > 0 || signature.Length == 1)
+        {
+            return null;
+        }
+        return signature.ToArray();
+    }
 
     public VariantValueType Type
         => DetermineType();
 
-    internal VariantValue(byte value)
+    private VariantValue(long l, object? o)
     {
-        _l = value | ((long)VariantValueType.Byte << TypeShift);
+        _l = l;
+        _o = o;
+    }
+    internal VariantValue(byte value) :
+        this(value, nesting: 0)
+    { }
+    internal VariantValue(byte value, byte nesting)
+    {
+        _l = value | GetTypeMetadata(VariantValueType.Byte, nesting);
         _o = null;
     }
-    internal VariantValue(bool value)
+    internal VariantValue(bool value) :
+        this(value, nesting: 0)
+    { }
+    internal VariantValue(bool value, byte nesting)
     {
-        _l = (value ? 1L : 0) | ((long)VariantValueType.Bool << TypeShift);
+        _l = (value ? 1L : 0) | GetTypeMetadata(VariantValueType.Bool, nesting);
         _o = null;
     }
-    internal VariantValue(short value)
+    internal VariantValue(short value) :
+        this(value, nesting: 0)
+    { }
+    internal VariantValue(short value, byte nesting)
     {
-        _l = (ushort)value | ((long)VariantValueType.Int16 << TypeShift);
+        _l = (ushort)value | GetTypeMetadata(VariantValueType.Int16, nesting);
         _o = null;
     }
-    internal VariantValue(ushort value)
+    internal VariantValue(ushort value) :
+        this(value, nesting: 0)
+    { }
+    internal VariantValue(ushort value, byte nesting)
     {
-        _l = value | ((long)VariantValueType.UInt16 << TypeShift);
+        _l = value | GetTypeMetadata(VariantValueType.UInt16, nesting);
         _o = null;
     }
-    internal VariantValue(int value)
+    internal VariantValue(int value) :
+        this(value, nesting: 0)
+    { }
+    internal VariantValue(int value, byte nesting)
     {
-        _l = (uint)value | ((long)VariantValueType.Int32 << TypeShift);
+        _l = (uint)value | GetTypeMetadata(VariantValueType.Int32, nesting);
         _o = null;
     }
-    internal VariantValue(uint value)
+    internal VariantValue(uint value) :
+        this(value, nesting: 0)
+    { }
+    internal VariantValue(uint value, byte nesting)
     {
-        _l = value | ((long)VariantValueType.UInt32 << TypeShift);
+        _l = value | GetTypeMetadata(VariantValueType.UInt32, nesting);
         _o = null;
     }
-    internal VariantValue(long value)
+    internal VariantValue(long value) :
+        this(value, nesting: 0)
+    { }
+    internal VariantValue(long value, byte nesting)
     {
         _l = value;
-        _o = Int64Type;
+        _o = nesting switch
+        {
+            0 => Int64TypeDescriptor,
+            1 => VariantOfInt64TypeDescriptor,
+            _ => new TypeData(GetTypeMetadata(VariantValueType.Int64, nesting))
+        };
     }
-    internal VariantValue(ulong value)
+    internal VariantValue(ulong value) :
+        this(value, nesting: 0)
+    { }
+    internal VariantValue(ulong value, byte nesting)
     {
         _l = (long)value;
-        _o = UInt64Type;
+        _o = nesting switch
+        {
+            0 => UInt64TypeDescriptor,
+            1 => VariantOfUInt64TypeDescriptor,
+            _ => new TypeData(GetTypeMetadata(VariantValueType.UInt64, nesting))
+        };
     }
-    internal unsafe VariantValue(double value)
+    internal unsafe VariantValue(double value) :
+        this(value, nesting: 0)
+    { }
+    internal unsafe VariantValue(double value, byte nesting)
     {
         _l = *(long*)&value;
-        _o = DoubleType;
+        _o = nesting switch
+        {
+            0 => DoubleTypeDescriptor,
+            1 => VariantOfDoubleTypeDescriptor,
+            _ => new TypeData(GetTypeMetadata(VariantValueType.Double, nesting))
+        };
     }
-    internal VariantValue(string value)
+    internal VariantValue(string value) :
+        this(value, nesting: 0)
+    { }
+    internal VariantValue(string value, byte nesting)
     {
-        _l = (long)VariantValueType.String << TypeShift;
+        _l = GetTypeMetadata(VariantValueType.String, nesting);
         _o = value ?? throw new ArgumentNullException(nameof(value));
     }
-    internal VariantValue(ObjectPath value)
+    internal VariantValue(ObjectPath value) :
+        this(value, nesting: 0)
+    { }
+    internal VariantValue(ObjectPath value, byte nesting)
     {
-        _l = (long)VariantValueType.ObjectPath << TypeShift;
+        _l = GetTypeMetadata(VariantValueType.ObjectPath, nesting);
         string s = value.ToString();
         if (s.Length == 0)
         {
@@ -88,9 +215,12 @@ public readonly struct VariantValue : IEquatable<VariantValue>
         }
         _o = s;
     }
-    internal VariantValue(Signature value)
+    internal VariantValue(Signature value) :
+        this(value, nesting: 0)
+    { }
+    internal VariantValue(Signature value, byte nesting)
     {
-        _l = (long)VariantValueType.Signature << TypeShift;
+        _l = GetTypeMetadata(VariantValueType.Signature, nesting);
         string s = value.ToString();
         if (s.Length == 0)
         {
@@ -99,7 +229,7 @@ public readonly struct VariantValue : IEquatable<VariantValue>
         _o = s;
     }
     // Array
-    internal VariantValue(VariantValueType itemType, VariantValue[] items)
+    internal VariantValue(VariantValueType itemType, object? itemSignature, VariantValue[] items, byte nesting)
     {
         Debug.Assert(
             itemType != VariantValueType.Byte &&
@@ -111,76 +241,169 @@ public readonly struct VariantValue : IEquatable<VariantValue>
             itemType != VariantValueType.UInt64 &&
             itemType != VariantValueType.Double
         );
-        _l = ((long)VariantValueType.Array << TypeShift) |
-             ((long)itemType << ArrayItemTypeShift);
-        _o = items;
+        int count = items.Length;
+        _l = GetArrayTypeMetadata(itemType, count, nesting);
+        _o = count == 0 ? itemSignature : items;
+        if (_o?.GetType() == typeof(int))
+        {
+            throw new Exception();
+        }
     }
-    internal VariantValue(VariantValueType itemType, string[] items)
+    // For testing
+    internal VariantValue(VariantValueType itemType, VariantValue[] items, object? itemSignature = null) :
+        this(itemType, itemSignature, items, nesting: 0)
+    { }
+    internal VariantValue(VariantValueType itemType, string[] items) :
+        this(itemType, items, nesting: 0)
+    { }
+    internal VariantValue(VariantValueType itemType, string[] items, byte nesting)
     {
         Debug.Assert(itemType == VariantValueType.String || itemType == VariantValueType.ObjectPath);
-        _l = ((long)VariantValueType.Array << TypeShift) |
-             ((long)itemType << ArrayItemTypeShift);
+        _l = GetArrayTypeMetadata(itemType, items.Length, nesting);
         _o = items;
     }
-    internal VariantValue(byte[] items)
+    internal VariantValue(byte[] items) :
+        this(items, nesting: 0)
+    { }
+    internal VariantValue(byte[] items, byte nesting)
     {
-        _l = ArrayOfByte;
+        _l = GetArrayTypeMetadata(VariantValueType.Byte, items.Length, nesting);
         _o = items;
     }
-    internal VariantValue(short[] items)
+    internal VariantValue(short[] items) :
+        this(items, nesting: 0)
+    { }
+    internal VariantValue(short[] items, byte nesting)
     {
-        _l = ArrayOfInt16;
+        _l = GetArrayTypeMetadata(VariantValueType.Int16, items.Length, nesting);
         _o = items;
     }
-    internal VariantValue(ushort[] items)
+    internal VariantValue(ushort[] items) :
+        this(items, nesting: 0)
+    { }
+    internal VariantValue(ushort[] items, byte nesting)
     {
-        _l = ArrayOfUInt16;
+        _l = GetArrayTypeMetadata(VariantValueType.UInt16, items.Length, nesting);
         _o = items;
     }
-    internal VariantValue(int[] items)
+    internal VariantValue(int[] items) :
+        this(items, nesting: 0)
+    { }
+    internal VariantValue(int[] items, byte nesting)
     {
-        _l = ArrayOfInt32;
+        _l = GetArrayTypeMetadata(VariantValueType.Int32, items.Length, nesting);
         _o = items;
     }
-    internal VariantValue(uint[] items)
+    internal VariantValue(uint[] items) :
+        this(items, nesting: 0)
+    { }
+    internal VariantValue(uint[] items, byte nesting)
     {
-        _l = ArrayOfUInt32;
+        _l = GetArrayTypeMetadata(VariantValueType.UInt32, items.Length, nesting);
         _o = items;
     }
-    internal VariantValue(long[] items)
+    internal VariantValue(long[] items) :
+        this(items, nesting: 0)
+    { }
+    internal VariantValue(long[] items, byte nesting)
     {
-        _l = ArrayOfInt64;
+        _l = GetArrayTypeMetadata(VariantValueType.Int64, items.Length, nesting);
         _o = items;
     }
-    internal VariantValue(ulong[] items)
+    internal VariantValue(ulong[] items) :
+        this(items, nesting: 0)
+    { }
+    internal VariantValue(ulong[] items, byte nesting)
     {
-        _l = ArrayOfUInt64;
+        _l = GetArrayTypeMetadata(VariantValueType.UInt64, items.Length, nesting);
         _o = items;
     }
-    internal VariantValue(double[] items)
+    internal VariantValue(double[] items) :
+        this(items, nesting: 0)
+    { }
+    internal VariantValue(double[] items, byte nesting)
     {
-        _l = ArrayOfDouble;
+        _l = GetArrayTypeMetadata(VariantValueType.Double, items.Length, nesting);
         _o = items;
     }
     // Dictionary
-    internal VariantValue(VariantValueType keyType, VariantValueType valueType, KeyValuePair<VariantValue, VariantValue>[] pairs)
+    internal VariantValue(VariantValueType keyType, VariantValueType valueType, object? valueSignature, KeyValuePair<VariantValue, VariantValue>[] pairs, byte nesting)
     {
-        _l = ((long)VariantValueType.Dictionary << TypeShift) |
-             ((long)keyType << DictionaryKeyTypeShift) |
-             ((long)valueType << DictionaryValueTypeShift);
-        _o = pairs;
+        int count = pairs.Length;
+        _l = GetDictionaryTypeMetadata(keyType, valueType, count, nesting);
+        _o = count == 0 ? valueSignature : pairs;
     }
+    // For testing
+    internal VariantValue(VariantValueType keyType, VariantValueType valueType, KeyValuePair<VariantValue, VariantValue>[] pairs, object? valueSignature = null) :
+        this(keyType, valueType, valueSignature, pairs, nesting: 0)
+    { }
     // Struct
-    internal VariantValue(VariantValue[] fields)
+    internal VariantValue(VariantValue[] fields) :
+        this(fields, nesting: 0)
+    { }
+    internal VariantValue(VariantValue[] fields, byte nesting)
     {
-        _l = ((long)VariantValueType.Struct << TypeShift);
+        long variantMask = 0;
+        for (int i = 0; i < fields.Length; i++)
+        {
+            if (i > VariantValue.MaxStructFields)
+            {
+                ThrowMaxStructFieldsExceeded();
+            }
+            VariantValue value = fields[i];
+            if (value.Type == VariantValueType.Variant)
+            {
+                variantMask |= (1L << i);
+                fields[i] = value.GetVariantValue();
+            }
+        }
+        _l = GetStructMetadata(variantMask, fields.Length, nesting);
+        _o = fields;
+    }
+    internal static void ThrowMaxStructFieldsExceeded()
+    {
+        throw new NotSupportedException($"Struct types {VariantValue.MaxStructFields}+ fields are not supported.");
+    }
+    internal VariantValue(long variantMask, VariantValue[] fields, byte nesting)
+    {
+        _l = GetStructMetadata(variantMask, fields.Length, nesting);
         _o = fields;
     }
     // UnixFd
-    internal VariantValue(UnixFdCollection? fdCollection, int index)
+    internal VariantValue(UnixFdCollection? fdCollection, int index) :
+        this(fdCollection, index, nesting: 0)
+    { }
+    internal VariantValue(UnixFdCollection? fdCollection, int index, byte nesting)
     {
-        _l = (long)index | ((long)VariantValueType.UnixFd << TypeShift);
+        _l = (long)index | GetTypeMetadata(VariantValueType.UnixFd, nesting);
         _o = fdCollection;
+    }
+    // Variant
+    internal static VariantValue CreateVariant(VariantValue value)
+    {
+        object? o = value._o;
+        long l = value._l;
+        if (o is TypeData td)
+        {
+            return new VariantValue(l, UpdateNesting(td, +1));
+        }
+        else
+        {
+            return new VariantValue(UpdateNesting(l, +1), o);
+        }
+    }
+
+    public VariantValue GetVariantValue()
+    {
+        EnsureTypeIs(VariantValueType.Variant);
+        if (_o is TypeData td)
+        {
+            return new VariantValue(_l, UpdateNesting(td, -1));
+        }
+        else
+        {
+            return new VariantValue(UpdateNesting(_l, -1), _o);
+        }
     }
 
     public byte GetByte()
@@ -192,7 +415,7 @@ public readonly struct VariantValue : IEquatable<VariantValue>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private byte UnsafeGetByte()
     {
-        return (byte)(_l & StripTypeMask);
+        return (byte)(_l & StripMetadataMask);
     }
 
     public bool GetBool()
@@ -204,7 +427,7 @@ public readonly struct VariantValue : IEquatable<VariantValue>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private bool UnsafeGetBool()
     {
-        return (_l & StripTypeMask) != 0;
+        return (_l & StripMetadataMask) != 0;
     }
 
     public short GetInt16()
@@ -216,7 +439,7 @@ public readonly struct VariantValue : IEquatable<VariantValue>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private short UnsafeGetInt16()
     {
-        return (short)(_l & StripTypeMask);
+        return (short)(_l & StripMetadataMask);
     }
 
     public ushort GetUInt16()
@@ -228,7 +451,7 @@ public readonly struct VariantValue : IEquatable<VariantValue>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private ushort UnsafeGetUInt16()
     {
-        return (ushort)(_l & StripTypeMask);
+        return (ushort)(_l & StripMetadataMask);
     }
 
     public int GetInt32()
@@ -240,7 +463,7 @@ public readonly struct VariantValue : IEquatable<VariantValue>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private int UnsafeGetInt32()
     {
-        return (int)(_l & StripTypeMask);
+        return (int)(_l & StripMetadataMask);
     }
 
     public uint GetUInt32()
@@ -252,7 +475,7 @@ public readonly struct VariantValue : IEquatable<VariantValue>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private uint UnsafeGetUInt32()
     {
-        return (uint)(_l & StripTypeMask);
+        return (uint)(_l & StripMetadataMask);
     }
 
     public long GetInt64()
@@ -401,6 +624,11 @@ public readonly struct VariantValue : IEquatable<VariantValue>
         EnsureTypeIs(VariantValueType.Array);
         EnsureCanUnsafeGet<T>(ItemType);
 
+        if (UnsafeCount == 0)
+        {
+            return Array.Empty<T>();
+        }
+
         // Return the array by reference when we can.
         // Don't bother to make a copy in case the caller mutates the data and
         // calls GetArray again to retrieve the original data. It's an unlikely scenario.
@@ -530,55 +758,72 @@ public readonly struct VariantValue : IEquatable<VariantValue>
         return handles.ReadHandleGeneric<T>(index);
     }
 
+    private int UnsafeCount => (int)_l;
+
     // Use for Array, Struct and Dictionary.
     public int Count
     {
         get
         {
-            Array? array = _o as Array;
-            return array?.Length ?? -1;
+            if (Type is VariantValueType.Array or VariantValueType.Struct or VariantValueType.Dictionary)
+            {
+                return UnsafeCount;
+            }
+            return -1;
         }
     }
 
     // Valid for Array, Struct.
     public VariantValue GetItem(int i)
     {
-        if (Type == VariantValueType.Array)
+        VariantValueType type = Type;
+        EnsureTypeIs(type, [VariantValueType.Array, VariantValueType.Struct]);
+
+        if (UnsafeCount == 0)
         {
-            switch (_l)
+            throw new IndexOutOfRangeException();
+        }
+
+        if (type == VariantValueType.Array)
+        {
+            switch (UnsafeDetermineInnerType(ArrayItemTypeShift))
             {
-                case ArrayOfByte:
+                case VariantValueType.Byte:
                     return new VariantValue((_o as byte[])![i]);
-                case ArrayOfInt16:
+                case VariantValueType.Int16:
                     return new VariantValue((_o as short[])![i]);
-                case ArrayOfUInt16:
+                case VariantValueType.UInt16:
                     return new VariantValue((_o as ushort[])![i]);
-                case ArrayOfInt32:
+                case VariantValueType.Int32:
                     return new VariantValue((_o as int[])![i]);
-                case ArrayOfUInt32:
+                case VariantValueType.UInt32:
                     return new VariantValue((_o as uint[])![i]);
-                case ArrayOfInt64:
+                case VariantValueType.Int64:
                     return new VariantValue((_o as long[])![i]);
-                case ArrayOfUInt64:
+                case VariantValueType.UInt64:
                     return new VariantValue((_o as ulong[])![i]);
-                case ArrayOfDouble:
+                case VariantValueType.Double:
                     return new VariantValue((_o as double[])![i]);
-                case ArrayOfString:
-                case ArrayOfObjectPath:
+                case VariantValueType.String:
+                case VariantValueType.ObjectPath:
                     return new VariantValue((_o as string[])![i]);
             }
         }
+
         var values = _o as VariantValue[];
-        if (_o is null)
-        {
-            ThrowCannotRetrieveAs(Type, [VariantValueType.Array, VariantValueType.Struct]);
-        }
         return values![i];
     }
 
     // Valid for Dictionary.
     public KeyValuePair<VariantValue, VariantValue> GetDictionaryEntry(int i)
     {
+        EnsureTypeIs(VariantValueType.Dictionary);
+
+        if (UnsafeCount == 0)
+        {
+            throw new IndexOutOfRangeException();
+        }
+
         var values = _o as KeyValuePair<VariantValue, VariantValue>[];
         if (_o is null)
         {
@@ -622,6 +867,20 @@ public readonly struct VariantValue : IEquatable<VariantValue>
     public VariantValueType ValueType
         => DetermineInnerType(VariantValueType.Dictionary, DictionaryValueTypeShift);
 
+    public VariantValueType GetStructFieldType(int index)
+    {
+        EnsureTypeIs(VariantValueType.Struct);
+        if (index < 0 || index > UnsafeCount)
+        {
+            throw new IndexOutOfRangeException();
+        }
+        if (UnsafeIsStructFieldVariant(index))
+        {
+            return VariantValueType.Variant;
+        }
+        return ((VariantValue[])_o!)[index].Type;
+    }
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private void EnsureTypeIs(VariantValueType expected)
         => EnsureTypeIs(Type, expected);
@@ -644,28 +903,35 @@ public readonly struct VariantValue : IEquatable<VariantValue>
         }
     }
 
+    private VariantValueType UnsafeDetermineInnerType(int typeShift)
+    {
+        return (VariantValueType)((_l >> typeShift) & 0xff);
+    }
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private VariantValueType DetermineInnerType(VariantValueType outer, int typeShift)
     {
         VariantValueType type = DetermineType();
-        return type == outer ? (VariantValueType)((_l >> typeShift) & 0xff) : VariantValueType.Invalid;
+        return type == outer ? UnsafeDetermineInnerType(typeShift) : VariantValueType.Invalid;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private (VariantValueType type, byte nesting) DetermineTypeAndNesting()
+    {
+        long l = _o is TypeData td ? td.L : _l;
+
+        byte nesting = (byte)(l >> NestingShift);
+        VariantValueType type = (VariantValueType)((l >> TypeShift) & 0xff);
+        return (type, nesting);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private VariantValueType DetermineType()
     {
-        // For most types, we store the VariantValueType in the highest byte of the long.
-        // Except for some types, like Int64, for which we store the value allocation free
-        // in the long, and use the object field to store the type.
-        VariantValueType type = (VariantValueType)(_l >> TypeShift);
-        if (_o is not null)
-        {
-            if (_o.GetType() == typeof(VariantValueType))
-            {
-                type = (VariantValueType)_o;
-            }
-        }
-        return type;
+        long l = _o is TypeData td ? td.L : _l;
+
+        l >>= TypeShift;
+        return l > 0xff ? VariantValueType.Variant : (VariantValueType)l;
     }
 
     private static void ThrowCannotRetrieveAs(VariantValueType from, VariantValueType to)
@@ -692,60 +958,68 @@ public readonly struct VariantValue : IEquatable<VariantValue>
     {
         // This is implemented so something user-friendly shows in the debugger.
         // By overriding the ToString method, it will also affect generic types like KeyValueType<TKey, TValue> that call ToString.
-        VariantValueType type = Type;
+        (VariantValueType type, byte nesting) = DetermineTypeAndNesting();
         switch (type)
         {
             case VariantValueType.Byte:
-                return $"{GetByte()}{TypeSuffix(includeTypeSuffix, type)}";
+                return $"{UnsafeGetByte()}{TypeSuffix(includeTypeSuffix, type, nesting)}";
             case VariantValueType.Bool:
-                return $"{GetBool()}{TypeSuffix(includeTypeSuffix, type)}";
+                return $"{UnsafeGetBool()}{TypeSuffix(includeTypeSuffix, type, nesting)}";
             case VariantValueType.Int16:
-                return $"{GetInt16()}{TypeSuffix(includeTypeSuffix, type)}";
+                return $"{UnsafeGetInt16()}{TypeSuffix(includeTypeSuffix, type, nesting)}";
             case VariantValueType.UInt16:
-                return $"{GetUInt16()}{TypeSuffix(includeTypeSuffix, type)}";
+                return $"{UnsafeGetUInt16()}{TypeSuffix(includeTypeSuffix, type, nesting)}";
             case VariantValueType.Int32:
-                return $"{GetInt32()}{TypeSuffix(includeTypeSuffix, type)}";
+                return $"{UnsafeGetInt32()}{TypeSuffix(includeTypeSuffix, type, nesting)}";
             case VariantValueType.UInt32:
-                return $"{GetUInt32()}{TypeSuffix(includeTypeSuffix, type)}";
+                return $"{UnsafeGetUInt32()}{TypeSuffix(includeTypeSuffix, type, nesting)}";
             case VariantValueType.Int64:
-                return $"{GetInt64()}{TypeSuffix(includeTypeSuffix, type)}";
+                return $"{UnsafeGetInt64()}{TypeSuffix(includeTypeSuffix, type, nesting)}";
             case VariantValueType.UInt64:
-                return $"{GetUInt64()}{TypeSuffix(includeTypeSuffix, type)}";
+                return $"{UnsafeGetUInt64()}{TypeSuffix(includeTypeSuffix, type, nesting)}";
             case VariantValueType.Double:
-                return $"{GetDouble()}{TypeSuffix(includeTypeSuffix, type)}";
+                return $"{UnsafeGetDouble()}{TypeSuffix(includeTypeSuffix, type, nesting)}";
             case VariantValueType.String:
-                return $"{GetString()}{TypeSuffix(includeTypeSuffix, type)}";
+                return $"{UnsafeGetString()}{TypeSuffix(includeTypeSuffix, type, nesting)}";
             case VariantValueType.ObjectPath:
-                return $"{GetObjectPath()}{TypeSuffix(includeTypeSuffix, type)}";
+                return $"{UnsafeGetString()}{TypeSuffix(includeTypeSuffix, type, nesting)}";
             case VariantValueType.Signature:
-                return $"{GetSignature()}{TypeSuffix(includeTypeSuffix, type)}";
-
-            case VariantValueType.Array:
-                return $"[{nameof(VariantValueType.Array)}<{ItemType}>, Count={Count}]";
+                return $"{UnsafeGetString()}{TypeSuffix(includeTypeSuffix, type, nesting)}";
             case VariantValueType.Struct:
                 var values = (_o as VariantValue[]) ?? Array.Empty<VariantValue>();
-                return $"({
-                            string.Join(", ", values.Select(v => v.ToString(includeTypeSuffix: false)))
-                          }){(
-                            !includeTypeSuffix ? ""
-                                : $" [{nameof(VariantValueType.Struct)}]<{
-                                    string.Join(", ", values.Select(v => v.Type))
-                                }>]")})";
-            case VariantValueType.Dictionary:
-                return $"[{nameof(VariantValueType.Dictionary)}<{KeyType}, {ValueType}>, Count={Count}]";
-            case VariantValueType.UnixFd:
-                return $"[{nameof(VariantValueType.UnixFd)}]";
-
-            case VariantValueType.Invalid:
-                return $"[{nameof(VariantValueType.Invalid)}]";
-            case VariantValueType.VariantValue: // note: No VariantValue returns this as its Type.
+                return $"({string.Join(", ", values.Select(v => v.ToString(includeTypeSuffix: false)))}){TypeSuffix(includeTypeSuffix, type, nesting)}";
             default:
-                return $"[?{Type}?]";
+                return $"{TypeString(type, nesting)}";
         }
     }
 
-    static string TypeSuffix(bool includeTypeSuffix, VariantValueType type)
-        => includeTypeSuffix ? $" [{type}]" : "";
+    string TypeSuffix(bool includeTypeSuffix, VariantValueType type, byte nesting)
+        => !includeTypeSuffix ? "" : $" {TypeString(type, nesting)}";
+
+    string TypeString(VariantValueType type, byte nesting)
+    {
+        string suffix = "";
+        if (type == VariantValueType.Struct)
+        {
+            var _this = this;
+            var values = (_o as VariantValue[]) ?? Array.Empty<VariantValue>();
+            suffix = $"<{string.Join(", ", values.Select((v, idx) => _this.UnsafeIsStructFieldVariant(idx) ? VariantValueType.Variant : v.Type))}>";
+        }
+        else if (type == VariantValueType.Array)
+        {
+            suffix = $"<{UnsafeDetermineInnerType(ArrayItemTypeShift)}>, Count={UnsafeCount}";
+        }
+        else if (type == VariantValueType.Dictionary)
+        {
+            suffix = $"<{UnsafeDetermineInnerType(DictionaryKeyTypeShift)}, {UnsafeDetermineInnerType(DictionaryValueTypeShift)}>, Count={UnsafeCount}";
+        }
+        return nesting switch
+        {
+            0 => $"[{type}{suffix}]",
+            1 => $"[{nameof(VariantValueType.Variant)}<{type}{suffix}>]",
+            _ => $"[{nameof(VariantValueType.Variant)}^{nesting}<{type}{suffix}]>"
+        };
+    }
 
     public static bool operator==(VariantValue lhs, VariantValue rhs)
         => lhs.Equals(rhs);
@@ -773,17 +1047,26 @@ public readonly struct VariantValue : IEquatable<VariantValue>
 
     public bool Equals(VariantValue other)
     {
-        if (_l == other._l && object.ReferenceEquals(_o, other._o))
+        if (_l != other._l)
+        {
+            return false;
+        }
+        if (object.ReferenceEquals(_o, other._o))
         {
             return true;
         }
-        VariantValueType type = Type;
-        if (type != other.Type)
+        (VariantValueType type, byte nesting) = DetermineTypeAndNesting();
+        if ((type, nesting) != other.DetermineTypeAndNesting())
         {
             return false;
         }
         switch (type)
         {
+            case VariantValueType.Int64:
+            case VariantValueType.UInt64:
+            case VariantValueType.Double:
+                // l, type, and nesting are the same (per previous checks)
+                return true;
             case VariantValueType.String:
             case VariantValueType.ObjectPath:
             case VariantValueType.Signature:
@@ -791,5 +1074,114 @@ public readonly struct VariantValue : IEquatable<VariantValue>
         }
         // Always return false for composite types and handles.
         return false;
+    }
+
+    // For testing.
+    internal string Signature
+    {
+        get
+        {
+            Span<byte> span = stackalloc byte[ProtocolConstants.MaxSignatureLength];
+            return GetSignature(span).ToString();
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private Utf8Span GetSignature(scoped Span<byte> buffer)
+    {
+        Debug.Assert(buffer.Length >= ProtocolConstants.MaxSignatureLength);
+
+        int bytesWritten = AppendTypeSignature(buffer);
+        return new Utf8Span(buffer.Slice(0, bytesWritten).ToArray());
+    }
+
+    private int AppendTypeSignature(Span<byte> signature)
+    {
+        VariantValueType type = Type;
+        switch (type)
+        {
+            case VariantValueType.Invalid:
+                ThrowTypeInvalid();
+                break;
+            case VariantValueType.Array:
+            {
+                int length = 0;
+                signature[length++] = (byte)'a';
+                VariantValueType itemType = UnsafeDetermineInnerType(ArrayItemTypeShift);
+                if (!TryAppendSignatureFromMetadata(signature, ref length, itemType))
+                {
+                    VariantValue vv = (_o as VariantValue[])![0];
+                    length += vv.AppendTypeSignature(signature.Slice(length));
+                }
+                return length;
+            }
+            case VariantValueType.Struct:
+            {
+                int length = 0;
+                signature[length++] = (byte)'(';
+                int count = UnsafeCount;
+                for (int i = 0; i < count; i++)
+                {
+                    if (UnsafeIsStructFieldVariant(i))
+                    {
+                        signature[length++] = (byte)VariantValueType.Variant;
+                    }
+                    else
+                    {
+                        VariantValue vv = (_o as VariantValue[])![i];
+                        length += vv.AppendTypeSignature(signature.Slice(length));
+                    }
+                }
+                signature[length++] = (byte)')';
+                return length;
+            }
+            case VariantValueType.Dictionary:
+            {
+                int length = 0;
+                signature[length++] = (byte)'a';
+                signature[length++] = (byte)'{';
+                signature[length++] = (byte)UnsafeDetermineInnerType(DictionaryKeyTypeShift);
+                VariantValueType valueType = UnsafeDetermineInnerType(DictionaryValueTypeShift);
+                if (!TryAppendSignatureFromMetadata(signature, ref length, valueType))
+                {
+                    VariantValue vv = (_o as KeyValuePair<VariantValue, VariantValue>[])![0].Value;
+                    length += vv.AppendTypeSignature(signature.Slice(length));
+                }
+                signature[length++] = (byte)'}';
+                return length;
+            }
+        }
+        signature[0] = (byte)type;
+        return 1;
+    }
+
+    bool TryAppendSignatureFromMetadata(Span<byte> signature, ref int length, VariantValueType type)
+    {
+        if (IsSimpleSignature(type))
+        {
+            signature[length++] = (byte)type;
+            return true;
+        }
+        else if (UnsafeCount == 0)
+        {
+            byte[] itemSig = (byte[])_o!;
+            itemSig.CopyTo(signature.Slice(length));
+            length += itemSig.Length;
+            return true;
+        }
+        else
+        {
+            return false;
+        }
+
+        static bool IsSimpleSignature(VariantValueType type)
+            => type != VariantValueType.Array &&
+               type != VariantValueType.Dictionary &&
+               type != VariantValueType.Struct;
+    }
+
+    private static void ThrowTypeInvalid()
+    {
+        throw new ArgumentNullException();
     }
 }

--- a/src/Tmds.DBus.Protocol/VariantValueType.cs
+++ b/src/Tmds.DBus.Protocol/VariantValueType.cs
@@ -1,14 +1,8 @@
 namespace Tmds.DBus.Protocol;
 
-public enum VariantValueType
+public enum VariantValueType : byte
 {
     Invalid = 0,
-
-    // VariantValue is used for a variant for which we read the value
-    // and no longer track its signature.
-    VariantValue = 1,
-
-    //  Match the DBusType values for easy conversion.
     Byte = DBusType.Byte,
     Bool = DBusType.Bool,
     Int16 = DBusType.Int16,
@@ -25,6 +19,5 @@ public enum VariantValueType
     Struct = DBusType.Struct,
     Dictionary = DBusType.DictEntry,
     UnixFd = DBusType.UnixFd,
-    // We don't need this : variants are resolved into the VariantValue.
-    // Variant = DBusType.Variant,
+    Variant = DBusType.Variant,
 }

--- a/test/Tmds.DBus.Protocol.Tests/VariantValueTests.cs
+++ b/test/Tmds.DBus.Protocol.Tests/VariantValueTests.cs
@@ -8,13 +8,18 @@ namespace Tmds.DBus.Protocol.Tests;
 public class VariantValueTests
 {
     [Theory]
-    [InlineData(byte.MinValue)]
-    [InlineData(0)]
-    [InlineData(1)]
-    [InlineData(byte.MaxValue)]
-    public void Byte(Byte value)
+    [InlineData(byte.MinValue, 0)]
+    [InlineData(0, 0)]
+    [InlineData(1, 0)]
+    [InlineData(byte.MaxValue, 0)]
+    [InlineData(byte.MinValue, 1)]
+    [InlineData(0, 1)]
+    [InlineData(1, 1)]
+    [InlineData(byte.MaxValue, 1)]
+    public void Byte(Byte value, byte nesting)
     {
-        VariantValue vv = new(value);
+        VariantValue vv = nesting > 0 ? new(value, nesting) : new(value);
+        UnwrapVariant(ref vv, nesting);
 
         Assert.Equal(value, vv.GetByte());
 
@@ -22,16 +27,20 @@ public class VariantValueTests
         Assert.Equal(VariantValueType.Invalid, vv.ItemType);
         Assert.Equal(VariantValueType.Invalid, vv.KeyType);
         Assert.Equal(VariantValueType.Invalid, vv.ValueType);
+        Assert.Equal("y", vv.Signature);
 
         Assert.Equal(-1, vv.Count);
     }
 
     [Theory]
-    [InlineData(true)]
-    [InlineData(false)]
-    public void Bool(bool value)
+    [InlineData(true, 0)]
+    [InlineData(false, 0)]
+    [InlineData(true, 1)]
+    [InlineData(false, 1)]
+    public void Bool(bool value, byte nesting)
     {
-        VariantValue vv = new(value);
+        VariantValue vv = nesting > 0 ? new(value, nesting) : new(value);
+        UnwrapVariant(ref vv, nesting);
 
         Assert.Equal(value, vv.GetBool());
 
@@ -39,19 +48,26 @@ public class VariantValueTests
         Assert.Equal(VariantValueType.Invalid, vv.ItemType);
         Assert.Equal(VariantValueType.Invalid, vv.KeyType);
         Assert.Equal(VariantValueType.Invalid, vv.ValueType);
+        Assert.Equal("b", vv.Signature);
 
         Assert.Equal(-1, vv.Count);
     }
 
     [Theory]
-    [InlineData(short.MinValue)]
-    [InlineData(-1)]
-    [InlineData(0)]
-    [InlineData(1)]
-    [InlineData(short.MaxValue)]
-    public void Int16(Int16 value)
+    [InlineData(short.MinValue, 0)]
+    [InlineData(-1, 0)]
+    [InlineData(0, 0)]
+    [InlineData(1, 0)]
+    [InlineData(short.MaxValue, 0)]
+    [InlineData(short.MinValue, 1)]
+    [InlineData(-1, 1)]
+    [InlineData(0, 1)]
+    [InlineData(1, 1)]
+    [InlineData(short.MaxValue, 1)]
+    public void Int16(Int16 value, byte nesting)
     {
-        VariantValue vv = new(value);
+        VariantValue vv = nesting > 0 ? new(value, nesting) : new(value);
+        UnwrapVariant(ref vv, nesting);
 
         Assert.Equal(value, vv.GetInt16());
 
@@ -59,18 +75,24 @@ public class VariantValueTests
         Assert.Equal(VariantValueType.Invalid, vv.ItemType);
         Assert.Equal(VariantValueType.Invalid, vv.KeyType);
         Assert.Equal(VariantValueType.Invalid, vv.ValueType);
+        Assert.Equal("n", vv.Signature);
 
         Assert.Equal(-1, vv.Count);
     }
 
     [Theory]
-    [InlineData(ushort.MinValue)]
-    [InlineData(0)]
-    [InlineData(1)]
-    [InlineData(ushort.MaxValue)]
-    public void UInt16(UInt16 value)
+    [InlineData(ushort.MinValue, 0)]
+    [InlineData(0, 0)]
+    [InlineData(1, 0)]
+    [InlineData(ushort.MaxValue, 0)]
+    [InlineData(ushort.MinValue, 1)]
+    [InlineData(0, 1)]
+    [InlineData(1, 1)]
+    [InlineData(ushort.MaxValue, 1)]
+    public void UInt16(UInt16 value, byte nesting)
     {
-        VariantValue vv = new(value);
+        VariantValue vv = nesting > 0 ? new(value, nesting) : new(value);
+        UnwrapVariant(ref vv, nesting);
 
         Assert.Equal(value, vv.GetUInt16());
 
@@ -78,19 +100,26 @@ public class VariantValueTests
         Assert.Equal(VariantValueType.Invalid, vv.ItemType);
         Assert.Equal(VariantValueType.Invalid, vv.KeyType);
         Assert.Equal(VariantValueType.Invalid, vv.ValueType);
+        Assert.Equal("q", vv.Signature);
 
         Assert.Equal(-1, vv.Count);
     }
 
     [Theory]
-    [InlineData(int.MinValue)]
-    [InlineData(-1)]
-    [InlineData(0)]
-    [InlineData(1)]
-    [InlineData(int.MaxValue)]
-    public void Int32(Int32 value)
+    [InlineData(int.MinValue, 0)]
+    [InlineData(-1, 0)]
+    [InlineData(0, 0)]
+    [InlineData(1, 0)]
+    [InlineData(int.MaxValue, 0)]
+    [InlineData(int.MinValue, 1)]
+    [InlineData(-1, 1)]
+    [InlineData(0, 1)]
+    [InlineData(1, 1)]
+    [InlineData(int.MaxValue, 1)]
+    public void Int32(Int32 value, byte nesting)
     {
-        VariantValue vv = new(value);
+        VariantValue vv = nesting > 0 ? new(value, nesting) : new(value);
+        UnwrapVariant(ref vv, nesting);
 
         Assert.Equal(value, vv.GetInt32());
 
@@ -98,18 +127,24 @@ public class VariantValueTests
         Assert.Equal(VariantValueType.Invalid, vv.ItemType);
         Assert.Equal(VariantValueType.Invalid, vv.KeyType);
         Assert.Equal(VariantValueType.Invalid, vv.ValueType);
+        Assert.Equal("i", vv.Signature);
 
         Assert.Equal(-1, vv.Count);
     }
 
     [Theory]
-    [InlineData(uint.MinValue)]
-    [InlineData(0)]
-    [InlineData(1)]
-    [InlineData(uint.MaxValue)]
-    public void UInt32(UInt32 value)
+    [InlineData(uint.MinValue, 0)]
+    [InlineData(0, 0)]
+    [InlineData(1, 0)]
+    [InlineData(uint.MaxValue, 0)]
+    [InlineData(uint.MinValue, 1)]
+    [InlineData(0, 1)]
+    [InlineData(1, 1)]
+    [InlineData(uint.MaxValue, 1)]
+    public void UInt32(UInt32 value, byte nesting)
     {
-        VariantValue vv = new(value);
+        VariantValue vv = nesting > 0 ? new(value, nesting) : new(value);
+        UnwrapVariant(ref vv, nesting);
 
         Assert.Equal(value, vv.GetUInt32());
 
@@ -117,19 +152,31 @@ public class VariantValueTests
         Assert.Equal(VariantValueType.Invalid, vv.ItemType);
         Assert.Equal(VariantValueType.Invalid, vv.KeyType);
         Assert.Equal(VariantValueType.Invalid, vv.ValueType);
+        Assert.Equal("u", vv.Signature);
 
         Assert.Equal(-1, vv.Count);
     }
 
     [Theory]
-    [InlineData(long.MinValue)]
-    [InlineData(-1)]
-    [InlineData(0)]
-    [InlineData(1)]
-    [InlineData(long.MaxValue)]
-    public void Int64(Int64 value)
+    [InlineData(long.MinValue, 0)]
+    [InlineData(-1, 0)]
+    [InlineData(0, 0)]
+    [InlineData(1, 0)]
+    [InlineData(long.MaxValue, 0)]
+    [InlineData(long.MinValue, 1)]
+    [InlineData(-1, 1)]
+    [InlineData(0, 1)]
+    [InlineData(1, 1)]
+    [InlineData(long.MaxValue, 1)]
+    [InlineData(long.MinValue, 3)]
+    [InlineData(-1, 3)]
+    [InlineData(0, 3)]
+    [InlineData(1, 3)]
+    [InlineData(long.MaxValue, 3)]
+    public void Int64(Int64 value, byte nesting)
     {
-        VariantValue vv = new(value);
+        VariantValue vv = nesting > 0 ? new(value, nesting) : new(value);
+        UnwrapVariant(ref vv, nesting);
 
         Assert.Equal(value, vv.GetInt64());
 
@@ -137,18 +184,28 @@ public class VariantValueTests
         Assert.Equal(VariantValueType.Invalid, vv.ItemType);
         Assert.Equal(VariantValueType.Invalid, vv.KeyType);
         Assert.Equal(VariantValueType.Invalid, vv.ValueType);
+        Assert.Equal("x", vv.Signature);
 
         Assert.Equal(-1, vv.Count);
     }
 
     [Theory]
-    [InlineData(ulong.MinValue)]
-    [InlineData(0)]
-    [InlineData(1)]
-    [InlineData(ulong.MaxValue)]
-    public void UInt64(UInt64 value)
+    [InlineData(ulong.MinValue, 0)]
+    [InlineData(0, 0)]
+    [InlineData(1, 0)]
+    [InlineData(ulong.MaxValue, 0)]
+    [InlineData(ulong.MinValue, 1)]
+    [InlineData(0, 1)]
+    [InlineData(1, 1)]
+    [InlineData(ulong.MaxValue, 1)]
+    [InlineData(ulong.MinValue, 3)]
+    [InlineData(0, 3)]
+    [InlineData(1, 3)]
+    [InlineData(ulong.MaxValue, 3)]
+    public void UInt64(UInt64 value, byte nesting)
     {
-        VariantValue vv = new(value);
+        VariantValue vv = nesting > 0 ? new(value, nesting) : new(value);
+        UnwrapVariant(ref vv, nesting);
 
         Assert.Equal(value, vv.GetUInt64());
 
@@ -156,19 +213,31 @@ public class VariantValueTests
         Assert.Equal(VariantValueType.Invalid, vv.ItemType);
         Assert.Equal(VariantValueType.Invalid, vv.KeyType);
         Assert.Equal(VariantValueType.Invalid, vv.ValueType);
+        Assert.Equal("t", vv.Signature);
 
         Assert.Equal(-1, vv.Count);
     }
 
     [Theory]
-    [InlineData(double.MinValue)]
-    [InlineData(-1.0)]
-    [InlineData(0.0)]
-    [InlineData(1.0)]
-    [InlineData(double.MaxValue)]
-    public void Double(Double value)
+    [InlineData(double.MinValue, 0)]
+    [InlineData(-1.0, 0)]
+    [InlineData(0.0, 0)]
+    [InlineData(1.0, 0)]
+    [InlineData(double.MaxValue, 0)]
+    [InlineData(double.MinValue, 1)]
+    [InlineData(-1.0, 1)]
+    [InlineData(0.0, 1)]
+    [InlineData(1.0, 1)]
+    [InlineData(double.MaxValue, 1)]
+    [InlineData(double.MinValue, 3)]
+    [InlineData(-1.0, 3)]
+    [InlineData(0.0, 3)]
+    [InlineData(1.0, 3)]
+    [InlineData(double.MaxValue, 3)]
+    public void Double(Double value, byte nesting)
     {
-        VariantValue vv = new(value);
+        VariantValue vv = nesting > 0 ? new(value, nesting) : new(value);
+        UnwrapVariant(ref vv, nesting);
 
         Assert.Equal(value, vv.GetDouble());
 
@@ -176,15 +245,18 @@ public class VariantValueTests
         Assert.Equal(VariantValueType.Invalid, vv.ItemType);
         Assert.Equal(VariantValueType.Invalid, vv.KeyType);
         Assert.Equal(VariantValueType.Invalid, vv.ValueType);
+        Assert.Equal("d", vv.Signature);
 
         Assert.Equal(-1, vv.Count);
     }
 
     [Theory]
-    [InlineData("test")]
-    public void String(String value)
+    [InlineData("test", 0)]
+    [InlineData("test", 1)]
+    public void String(String value, byte nesting)
     {
-        VariantValue vv = new(value);
+        VariantValue vv = nesting > 0 ? new(value, nesting) : new(value);
+        UnwrapVariant(ref vv, nesting);
 
         Assert.Equal(value, vv.GetString());
 
@@ -192,16 +264,19 @@ public class VariantValueTests
         Assert.Equal(VariantValueType.Invalid, vv.ItemType);
         Assert.Equal(VariantValueType.Invalid, vv.KeyType);
         Assert.Equal(VariantValueType.Invalid, vv.ValueType);
+        Assert.Equal("s", vv.Signature);
 
         Assert.Equal(-1, vv.Count);
     }
 
     [Theory]
-    [InlineData("/test/path")]
-    public void ObjectPath(string s)
+    [InlineData("/test/path", 0)]
+    [InlineData("/test/path", 1)]
+    public void ObjectPath(string s, byte nesting)
     {
         ObjectPath value = new ObjectPath(s);
-        VariantValue vv = new(value);
+        VariantValue vv = nesting > 0 ? new(value, nesting) : new(value);
+        UnwrapVariant(ref vv, nesting);
 
         Assert.Equal(s, vv.GetObjectPath());
 
@@ -209,16 +284,19 @@ public class VariantValueTests
         Assert.Equal(VariantValueType.Invalid, vv.ItemType);
         Assert.Equal(VariantValueType.Invalid, vv.KeyType);
         Assert.Equal(VariantValueType.Invalid, vv.ValueType);
+        Assert.Equal("o", vv.Signature);
 
         Assert.Equal(-1, vv.Count);
     }
 
     [Theory]
-    [InlineData("sis")]
-    public void Signature(string s)
+    [InlineData("sis", 0)]
+    [InlineData("sis", 1)]
+    public void Signature(string s, byte nesting)
     {
         Signature value = new Signature(s);
-        VariantValue vv = new(value);
+        VariantValue vv = nesting > 0 ? new(value, nesting) : new(value);
+        UnwrapVariant(ref vv, nesting);
 
         Assert.Equal(s, vv.GetSignature());
 
@@ -226,19 +304,25 @@ public class VariantValueTests
         Assert.Equal(VariantValueType.Invalid, vv.ItemType);
         Assert.Equal(VariantValueType.Invalid, vv.KeyType);
         Assert.Equal(VariantValueType.Invalid, vv.ValueType);
+        Assert.Equal("g", vv.Signature);
 
         Assert.Equal(-1, vv.Count);
     }
 
-    [Fact]
-    public void Array()
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    public void Array(byte nesting)
     {
-        VariantValue vv = new VariantValue(VariantValueType.String, new string[] { "1", "2" });
+        VariantValue vv = nesting > 0 ? new VariantValue(VariantValueType.String, new string[] { "1", "2" }, nesting)
+                                      : new VariantValue(VariantValueType.String, new string[] { "1", "2" });
+        UnwrapVariant(ref vv, nesting);
 
         Assert.Equal(VariantValueType.Array, vv.Type);
         Assert.Equal(VariantValueType.String, vv.ItemType);
         Assert.Equal(VariantValueType.Invalid, vv.KeyType);
         Assert.Equal(VariantValueType.Invalid, vv.ValueType);
+        Assert.Equal("as", vv.Signature);
 
         Assert.Equal(2, vv.Count);
 
@@ -248,17 +332,20 @@ public class VariantValueTests
         Assert.Equal(new[] { "1", "2" }, vv.GetArray<string>());
     }
 
-
-
-    [Fact]
-    public void ArrayOfByte()
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    public void ArrayOfByte(byte nesting)
     {
-        VariantValue vv = new VariantValue(new byte[] { 1, 2 });
+        VariantValue vv = nesting > 0 ? new VariantValue(new byte[] { 1, 2 }, nesting)
+                                      : new VariantValue(new byte[] { 1, 2 });
+        UnwrapVariant(ref vv, nesting);
 
         Assert.Equal(VariantValueType.Array, vv.Type);
         Assert.Equal(VariantValueType.Byte, vv.ItemType);
         Assert.Equal(VariantValueType.Invalid, vv.KeyType);
         Assert.Equal(VariantValueType.Invalid, vv.ValueType);
+        Assert.Equal("ay", vv.Signature);
 
         Assert.Equal(2, vv.Count);
 
@@ -268,15 +355,20 @@ public class VariantValueTests
         Assert.Equal(new byte[] { 1, 2 }, vv.GetArray<byte>());
     }
 
-    [Fact]
-    public void ArrayOfInt16()
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    public void ArrayOfInt16(byte nesting)
     {
-        VariantValue vv = new VariantValue(new short[] { 1, 2 });
+        VariantValue vv = nesting > 0 ? new VariantValue(new short[] { 1, 2 }, nesting)
+                                      : new VariantValue(new short[] { 1, 2 });
+        UnwrapVariant(ref vv, nesting);
 
         Assert.Equal(VariantValueType.Array, vv.Type);
         Assert.Equal(VariantValueType.Int16, vv.ItemType);
         Assert.Equal(VariantValueType.Invalid, vv.KeyType);
         Assert.Equal(VariantValueType.Invalid, vv.ValueType);
+        Assert.Equal("an", vv.Signature);
 
         Assert.Equal(2, vv.Count);
 
@@ -286,15 +378,20 @@ public class VariantValueTests
         Assert.Equal(new short[] { 1, 2 }, vv.GetArray<short>());
     }
 
-    [Fact]
-    public void ArrayOfUInt16()
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    public void ArrayOfUInt16(byte nesting)
     {
-        VariantValue vv = new VariantValue(new ushort[] { 1, 2 });
+        VariantValue vv = nesting > 0 ? new VariantValue(new ushort[] { 1, 2 }, nesting)
+                                      : new VariantValue(new ushort[] { 1, 2 });
+        UnwrapVariant(ref vv, nesting);
 
         Assert.Equal(VariantValueType.Array, vv.Type);
         Assert.Equal(VariantValueType.UInt16, vv.ItemType);
         Assert.Equal(VariantValueType.Invalid, vv.KeyType);
         Assert.Equal(VariantValueType.Invalid, vv.ValueType);
+        Assert.Equal("aq", vv.Signature);
 
         Assert.Equal(2, vv.Count);
 
@@ -304,15 +401,20 @@ public class VariantValueTests
         Assert.Equal(new ushort[] { 1, 2 }, vv.GetArray<ushort>());
     }
 
-    [Fact]
-    public void ArrayOfInt32()
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    public void ArrayOfInt32(byte nesting)
     {
-        VariantValue vv = new VariantValue(new int[] { 1, 2 });
+        VariantValue vv = nesting > 0 ? new VariantValue(new int[] { 1, 2 }, nesting)
+                                      : new VariantValue(new int[] { 1, 2 });
+        UnwrapVariant(ref vv, nesting);
 
         Assert.Equal(VariantValueType.Array, vv.Type);
         Assert.Equal(VariantValueType.Int32, vv.ItemType);
         Assert.Equal(VariantValueType.Invalid, vv.KeyType);
         Assert.Equal(VariantValueType.Invalid, vv.ValueType);
+        Assert.Equal("ai", vv.Signature);
 
         Assert.Equal(2, vv.Count);
 
@@ -322,15 +424,20 @@ public class VariantValueTests
         Assert.Equal(new int[] { 1, 2 }, vv.GetArray<int>());
     }
 
-    [Fact]
-    public void ArrayOfUInt32()
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    public void ArrayOfUInt32(byte nesting)
     {
-        VariantValue vv = new VariantValue(new uint[] { 1, 2 });
+        VariantValue vv = nesting > 0 ? new VariantValue(new uint[] { 1, 2 }, nesting)
+                                      : new VariantValue(new uint[] { 1, 2 });
+        UnwrapVariant(ref vv, nesting);
 
         Assert.Equal(VariantValueType.Array, vv.Type);
         Assert.Equal(VariantValueType.UInt32, vv.ItemType);
         Assert.Equal(VariantValueType.Invalid, vv.KeyType);
         Assert.Equal(VariantValueType.Invalid, vv.ValueType);
+        Assert.Equal("au", vv.Signature);
 
         Assert.Equal(2, vv.Count);
 
@@ -340,15 +447,20 @@ public class VariantValueTests
         Assert.Equal(new uint[] { 1, 2 }, vv.GetArray<uint>());
     }
 
-    [Fact]
-    public void ArrayOfInt64()
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    public void ArrayOfInt64(byte nesting)
     {
-        VariantValue vv = new VariantValue(new long[] { 1, 2 });
+        VariantValue vv = nesting > 0 ? new VariantValue(new long[] { 1, 2 }, nesting)
+                                      : new VariantValue(new long[] { 1, 2 });;
+        UnwrapVariant(ref vv, nesting);
 
         Assert.Equal(VariantValueType.Array, vv.Type);
         Assert.Equal(VariantValueType.Int64, vv.ItemType);
         Assert.Equal(VariantValueType.Invalid, vv.KeyType);
         Assert.Equal(VariantValueType.Invalid, vv.ValueType);
+        Assert.Equal("ax", vv.Signature);
 
         Assert.Equal(2, vv.Count);
 
@@ -358,15 +470,20 @@ public class VariantValueTests
         Assert.Equal(new long[] { 1, 2 }, vv.GetArray<long>());
     }
 
-    [Fact]
-    public void ArrayOfUInt64()
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    public void ArrayOfUInt64(byte nesting)
     {
-        VariantValue vv = new VariantValue(new ulong[] { 1, 2 });
+        VariantValue vv = nesting > 0 ? new VariantValue(new ulong[] { 1, 2 }, nesting)
+                                      : new VariantValue(new ulong[] { 1, 2 });
+        UnwrapVariant(ref vv, nesting);
 
         Assert.Equal(VariantValueType.Array, vv.Type);
         Assert.Equal(VariantValueType.UInt64, vv.ItemType);
         Assert.Equal(VariantValueType.Invalid, vv.KeyType);
         Assert.Equal(VariantValueType.Invalid, vv.ValueType);
+        Assert.Equal("at", vv.Signature);
 
         Assert.Equal(2, vv.Count);
 
@@ -376,20 +493,23 @@ public class VariantValueTests
         Assert.Equal(new ulong[] { 1, 2 }, vv.GetArray<ulong>());
     }
 
-
-
-    [Fact]
-    public void ArrayOfDouble()
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    public void ArrayOfDouble(byte nesting)
     {
         double d1 = Math.PI;
         double d2 = Math.E;
 
-        VariantValue vv = new VariantValue(new double[] { d1, d2 });
+        VariantValue vv = nesting > 0 ? new VariantValue(new double[] { d1, d2 }, nesting)
+                                      : new VariantValue(new double[] { d1, d2 });
+        UnwrapVariant(ref vv, nesting);
 
         Assert.Equal(VariantValueType.Array, vv.Type);
         Assert.Equal(VariantValueType.Double, vv.ItemType);
         Assert.Equal(VariantValueType.Invalid, vv.KeyType);
         Assert.Equal(VariantValueType.Invalid, vv.ValueType);
+        Assert.Equal("ad", vv.Signature);
 
         Assert.Equal(2, vv.Count);
 
@@ -399,54 +519,83 @@ public class VariantValueTests
         Assert.Equal(new double[] { d1, d2 }, vv.GetArray<double>());
     }
 
-
-    [Fact]
-    public void Struct()
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    public void Struct(byte nesting)
     {
-        VariantValue vv = new VariantValue(new VariantValue[] { new VariantValue((byte)1), new VariantValue((byte)2) });
+        VariantValue vv = nesting > 0
+                            ? new VariantValue(new VariantValue[] { new VariantValue((byte)1), new VariantValue("string") }, nesting)
+                            : new VariantValue(new VariantValue[] { new VariantValue((byte)1), new VariantValue("string") });
+        UnwrapVariant(ref vv, nesting);
 
         Assert.Equal(VariantValueType.Struct, vv.Type);
         Assert.Equal(VariantValueType.Invalid, vv.ItemType);
         Assert.Equal(VariantValueType.Invalid, vv.KeyType);
         Assert.Equal(VariantValueType.Invalid, vv.ValueType);
+        Assert.Equal("(ys)", vv.Signature);
 
         Assert.Equal(2, vv.Count);
 
         Assert.Equal(1, vv.GetItem(0).GetByte());
-        Assert.Equal(2, vv.GetItem(1).GetByte());
+        Assert.Equal("string", vv.GetItem(1).GetString());
     }
 
     [Fact]
-    public void Dictionary()
+    public void StructWithVariantFields()
     {
-        VariantValue vv = new VariantValue(VariantValueType.Byte, VariantValueType.String,
-            new[]
-            {
-                KeyValuePair.Create(new VariantValue(1), new VariantValue("one")),
-                KeyValuePair.Create(new VariantValue(2), new VariantValue("two")),
-            });
+        VariantValue vv = new VariantValue(new VariantValue[] { new VariantValue((byte)1), VariantValue.CreateVariant(2), new VariantValue((short)3), new VariantValue("string") });
+
+        Assert.Equal(VariantValueType.Struct, vv.Type);
+        Assert.Equal(VariantValueType.Invalid, vv.ItemType);
+        Assert.Equal(VariantValueType.Invalid, vv.KeyType);
+        Assert.Equal(VariantValueType.Invalid, vv.ValueType);
+        Assert.Equal("(yvns)", vv.Signature); // Variant field is reported as variant.
+
+        Assert.Equal(4, vv.Count);
+
+        Assert.Equal(1, vv.GetItem(0).GetByte());
+        Assert.Equal(2, vv.GetItem(1).GetInt32()); // Variant field value is unwrapped.
+        Assert.Equal(3, vv.GetItem(2).GetInt16());
+        Assert.Equal("string", vv.GetItem(3).GetString());
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    public void Dictionary(byte nesting)
+    {
+        var item1 = KeyValuePair.Create(new VariantValue((byte)1), new VariantValue("one"));
+        var item2 = KeyValuePair.Create(new VariantValue((byte)2), new VariantValue("two"));
+        VariantValue vv = nesting > 0
+                            ? new VariantValue(VariantValueType.Byte, VariantValueType.String, valueSignature: null, new[] { item1, item2 }, nesting)
+                            : new VariantValue(VariantValueType.Byte, VariantValueType.String, new[] { item1, item2 });
+        UnwrapVariant(ref vv, nesting);
 
         Assert.Equal(VariantValueType.Dictionary, vv.Type);
         Assert.Equal(VariantValueType.Invalid, vv.ItemType);
         Assert.Equal(VariantValueType.Byte, vv.KeyType);
         Assert.Equal(VariantValueType.String, vv.ValueType);
+        Assert.Equal("a{ys}", vv.Signature);
 
         Assert.Equal(2, vv.Count);
 
         var item = vv.GetDictionaryEntry(0);
-        Assert.Equal(1, item.Key.GetInt32());
+        Assert.Equal(1, item.Key.GetByte());
         Assert.Equal("one", item.Value.GetString());
 
         item = vv.GetDictionaryEntry(1);
-        Assert.Equal(2, item.Key.GetInt32());
+        Assert.Equal(2, item.Key.GetByte());
         Assert.Equal("two", item.Value.GetString());
 
         Dictionary<byte, string> dict = vv.GetDictionary<byte, string>();
         Assert.Equal(new Dictionary<byte, string>() { { 1, "one"}, { 2, "two" } }, dict);
     }
 
-    [Fact]
-    public void UnixFd()
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    public void UnixFd(byte nesting)
     {
         byte handleIndex = 1;
         IntPtr expected = new IntPtr(-3);
@@ -454,7 +603,10 @@ public class VariantValueTests
         fds.AddHandle(new IntPtr(-2));
         fds.AddHandle(expected);
 
-        VariantValue vv = new VariantValue(fds, handleIndex);
+        VariantValue vv = nesting > 0
+                            ? new VariantValue(fds, handleIndex, nesting)
+                            : new VariantValue(fds, handleIndex);
+        UnwrapVariant(ref vv, nesting);
 
         using var handle = vv.ReadHandle<SafeFileHandle>();
 
@@ -464,7 +616,22 @@ public class VariantValueTests
         Assert.Equal(VariantValueType.Invalid, vv.ItemType);
         Assert.Equal(VariantValueType.Invalid, vv.KeyType);
         Assert.Equal(VariantValueType.Invalid, vv.ValueType);
+        Assert.Equal("h", vv.Signature);
 
         Assert.Equal(-1, vv.Count);
+    }
+
+    private static void UnwrapVariant(ref VariantValue vv, byte nesting)
+    {
+        for (int i = 0; i < nesting; i++)
+        {
+            Assert.Equal(VariantValueType.Variant, vv.Type);
+            Assert.Equal(VariantValueType.Invalid, vv.ItemType);
+            Assert.Equal(VariantValueType.Invalid, vv.KeyType);
+            Assert.Equal(VariantValueType.Invalid, vv.ValueType);
+            Assert.Equal("v", vv.Signature);
+
+            vv = vv.GetVariantValue();
+        }
     }
 }


### PR DESCRIPTION
This makes VariantValue track information required to write back the value to the bus.

This comes with the following breaking changes:
- A variant that holds another variant is represented as a separate instance of VariantValue. The common scenario, where a variant holds an actual non-variant type, works the same as before.
- VariantValueType.VariantValue is replaced by VariantValueType.Variant.

Fixes https://github.com/tmds/Tmds.DBus/issues/282
Contributes to https://github.com/tmds/Tmds.DBus/issues/303