### PR TITLE
Reader: add ReadSignature overloads.

### DIFF
--- a/src/Tmds.DBus.Protocol/Reader.Basic.cs
+++ b/src/Tmds.DBus.Protocol/Reader.Basic.cs
@@ -65,6 +65,9 @@ public ref partial struct Reader
         return value;
     }
 
+    public Signature ReadSignature()
+        => new Signature(ReadSignatureAsSpan());
+
     public ReadOnlySpan<byte> ReadSignatureAsSpan()
     {
         int length = ReadByte();
@@ -87,6 +90,15 @@ public ref partial struct Reader
         }
     }
 
+    public void ReadSignature(ReadOnlySpan<byte> expected)
+    {
+        ReadOnlySpan<byte> signature = ReadSignatureAsSpan();
+        if (!signature.SequenceEqual(expected))
+        {
+            ThrowHelper.ThrowUnexpectedSignature(signature, Encoding.UTF8.GetString(expected));
+        }
+    }
+
     public ReadOnlySpan<byte> ReadObjectPathAsSpan() => ReadSpan();
 
     public ObjectPath ReadObjectPath() => new ObjectPath(ReadString());
@@ -96,8 +108,6 @@ public ref partial struct Reader
     public ReadOnlySpan<byte> ReadStringAsSpan() => ReadSpan();
 
     public string ReadString() => Encoding.UTF8.GetString(ReadSpan());
-
-    public Signature ReadSignatureAsSignature() => new Signature(ReadSignatureAsSpan());
 
     public string ReadSignatureAsString() => Encoding.UTF8.GetString(ReadSignatureAsSpan());
 

--- a/src/Tmds.DBus.Protocol/Reader.ReadT.cs
+++ b/src/Tmds.DBus.Protocol/Reader.ReadT.cs
@@ -51,7 +51,7 @@ public ref partial struct Reader
         }
         else if (typeof(T) == typeof(Signature))
         {
-            return (T)(object)ReadSignatureAsSignature();
+            return (T)(object)ReadSignature();
         }
         else if (typeof(T).IsAssignableTo(typeof(SafeHandle)))
         {

--- a/src/Tmds.DBus.Protocol/Reader.Variant.cs
+++ b/src/Tmds.DBus.Protocol/Reader.Variant.cs
@@ -44,7 +44,7 @@ public ref partial struct Reader
             case DBusType.ObjectPath:
                 return new VariantValue(ReadObjectPath(), nesting);
             case DBusType.Signature:
-                return new VariantValue(ReadSignatureAsSignature(), nesting);
+                return new VariantValue(ReadSignature(), nesting);
             case DBusType.UnixFd:
                 int idx = (int)ReadUInt32();
                 return new VariantValue(_handles, idx, nesting);

--- a/src/Tmds.DBus.Tool/ProtocolGenerator.cs
+++ b/src/Tmds.DBus.Tool/ProtocolGenerator.cs
@@ -518,7 +518,7 @@ namespace Tmds.DBus.Tool
                 {
                     AppendLine($"case \"{property.Name}\":");
                     _indentation++;
-                    AppendLine($"reader.ReadSignature(\"{property.Signature}\");");
+                    AppendLine($"reader.ReadSignature(\"{property.Signature}\"u8);");
                     AppendLine($"props.{property.NameUpper} = {CallReadArgumentType(property.Signature)};");
                     AppendLine($"changedList?.Add(\"{property.NameUpper}\");");
                     AppendLine("break;");
@@ -757,7 +757,7 @@ namespace Tmds.DBus.Tool
             AppendLine("var reader = message.GetBodyReader();");
             if (variant)
             {
-                AppendLine($"reader.ReadSignature(\"{signature}\");");
+                AppendLine($"reader.ReadSignature(\"{signature}\"u8);");
             }
             if (args.Length == 1)
             {


### PR DESCRIPTION
Rename ReadSignatureAsSignature to ReadSignature.
Add ReadSignature overload that accepts expected as ROS<byte>.