### PR TITLE
VariantValue: for object paths, prefer ObjectPath type over string type.

### DIFF
--- a/src/Tmds.DBus.Protocol/Reader.Variant.cs
+++ b/src/Tmds.DBus.Protocol/Reader.Variant.cs
@@ -117,10 +117,13 @@ public ref partial struct Reader
                     {
                         return new VariantValue(ReadArrayOfDouble(), nesting);
                     }
-                    else if (type == DBusType.String ||
-                             type == DBusType.ObjectPath)
+                    else if (type == DBusType.String)
                     {
-                        return new VariantValue(ToVariantValueType(type), ReadArrayOfString(), nesting);
+                        return new VariantValue(ReadArrayOfString(), nesting);
+                    }
+                    else if (type == DBusType.ObjectPath)
+                    {
+                        return new VariantValue(ReadArrayOfObjectPath(), nesting);
                     }
                     else
                     {

--- a/test/Tmds.DBus.Protocol.Tests/VariantValueTests.cs
+++ b/test/Tmds.DBus.Protocol.Tests/VariantValueTests.cs
@@ -315,8 +315,8 @@ public class VariantValueTests
     [InlineData(1)]
     public void Array(byte nesting)
     {
-        VariantValue vv = nesting > 0 ? new VariantValue(VariantValueType.String, new string[] { "1", "2" }, nesting)
-                                      : new VariantValue(VariantValueType.String, new string[] { "1", "2" });
+        VariantValue vv = nesting > 0 ? new VariantValue(new string[] { "1", "2" }, nesting)
+                                      : new VariantValue(new string[] { "1", "2" });
         UnwrapVariant(ref vv, nesting);
 
         Assert.Equal(VariantValueType.Array, vv.Type);


### PR DESCRIPTION
This causes breaking changes:

- The GetObjectPath method now returns an ObjectPath.
- The generic parameters of GetArray/GetDictionary require an 'ObjectPath' type instead of a 'string' type.