### PR TITLE
Protocol: add Notification<T> API for observer callbacks.

### DIFF
--- a/examples/MediaPlayerRemote/Program.cs
+++ b/examples/MediaPlayerRemote/Program.cs
@@ -96,13 +96,8 @@ class Player
 
         return watcher;
 
-        async void OnPropertiesChanged(Exception? ex, IPlayerProperties props)
+        async void OnPropertiesChanged(IPlayerProperties props)
         {
-            if (ex is not null)
-            {
-                return;
-            }
-
             if (props.HasMetadataChanged)
             {
                 try

--- a/examples/NetworkManager/Program.cs
+++ b/examples/NetworkManager/Program.cs
@@ -34,15 +34,11 @@ while (true)
             var interfaceName = await device.GetInterfaceAsync();
 
             Console.WriteLine($"Subscribing for state changes of '{interfaceName}'.");
-
             // The observers are automatically disposed when the owner of the name changes because the sender uses the NameOwnerWatcher owner.
             await device.WatchStateChangedAsync(
-                (Exception? ex, (DeviceState NewState, DeviceState OldState, uint Reason) change) =>
+                change =>
                 {
-                    if (ex is null)
-                    {
-                        Console.WriteLine($"Interface '{interfaceName}' changed from '{change.OldState}' to '{change.NewState}'.");
-                    }
+                    Console.WriteLine($"Interface '{interfaceName}' changed from '{(DeviceState)change.OldState}' to '{(DeviceState)change.NewState}'.");
                 });
         }
 
@@ -59,8 +55,6 @@ while (true)
 
 namespace NetworkManager.DBus
 {
-    using System.Threading.Tasks;
-
     enum DeviceState : uint
     {
         Unknown = 0,
@@ -76,26 +70,5 @@ namespace NetworkManager.DBus
         Activated = 100,
         Deactivating = 110,
         Failed = 120
-    }
-
-    partial class Device
-    {
-        public ValueTask<IDisposable> WatchStateChangedAsync(Action<Exception?, (DeviceState NewState, DeviceState OldState, uint Reason)> handler, bool emitOnCapturedContext = true, ObserverFlags flags = ObserverFlags.None)
-        {
-            return Connection.WatchSignalAsync(
-                Destination,
-                Path,
-                DBusInterfaceName,
-                "StateChanged",
-                (Message m, object? s) =>
-                {
-                    var reader = m.GetBodyReader();
-                    return ((DeviceState)reader.ReadUInt32(), (DeviceState)reader.ReadUInt32(), reader.ReadUInt32());
-                },
-                handler,
-                this,
-                emitOnCapturedContext,
-                flags);
-        }
     }
 }

--- a/src/Tmds.DBus.Protocol/DBusConnection.cs
+++ b/src/Tmds.DBus.Protocol/DBusConnection.cs
@@ -304,12 +304,13 @@ public sealed partial class DBusConnection : IDisposable
     /// <typeparam name="T">The type of value read from matched messages.</typeparam>
     /// <param name="rule">The match rule defining which messages to receive.</param>
     /// <param name="reader">Delegate to read values from matched messages.</param>
-    /// <param name="handler">Callback invoked for each matched message.</param>
+    /// <param name="handler">Callback invoked for matched messages and completion notifications.</param>
     /// <param name="flags">Observer behavior flags.</param>
     /// <param name="readerState">Optional state passed to the reader delegate.</param>
     /// <param name="handlerState">Optional state passed to the handler delegate.</param>
-    /// <param name="emitOnCapturedContext">Whether to invoke the handler on the captured synchronization context.</param>
-    /// <returns><see cref="IDisposable"/> that removes the observer when disposed.</returns>
+    /// <param name="emitOnCapturedContext">Whether to invoke the handler on the current synchronization context.</param>
+    /// <returns><see cref="IDisposable"/> that stops the observer when disposed.</returns>
+    [Obsolete("Use the overload that accepts Action<Notification<T>> instead.")]
     public ValueTask<IDisposable> AddMatchAsync<T>(MatchRule rule, MessageValueReader<T> reader, Action<Exception?, T, object?, object?> handler, ObserverFlags flags, object? readerState = null, object? handlerState = null, bool emitOnCapturedContext = true)
         => AddMatchAsync(rule, reader, handler, readerState, handlerState, emitOnCapturedContext, flags);
 
@@ -319,12 +320,13 @@ public sealed partial class DBusConnection : IDisposable
     /// <typeparam name="T">The type of value read from matched messages.</typeparam>
     /// <param name="rule">The match rule defining which messages to receive.</param>
     /// <param name="reader">Delegate to read values from matched messages.</param>
-    /// <param name="handler">Callback invoked for each matched message.</param>
+    /// <param name="handler">Callback invoked for matched messages and completion notifications.</param>
     /// <param name="readerState">Optional state passed to the reader delegate.</param>
     /// <param name="handlerState">Optional state passed to the handler delegate.</param>
-    /// <param name="emitOnCapturedContext">Whether to invoke the handler on the captured synchronization context.</param>
+    /// <param name="emitOnCapturedContext">Whether to invoke the handler on the current synchronization context.</param>
     /// <param name="flags">Observer behavior flags.</param>
-    /// <returns><see cref="IDisposable"/> that removes the observer when disposed.</returns>
+    /// <returns><see cref="IDisposable"/> that stops the observer when disposed.</returns>
+    [Obsolete("Use the overload that accepts Action<Notification<T>> instead.")]
     public ValueTask<IDisposable> AddMatchAsync<T>(MatchRule rule, MessageValueReader<T> reader, Action<Exception?, T, object?, object?> handler, object? readerState, object? handlerState, bool emitOnCapturedContext, ObserverFlags flags)
         => AddMatchAsync(rule, reader, handler, readerState, handlerState, emitOnCapturedContext ? SynchronizationContext.Current : null, flags);
 
@@ -334,21 +336,93 @@ public sealed partial class DBusConnection : IDisposable
     /// <typeparam name="T">The type of value read from matched messages.</typeparam>
     /// <param name="rule">The match rule defining which messages to receive.</param>
     /// <param name="reader">Delegate to read values from matched messages.</param>
-    /// <param name="handler">Callback invoked for each matched message.</param>
+    /// <param name="handler">Callback invoked for matched messages and completion notifications.</param>
     /// <param name="readerState">Optional state passed to the reader delegate.</param>
     /// <param name="handlerState">Optional state passed to the handler delegate.</param>
     /// <param name="synchronizationContext">The synchronization context to invoke the handler on.</param>
     /// <param name="flags">Observer behavior flags.</param>
-    /// <returns><see cref="IDisposable"/> that removes the observer when disposed.</returns>
-    public async ValueTask<IDisposable> AddMatchAsync<T>(MatchRule rule, MessageValueReader<T> reader, Action<Exception?, T, object?, object?> handler, object? readerState , object? handlerState, SynchronizationContext? synchronizationContext, ObserverFlags flags)
-    {
-        InnerConnection connection = await ConnectCoreAsync().ConfigureAwait(false);
-        return await connection.AddMatchAsync(synchronizationContext, rule, reader, handler, readerState, handlerState, flags).ConfigureAwait(false);
-    }
+    /// <returns><see cref="IDisposable"/> that stops the observer when disposed.</returns>
+    [Obsolete("Use the overload that accepts Action<Notification<T>> instead.")]
+    public ValueTask<IDisposable> AddMatchAsync<T>(MatchRule rule, MessageValueReader<T> reader, Action<Exception?, T, object?, object?> handler, object? readerState , object? handlerState, SynchronizationContext? synchronizationContext, ObserverFlags flags)
+        => AddMatchAsync(synchronizationContext, rule, reader, static (observer, ex, value) => ((Action<Exception?, T, object?, object?>)observer.State3!)(observer.Exception, value, observer.ReaderState, observer.State2), readerState: readerState, state2: handlerState, state3: handler, flags: flags);
+
+    /// <summary>
+    /// Adds an observer to receive D-Bus messages matching the specified criteria.
+    /// </summary>
+    /// <typeparam name="T">The type of value read from matched messages.</typeparam>
+    /// <param name="rule">The match rule defining which messages to receive.</param>
+    /// <param name="reader">Delegate to read values from matched messages.</param>
+    /// <param name="handler">Callback invoked for matched messages and completion notifications.</param>
+    /// <param name="emitOnCapturedContext">Whether to invoke the handler on the current synchronization context.</param>
+    /// <param name="flags">Observer behavior flags.</param>
+    /// <param name="state">Optional state object.</param>
+    /// <returns><see cref="IDisposable"/> that stops the observer when disposed.</returns>
+    /// <remarks>
+    /// The handler must not throw exceptions. If the handler throws, the connection will be disconnected.
+    /// </remarks>
+    public ValueTask<IDisposable> AddMatchAsync<T>(MatchRule rule, MessageValueReader<T> reader, Action<Notification<T>> handler, bool emitOnCapturedContext = true, ObserverFlags flags = ObserverFlags.None, object? state = null)
+        => AddMatchAsync(rule, reader, handler, emitOnCapturedContext ? SynchronizationContext.Current : null, flags, state);
+
+    /// <summary>
+    /// Adds an observer to receive D-Bus messages matching the specified criteria.
+    /// </summary>
+    /// <typeparam name="T">The type of value read from matched messages.</typeparam>
+    /// <param name="rule">The match rule defining which messages to receive.</param>
+    /// <param name="reader">Delegate to read values from matched messages.</param>
+    /// <param name="handler">Callback invoked for matched messages and completion notifications.</param>
+    /// <param name="synchronizationContext">The synchronization context to invoke the handler on.</param>
+    /// <param name="flags">Observer behavior flags.</param>
+    /// <param name="state">Optional state object.</param>
+    /// <returns><see cref="IDisposable"/> that stops the observer when disposed.</returns>
+    /// <remarks>
+    /// The handler must not throw exceptions. If the handler throws, the connection will be disconnected.
+    /// </remarks>
+    public ValueTask<IDisposable> AddMatchAsync<T>(MatchRule rule, MessageValueReader<T> reader, Action<Notification<T>> handler, SynchronizationContext? synchronizationContext, ObserverFlags flags, object? state)
+        => AddMatchAsync(synchronizationContext, rule, reader, static (observer, ex, value) => ((Action<Notification<T>>)observer.State2!).Invoke(new Notification<T>(observer, value, isCompletion: ex is not null)), readerState: state, state2: handler, state3: null, flags: flags);
+
+    /// <summary>
+    /// Adds an observer to receive D-Bus messages matching the specified criteria.
+    /// </summary>
+    /// <param name="rule">The match rule defining which messages to receive.</param>
+    /// <param name="handler">Callback invoked for matched messages and completion notifications.</param>
+    /// <param name="emitOnCapturedContext">Whether to invoke the handler on the current synchronization context.</param>
+    /// <param name="flags">Observer behavior flags.</param>
+    /// <param name="state">Optional state object.</param>
+    /// <returns><see cref="IDisposable"/> that stops the observer when disposed.</returns>
+    /// <remarks>
+    /// The handler must not throw exceptions. If the handler throws, the connection will be disconnected.
+    /// </remarks>
+    public ValueTask<IDisposable> AddMatchAsync(MatchRule rule, Action<Notification> handler, bool emitOnCapturedContext = true, ObserverFlags flags = ObserverFlags.None, object? state = null)
+        => AddMatchAsync(rule, handler, emitOnCapturedContext ? SynchronizationContext.Current : null, flags, state);
+
+    /// <summary>
+    /// Adds an observer to receive D-Bus messages matching the specified criteria.
+    /// </summary>
+    /// <param name="rule">The match rule defining which messages to receive.</param>
+    /// <param name="handler">Callback invoked for matched messages and completion notifications.</param>
+    /// <param name="synchronizationContext">The synchronization context to invoke the handler on.</param>
+    /// <param name="flags">Observer behavior flags.</param>
+    /// <param name="state">Optional state object.</param>
+    /// <returns><see cref="IDisposable"/> that stops the observer when disposed.</returns>
+    /// <remarks>
+    /// The handler must not throw exceptions. If the handler throws, the connection will be disconnected.
+    /// </remarks>
+    public ValueTask<IDisposable> AddMatchAsync(MatchRule rule, Action<Notification> handler, SynchronizationContext? synchronizationContext, ObserverFlags flags, object? state)
+        => AddMatchAsync<object>(synchronizationContext, rule, (Message message, object? state) => null!, static (observer, ex, value) => ((Action<Notification>)observer.State2!).Invoke(new Notification(observer, isCompletion: ex is not null)), readerState: state, state2: handler, state3: null, flags: flags);
 
     /// <summary>
     /// Watches for property changes.
     /// </summary>
+    /// <param name="sender">The sender to match (optional).</param>
+    /// <param name="path">The object path to match (optional).</param>
+    /// <param name="interface">The interface name.</param>
+    /// <param name="reader">Delegate to read values from matched messages.</param>
+    /// <param name="handler">Callback invoked for matched signals and completion notifications.</param>
+    /// <param name="readerState">Optional state passed to the reader delegate.</param>
+    /// <param name="emitOnCapturedContext">Whether to invoke the handler on the current synchronization context.</param>
+    /// <param name="flags">Observer behavior flags.</param>
+    /// <returns><see cref="IDisposable"/> that stops the observer when disposed.</returns>
+    [Obsolete("Use the overload that accepts Action<Notification<T>> instead.")]
     public ValueTask<IDisposable> WatchPropertiesChangedAsync<T>(string? sender, string? path, string @interface, MessageValueReader<T> reader, Action<Exception?, T> handler, object? readerState, bool emitOnCapturedContext, ObserverFlags flags)
     {
         if (string.IsNullOrEmpty(@interface))
@@ -366,8 +440,68 @@ public sealed partial class DBusConnection : IDisposable
     }
 
     /// <summary>
+    /// Watches for property changes.
+    /// </summary>
+    /// <param name="sender">The sender to match (optional).</param>
+    /// <param name="path">The object path to match (optional).</param>
+    /// <param name="interface">The interface name.</param>
+    /// <param name="reader">Delegate to read values from matched messages.</param>
+    /// <param name="handler">Callback invoked for matched signals and completion notifications.</param>
+    /// <param name="synchronizationContext">The synchronization context to invoke the handler on.</param>
+    /// <param name="flags">Observer behavior flags.</param>
+    /// <param name="state">Optional state object.</param>
+    /// <returns><see cref="IDisposable"/> that stops the observer when disposed.</returns>
+    /// <remarks>
+    /// The handler must not throw exceptions. If the handler throws, the connection will be disconnected.
+    /// </remarks>
+    public ValueTask<IDisposable> WatchPropertiesChangedAsync<T>(string? sender, string? path, string @interface, MessageValueReader<T> reader, Action<Notification<T>> handler, SynchronizationContext? synchronizationContext, ObserverFlags flags, object? state)
+    {
+        if (string.IsNullOrEmpty(@interface))
+            throw new ArgumentException("Value cannot be null or empty.", nameof(@interface));
+        var rule = new MatchRule
+        {
+            Type = MessageType.Signal,
+            Sender = sender,
+            Path = path,
+            Interface = "org.freedesktop.DBus.Properties",
+            Member = "PropertiesChanged",
+            Arg0 = @interface
+        };
+        return AddMatchAsync(rule, reader, handler, synchronizationContext, flags, state);
+    }
+
+    /// <summary>
+    /// Watches for property changes.
+    /// </summary>
+    /// <param name="sender">The sender to match (optional).</param>
+    /// <param name="path">The object path to match (optional).</param>
+    /// <param name="interface">The interface name.</param>
+    /// <param name="reader">Delegate to read values from matched messages.</param>
+    /// <param name="handler">Callback invoked for matched signals and completion notifications.</param>
+    /// <param name="flags">Observer behavior flags.</param>
+    /// <param name="emitOnCapturedContext">Whether to invoke the handler on the current synchronization context.</param>
+    /// <param name="state">Optional state object.</param>
+    /// <returns><see cref="IDisposable"/> that stops the observer when disposed.</returns>
+    /// <remarks>
+    /// The handler must not throw exceptions. If the handler throws, the connection will be disconnected.
+    /// </remarks>
+    public ValueTask<IDisposable> WatchPropertiesChangedAsync<T>(string? sender, string? path, string @interface, MessageValueReader<T> reader, Action<Notification<T>> handler, ObserverFlags flags, bool emitOnCapturedContext = true, object? state = null)
+        => WatchPropertiesChangedAsync(sender, path, @interface, reader, handler, emitOnCapturedContext ? SynchronizationContext.Current : null, flags, state);
+
+    /// <summary>
     /// Watches for a D-Bus signal.
     /// </summary>
+    /// <param name="sender">The sender to match (optional).</param>
+    /// <param name="path">The object path to match (optional).</param>
+    /// <param name="interface">The interface name.</param>
+    /// <param name="signal">The signal name.</param>
+    /// <param name="reader">Delegate to read values from matched messages.</param>
+    /// <param name="handler">Callback invoked for matched signals and completion notifications.</param>
+    /// <param name="readerState">Optional state passed to the reader delegate.</param>
+    /// <param name="emitOnCapturedContext">Whether to invoke the handler on the current synchronization context.</param>
+    /// <param name="flags">Observer behavior flags.</param>
+    /// <returns><see cref="IDisposable"/> that stops the observer when disposed.</returns>
+    [Obsolete("Use the overload that accepts Action<Notification<T>> instead.")]
     public ValueTask<IDisposable> WatchSignalAsync<T>(string? sender, string? path, string @interface, string signal, MessageValueReader<T> reader, Action<Exception?, T> handler, object? readerState, bool emitOnCapturedContext, ObserverFlags flags)
     {
         if (string.IsNullOrEmpty(@interface))
@@ -388,6 +522,118 @@ public sealed partial class DBusConnection : IDisposable
     /// <summary>
     /// Watches for a D-Bus signal.
     /// </summary>
+    /// <param name="sender">The sender to match (optional).</param>
+    /// <param name="path">The object path to match (optional).</param>
+    /// <param name="interface">The interface name.</param>
+    /// <param name="signal">The signal name.</param>
+    /// <param name="reader">Delegate to read values from matched messages.</param>
+    /// <param name="handler">Callback invoked for matched signals and completion notifications.</param>
+    /// <param name="synchronizationContext">The synchronization context to invoke the handler on.</param>
+    /// <param name="flags">Observer behavior flags.</param>
+    /// <param name="state">Optional state object.</param>
+    /// <returns><see cref="IDisposable"/> that stops the observer when disposed.</returns>
+    /// <remarks>
+    /// The handler must not throw exceptions. If the handler throws, the connection will be disconnected.
+    /// </remarks>
+    public ValueTask<IDisposable> WatchSignalAsync<T>(string? sender, string? path, string @interface, string signal, MessageValueReader<T> reader, Action<Notification<T>> handler, SynchronizationContext? synchronizationContext, ObserverFlags flags, object? state)
+    {
+        if (string.IsNullOrEmpty(@interface))
+            throw new ArgumentException("Value cannot be null or empty.", nameof(@interface));
+        if (string.IsNullOrEmpty(signal))
+            throw new ArgumentException("Value cannot be null or empty.", nameof(signal));
+        var rule = new MatchRule
+        {
+            Type = MessageType.Signal,
+            Sender = sender,
+            Path = path,
+            Member = signal,
+            Interface = @interface
+        };
+        return AddMatchAsync(rule, reader, handler, synchronizationContext, flags, state);
+    }
+
+    /// <summary>
+    /// Watches for a D-Bus signal.
+    /// </summary>
+    /// <param name="sender">The sender to match (optional).</param>
+    /// <param name="path">The object path to match (optional).</param>
+    /// <param name="interface">The interface name.</param>
+    /// <param name="signal">The signal name.</param>
+    /// <param name="handler">Callback invoked for matched signals and completion notifications.</param>
+    /// <param name="synchronizationContext">The synchronization context to invoke the handler on.</param>
+    /// <param name="flags">Observer behavior flags.</param>
+    /// <param name="state">Optional state object.</param>
+    /// <returns><see cref="IDisposable"/> that stops the observer when disposed.</returns>
+    /// <remarks>
+    /// The handler must not throw exceptions. If the handler throws, the connection will be disconnected.
+    /// </remarks>
+    public ValueTask<IDisposable> WatchSignalAsync(string? sender, string? path, string @interface, string signal, Action<Notification> handler, SynchronizationContext? synchronizationContext, ObserverFlags flags, object? state)
+    {
+        if (string.IsNullOrEmpty(@interface))
+            throw new ArgumentException("Value cannot be null or empty.", nameof(@interface));
+        if (string.IsNullOrEmpty(signal))
+            throw new ArgumentException("Value cannot be null or empty.", nameof(signal));
+        var rule = new MatchRule
+        {
+            Type = MessageType.Signal,
+            Sender = sender,
+            Path = path,
+            Member = signal,
+            Interface = @interface
+        };
+        return AddMatchAsync(rule, handler, synchronizationContext, flags, state);
+    }
+
+    /// <summary>
+    /// Watches for a D-Bus signal.
+    /// </summary>
+    /// <param name="sender">The sender to match (optional).</param>
+    /// <param name="path">The object path to match (optional).</param>
+    /// <param name="interface">The interface name.</param>
+    /// <param name="signal">The signal name.</param>
+    /// <param name="reader">Delegate to read values from matched messages.</param>
+    /// <param name="handler">Callback invoked for matched signals and completion notifications.</param>
+    /// <param name="flags">Observer behavior flags.</param>
+    /// <param name="emitOnCapturedContext">Whether to invoke the handler on the current synchronization context.</param>
+    /// <param name="state">Optional state object.</param>
+    /// <returns><see cref="IDisposable"/> that stops the observer when disposed.</returns>
+    /// <remarks>
+    /// The handler must not throw exceptions. If the handler throws, the connection will be disconnected.
+    /// </remarks>
+    public ValueTask<IDisposable> WatchSignalAsync<T>(string? sender, string? path, string @interface, string signal, MessageValueReader<T> reader, Action<Notification<T>> handler, ObserverFlags flags, bool emitOnCapturedContext = true, object? state = null)
+        => WatchSignalAsync(sender, path, @interface, signal, reader, handler, emitOnCapturedContext ? SynchronizationContext.Current : null, flags, state);
+
+    /// <summary>
+    /// Watches for a D-Bus signal.
+    /// </summary>
+    /// <param name="sender">The sender to match (optional).</param>
+    /// <param name="path">The object path to match (optional).</param>
+    /// <param name="interface">The interface name.</param>
+    /// <param name="signal">The signal name.</param>
+    /// <param name="handler">Callback invoked for matched signals and completion notifications.</param>
+    /// <param name="flags">Observer behavior flags.</param>
+    /// <param name="emitOnCapturedContext">Whether to invoke the handler on the current synchronization context.</param>
+    /// <param name="state">Optional state object.</param>
+    /// <returns><see cref="IDisposable"/> that stops the observer when disposed.</returns>
+    /// <remarks>
+    /// The handler must not throw exceptions. If the handler throws, the connection will be disconnected.
+    /// </remarks>
+    public ValueTask<IDisposable> WatchSignalAsync(string? sender, string? path, string @interface, string signal, Action<Notification> handler, ObserverFlags flags, bool emitOnCapturedContext = true, object? state = null)
+        => WatchSignalAsync(sender, path, @interface, signal, handler, emitOnCapturedContext ? SynchronizationContext.Current : null, flags, state);
+
+    /// <summary>
+    /// Watches for a D-Bus signal.
+    /// </summary>
+    /// <param name="sender">The sender to match (optional).</param>
+    /// <param name="path">The object path to match (optional).</param>
+    /// <param name="interface">The interface name.</param>
+    /// <param name="signal">The signal name.</param>
+    /// <param name="handler">Callback invoked for matched signals and completion notifications.</param>
+    /// <param name="readerState">Optional state passed to the reader delegate.</param>
+    /// <param name="emitOnCapturedContext">Whether to invoke the handler on the current synchronization context.</param>
+    /// <param name="flags">Observer behavior flags.</param>
+    /// <returns><see cref="IDisposable"/> that stops the observer when disposed.</returns>
+    [Obsolete("Use the overload that accepts Action<Notification> instead.")]
     public ValueTask<IDisposable> WatchSignalAsync(string? sender, string? path, string @interface, string signal, Action<Exception?> handler, object? readerState, bool emitOnCapturedContext, ObserverFlags flags)
     {
         if (string.IsNullOrEmpty(@interface))
@@ -556,4 +802,10 @@ public sealed partial class DBusConnection : IDisposable
     }
 
     internal uint GetNextSerial() => (uint)Interlocked.Increment(ref _nextSerial);
+
+    private async ValueTask<IDisposable> AddMatchAsync<T>(SynchronizationContext? synchronizationContext, MatchRule rule, MessageValueReader<T> valueReader, Action<InnerConnection.Observer, Exception?, T> valueHandler, object? readerState, object? state2, object? state3, ObserverFlags flags)
+    {
+        InnerConnection connection = await ConnectCoreAsync().ConfigureAwait(false);
+        return await connection.AddMatchAsync(synchronizationContext, rule, valueReader, valueHandler, readerState: readerState, state2: state2, state3: state3, flags: flags).ConfigureAwait(false);
+    }
 }

--- a/src/Tmds.DBus.Protocol/DBusOwnerChangedException.cs
+++ b/src/Tmds.DBus.Protocol/DBusOwnerChangedException.cs
@@ -3,7 +3,7 @@ namespace Tmds.DBus.Protocol;
 /// <summary>
 /// The exception that is thrown when the owner of a D-Bus well-known name has changed.
 /// </summary>
-public class DBusOwnerChangedException : DBusMessageException
+public sealed class DBusOwnerChangedException : DBusMessageException
 {
     /// <summary>
     /// Initializes a new instance of the DBusOwnerChangedException class.

--- a/src/Tmds.DBus.Protocol/InnerConnection.cs
+++ b/src/Tmds.DBus.Protocol/InnerConnection.cs
@@ -6,7 +6,13 @@ namespace Tmds.DBus.Protocol;
 
 class InnerConnection : IDisposable
 {
+    private static ObserverFlags DelayedCompletion => (ObserverFlags)(1 << 31);
+    private static ObserverFlags IsExecutingHandlerFlag => (ObserverFlags)(1 << 30);
     private static ObserverFlags StopOnOwnerChanged => (ObserverFlags)(1 << 29);
+
+    private static readonly ObjectDisposedException ObserverDisposedExceptionSingleton = new ObserverDisposedException();
+    private static readonly DBusOwnerChangedException OwnerChangedExceptionSingleton = new DBusOwnerChangedException();
+    private static readonly DBusConnectionClosedException DisconnectedExceptionSingleton = new DBusConnectionClosedException("The connection was disconnected.");
 
     private delegate void MessageReceivedHandler(Exception? exception, Message? message, object? state);
 
@@ -455,7 +461,7 @@ class InnerConnection : IDisposable
                     {
                         foreach (var observer in ownerChangedObservers)
                         {
-                            observer.Dispose(observer.EmitOnOwnerChanged ? new DBusOwnerChangedException() : null);
+                            observer.Dispose(OwnerChangedExceptionSingleton, emit: observer.EmitOnOwnerChanged);
                         }
                     }
 
@@ -568,10 +574,8 @@ class InnerConnection : IDisposable
         {
             foreach (var observer in watcher.Observers)
             {
-                bool emitException = !object.ReferenceEquals(disconnectReason, DBusConnection.DisposedException) ||
-                                     observer.EmitOnConnectionDispose;
-                Exception? exception = emitException ? new DBusConnectionClosedException(disconnectReason) : null;
-                observer.Dispose(exception, removeObserver: false);
+                bool emitException = ReferenceEquals(disconnectReason, DBusConnection.DisposedException) ? observer.EmitOnConnectionDispose : observer.EmitOnConnectionFailed;
+                observer.Dispose(DisconnectedExceptionSingleton, emitException, removeObserver: false);
             }
             if (watcher.SubscribeTask is not null)
             {
@@ -814,7 +818,7 @@ class InnerConnection : IDisposable
         }
     }
 
-    public async ValueTask<IDisposable> AddMatchAsync<T>(SynchronizationContext? synchronizationContext, MatchRule rule, MessageValueReader<T> valueReader, Action<Exception?, T, object?, object?> valueHandler, object? readerState, object? handlerState, ObserverFlags flags)
+    public async ValueTask<IDisposable> AddMatchAsync<T>(SynchronizationContext? synchronizationContext, MatchRule rule, MessageValueReader<T> valueReader, Action<Observer, Exception?, T> valueHandler, object? readerState, object? state2, object? state3, ObserverFlags flags)
     {
         if (BusName.IsOwnerIdentifier(rule.Sender.AsSpan()))
         {
@@ -825,7 +829,7 @@ class InnerConnection : IDisposable
             flags |= ObserverFlags.NoSubscribe;
             flags &= ~(ObserverFlags.EmitOnOwnerChanged | StopOnOwnerChanged);
         }
-        Observer observer = Observer.Create(synchronizationContext, valueReader, valueHandler, readerState, handlerState, flags);
+        Observer observer = Observer.Create(synchronizationContext, valueReader, valueHandler, readerState, state2, state3, flags);
         await AddWatcherUserAsync(rule.Data, observer);
         return observer;
     }
@@ -956,7 +960,7 @@ class InnerConnection : IDisposable
         if (emitOwnerChanged)
         {
             Debug.Assert(observer is not null);
-            observer.Dispose(observer.EmitOnOwnerChanged ? new DBusOwnerChangedException() : null, removeObserver: false);
+            observer.Dispose(OwnerChangedExceptionSingleton, emit: observer.EmitOnOwnerChanged, removeObserver: false);
             return new ValueTask<Watcher?>(result: null);
         }
 
@@ -1001,13 +1005,13 @@ class InnerConnection : IDisposable
                     await watcher.SubscribeTask!.ConfigureAwait(false);
                 }
             }
-            catch
+            catch (Exception ex)
             {
                 EnsureExceptionObserved(resolveUniqueNameTask);
 
                 if (observer is not null)
                 {
-                    bool disposedObserver = observer.Dispose(exception: null);
+                    bool disposedObserver = observer.Dispose(ex, emit: false);
                     // If something had already disposed the observer, we won't throw and just return it.
                     // The handler took care of the exception (if ObserverFlags registered for it).
                     if (disposedObserver)
@@ -1058,106 +1062,195 @@ class InnerConnection : IDisposable
         }
     }
 
-    internal static readonly ObjectDisposedException ObserverDisposedException = new ObjectDisposedException(typeof(Observer).FullName);
+    internal static NotificationType DetermineNotificationType(Exception? exception, InnerConnection? connection)
+    {
+        if (exception is null)
+        {
+            return NotificationType.Value;
+        }
+        if (exception is ObserverDisposedException)
+        {
+            return NotificationType.ObserverDisposed;
+        }
+        if (exception is DBusOwnerChangedException)
+        {
+            return NotificationType.OwnerChanged;
+        }
+        if (exception is DBusConnectionClosedException closedException)
+        {
+            Exception? innerException = closedException.InnerException;
+            if (ReferenceEquals(closedException, DisconnectedExceptionSingleton))
+            {
+                Debug.Assert(connection is not null, "DisconnectedExceptionSingleton requires a connection to distinguish closed vs failed.");
+                innerException = connection?.DisconnectReason;
+            }
+            if (ReferenceEquals(innerException, DBusConnection.DisposedException))
+            {
+                return NotificationType.ConnectionClosed;
+            }
+            return NotificationType.ConnectionFailed;
+        }
+        Debug.Assert(exception is DBusReadException);
+        return NotificationType.ReaderFailed;
+    }
 
     internal sealed class Observer : IDisposable
     {
-        private delegate void MessageHandlerDelegate4(Observer observer, Exception? exception, Message? message, object? state1, object? state2, object? state3, object? state4);
-
-        private readonly struct MessageHandler4
-        {
-            public MessageHandler4(MessageHandlerDelegate4 handler, object? state1 = null, object? state2 = null, object? state3 = null, object? state4 = null)
-            {
-                _delegate = handler;
-                _state1 = state1;
-                _state2 = state2;
-                _state3 = state3;
-                _state4 = state4;
-            }
-
-            public void Invoke(Observer observer, Exception? exception, Message? message)
-            {
-                _delegate(observer, exception, message, _state1, _state2, _state3, _state4);
-            }
-
-            public bool HasValue => _delegate is not null;
-
-            private readonly MessageHandlerDelegate4 _delegate;
-            private readonly object? _state1;
-            private readonly object? _state2;
-            private readonly object? _state3;
-            private readonly object? _state4;
-        }
-
         private readonly Lock _gate = new();
         private readonly SynchronizationContext? _synchronizationContext;
-        private readonly MessageHandler4 _messageHandler;
+        private readonly Action<Observer, Message?> _messageHandler;
         private readonly SendOrPostCallback _scMessageCallback;
-        private readonly ObserverFlags _flags;
-        private bool _disposed;
+        private ObserverFlags _flags;
+        private readonly object? _readerState;
+        private readonly object? _state2;
+        private readonly object? _state3;
+        private Exception? _disposeException;
+
+        internal bool IsDisposed => _disposeException is not null;
 
         public bool Subscribes => (_flags & ObserverFlags.NoSubscribe) == 0;
-        public bool EmitOnConnectionDispose => (_flags & ObserverFlags.EmitOnConnectionDispose) != 0;
+        public bool EmitOnConnectionDispose => (_flags & ObserverFlags.EmitOnConnectionClosed) != 0;
+        public bool EmitOnConnectionFailed => (_flags & ObserverFlags.EmitOnConnectionFailed) != 0;
         public bool EmitOnObserverDispose => (_flags & ObserverFlags.EmitOnObserverDispose) != 0;
+        public bool EmitOnReaderFailed => (_flags & ObserverFlags.EmitOnReaderFailed) != 0;
         public bool EmitOnOwnerChanged => (_flags & ObserverFlags.EmitOnOwnerChanged) != 0;
         public bool StopOnOwnerChanged => (_flags & InnerConnection.StopOnOwnerChanged) != 0;
         public bool ObservesOwnerChanged => (_flags & (ObserverFlags.EmitOnOwnerChanged | InnerConnection.StopOnOwnerChanged)) != 0;
+        public object? ReaderState => _readerState;
+        public object? State2 => _state2;
+        public object? State3 => _state3;
         public InnerConnection Connection => Watcher.DBusConnection;
-
         internal Watcher Watcher = null!;
 
-        private Observer(SynchronizationContext? synchronizationContext, in MessageHandler4 messageHandler, ObserverFlags flags)
+        public Exception? Exception
+        {
+            get
+            {
+                // The getter lazily replaces singleton exceptions with proper instances.
+                if (ReferenceEquals(_disposeException, ObserverDisposedExceptionSingleton))
+                {
+                    _disposeException = new ObserverDisposedException();
+                }
+                else if (ReferenceEquals(_disposeException, OwnerChangedExceptionSingleton))
+                {
+                    _disposeException = new DBusOwnerChangedException();
+                }
+                else if (ReferenceEquals(_disposeException, DisconnectedExceptionSingleton))
+                {
+                    _disposeException = new DBusConnectionClosedException(Connection.DisconnectReason);
+                }
+                return _disposeException;
+            }
+        }
+
+        public NotificationType ErrorType => DetermineNotificationType(_disposeException, Connection);
+
+        private Observer(SynchronizationContext? synchronizationContext, Action<Observer, Message?> messageHandler, object? state1, object? state2, object? state3, ObserverFlags flags)
         {
             _synchronizationContext = synchronizationContext;
             _messageHandler = messageHandler;
+            _readerState = state1;
+            _state2 = state2;
+            _state3 = state3;
             _flags = flags;
             _scMessageCallback ??= EmitMessageOnSynchronizationContext;
         }
 
-        public static Observer Create<T>(SynchronizationContext? synchronizationContext, MessageValueReader<T> valueReader, Action<Exception?, T, object?, object?> valueHandler, object? readerState, object? handlerState, ObserverFlags flags)
+        internal static Observer Create<T>(SynchronizationContext? synchronizationContext, MessageValueReader<T> valueReader, Action<Observer, Exception?, T> valueHandler, object? readerState, object? state2, object? state3, ObserverFlags flags)
         {
-            MessageHandlerDelegate4 fn = static (Observer observer, Exception? exception, Message? message, object? reader, object? handler, object? rs, object? hs) =>
+            Action<Observer, Message?> handler = (observer, message) =>
             {
                 try
                 {
-                    var valueHandlerState = (Action<Exception?, T, object?, object?>)handler!;
-                    if (exception is not null)
+                    if (message is null)
                     {
-                        valueHandlerState(exception, default(T)!, rs, hs);
-                        return;
+                        bool isExecuting = (observer._flags & IsExecutingHandlerFlag) != 0;
+                        if (isExecuting)
+                        {
+                            // Since we're holding the lock, the exception was thrown due to the executing handler doing something.
+                            // Don't re-enter the handler, we'll call it once it finished executing.
+                            observer._flags |= DelayedCompletion;
+                            return;
+                        }
+                        EmitCompletion();
                     }
-                    Debug.Assert(message is not null);
-                    var valueReaderState = (MessageValueReader<T>)reader!;
-                    T value = valueReaderState(message, rs);
-                    valueHandlerState(null, value, rs, hs);
+                    else
+                    {
+                        Debug.Assert((observer._flags & IsExecutingHandlerFlag) == 0);
+
+                        // We support passing an exception from the read delegate to the handler using EmitOnReaderFailed.
+                        // The reader is typically source-generated.
+                        // It's not expected to throw unless the sender sends something that doesn't match the expected content.
+                        T value;
+                        try
+                        {
+                            value = valueReader(message, observer.ReaderState);
+                        }
+                        catch (Exception ex) when (observer.EmitOnReaderFailed)
+                        {
+                            // Wrap the exception to ensure we preserve the stack trace if the user throws it.
+                            observer.Dispose(new DBusReadException("The handler encountered an error while reading the message.", ex), emit: true, ignoreSynchronizationContext: true);
+                            return;
+                        }
+
+                        try
+                        {
+                            observer._flags |= IsExecutingHandlerFlag;
+                            valueHandler(observer, null, value);
+                        }
+                        finally
+                        {
+                            observer._flags &= ~IsExecutingHandlerFlag;
+                        }
+                        bool hasDelayedCompletion = (observer._flags & DelayedCompletion) != 0;
+                        if (hasDelayedCompletion)
+                        {
+                            EmitCompletion();
+                        }
+                    }
                 }
                 catch (Exception ex)
                 {
                     observer.Connection.Disconnect(ex);
                 }
+
+                void EmitCompletion()
+                {
+                    Debug.Assert(observer._disposeException is not null);
+                    try
+                    {
+                        valueHandler(observer, observer._disposeException, default!);
+                    }
+                    catch (Exception ex)
+                    {
+                        observer.Connection.Disconnect(ex);
+                    }
+                }
             };
 
-            MessageHandler4 handler = new(fn, valueReader, valueHandler, readerState, handlerState);
-            return new Observer(synchronizationContext, handler, flags);
+            return new Observer(synchronizationContext, handler, readerState, state2, state3, flags);
         }
 
         public void Dispose() =>
-            Dispose(EmitOnObserverDispose ? ObserverDisposedException : null);
+            Dispose(ObserverDisposedExceptionSingleton, EmitOnObserverDispose);
 
-        public bool Dispose(Exception? exception, bool removeObserver = true, bool ignoreSynchronizationContext = false)
+        public void StopByHandler() =>
+            Dispose(ObserverDisposedExceptionSingleton, emit: false);
+
+        public bool Dispose(Exception exception, bool emit, bool removeObserver = true, bool ignoreSynchronizationContext = false)
         {
             lock (_gate)
             {
-                if (_disposed)
+                if (IsDisposed)
                 {
                     return false;
                 }
-                _disposed = true;
+                _disposeException = exception;
             }
 
-            if (exception is not null)
+            if (emit)
             {
-                Emit(exception, ignoreSynchronizationContext);
+                EmitCompletion(ignoreSynchronizationContext);
             }
 
             if (removeObserver)
@@ -1179,17 +1272,17 @@ class InnerConnection : IDisposable
             {
                 lock (_gate)
                 {
-                    if (_disposed)
+                    if (IsDisposed)
                     {
                         return;
                     }
 
-                    _messageHandler.Invoke(this, null, message);
+                    _messageHandler(this, message);
                 }
             }
             else
             {
-                if (_disposed)
+                if (IsDisposed)
                 {
                     return;
                 }
@@ -1207,11 +1300,11 @@ class InnerConnection : IDisposable
                 SynchronizationContext.SetSynchronizationContext(_synchronizationContext);
                 lock (_gate)
                 {
-                    if (_disposed)
+                    if (IsDisposed)
                     {
                         return;
                     }
-                    _messageHandler.Invoke(this, null, message);
+                    _messageHandler(this, message);
                 }
             }
             finally
@@ -1221,27 +1314,28 @@ class InnerConnection : IDisposable
             }
         }
 
-        private void Emit(Exception exception, bool ignoreSynchronizationContext = false)
+        private void EmitCompletion(bool ignoreSynchronizationContext = false)
         {
+            Debug.Assert(_disposeException is not null);
             if (ignoreSynchronizationContext ||
                 _synchronizationContext is null ||
                 SynchronizationContext.Current == _synchronizationContext)
             {
-                _messageHandler.Invoke(this, exception, null!);
+                _messageHandler(this, null);
             }
             else
             {
-                _synchronizationContext.Post(EmitExceptionOnSynchronizationContext, exception);
+                _synchronizationContext.Post(EmitCompletionOnSynchronizationContext, null);
             }
         }
 
-        private void EmitExceptionOnSynchronizationContext(object? state)
+        private void EmitCompletionOnSynchronizationContext(object? state)
         {
             SynchronizationContext? previousContext = SynchronizationContext.Current;
             try
             {
                 SynchronizationContext.SetSynchronizationContext(_synchronizationContext);
-                _messageHandler.Invoke(this, (Exception)state!, null!);
+                _messageHandler(this, null);
             }
             finally
             {
@@ -1258,12 +1352,12 @@ class InnerConnection : IDisposable
 
             lock (_gate)
             {
-                if (_disposed)
+                if (IsDisposed)
                 {
                     return;
                 }
 
-                _messageHandler.Invoke(this, null, message);
+                _messageHandler(this, message);
             }
         }
     }
@@ -1609,7 +1703,6 @@ class InnerConnection : IDisposable
 
             return true;
         }
-
 
         private static bool IsEqualOrChildOfName(ReadOnlySpan<byte> lhs, ReadOnlySpan<byte> rhs)
         {

--- a/src/Tmds.DBus.Protocol/Notification.cs
+++ b/src/Tmds.DBus.Protocol/Notification.cs
@@ -1,0 +1,131 @@
+namespace Tmds.DBus.Protocol;
+
+/// <summary>
+/// Notification that indicates a value was received or that the observer completed.
+/// </summary>
+/// <remarks>The completion notifications are limited to those specified with the <see cref="ObserverFlags"/>.</remarks>
+public readonly struct Notification
+{
+    private readonly InnerConnection.Observer? _observer;
+    private readonly bool _isCompletion;
+
+    internal Notification(InnerConnection.Observer observer, bool isCompletion)
+    {
+        _observer = observer;
+        _isCompletion = isCompletion;
+    }
+
+    /// <summary>
+    /// Returns an exception that indicates why the observer completed.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">The notification is not a completion.</exception>
+    public Exception Exception
+    {
+        get
+        {
+            if (!_isCompletion)
+            {
+                ThrowHelper.ThrowNotificationExceptionNotAvailable();
+            }
+            return _observer!.Exception!;
+        }
+    }
+
+    /// <summary>
+    /// Gets the type of notification.
+    /// </summary>
+    public NotificationType Type => _observer is null ? default : (_isCompletion ? _observer.ErrorType : NotificationType.Value);
+
+    /// <summary>
+    /// Returns whether this is a completion notification.
+    /// </summary>
+    public bool IsCompletion => _isCompletion;
+
+    /// <summary>
+    /// Gets the optional state object.
+    /// </summary>
+    public object? State => _observer?.ReaderState;
+
+    /// <summary>
+    /// Stops the observer. No more notifications will be received.
+    /// </summary>
+    /// <remarks>No completion notification will be sent for the dispose.</remarks>
+    public void Stop() => _observer?.StopByHandler();
+}
+
+/// <summary>
+/// Notification that indicates a value was received or that the observer completed.
+/// </summary>
+/// <remarks>The completion notifications are limited to those specified with the <see cref="ObserverFlags"/>.</remarks>
+/// <typeparam name="T">The type of the value that was read from the message.</typeparam>
+public readonly struct Notification<T>
+{
+    private readonly InnerConnection.Observer? _observer;
+    private readonly T _value;
+    private readonly bool _isCompletion;
+
+    internal Notification(InnerConnection.Observer observer, T value, bool isCompletion)
+    {
+        _observer = observer;
+        _value = value;
+        _isCompletion = isCompletion;
+    }
+
+    /// <summary>
+    /// Returns an exception that indicates why the observer completed.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">The notification is not a completion.</exception>
+    public Exception Exception
+    {
+        get
+        {
+            if (!_isCompletion)
+            {
+                ThrowHelper.ThrowNotificationExceptionNotAvailable();
+            }
+            return _observer!.Exception!;
+        }
+    }
+
+    /// <summary>
+    /// Gets the type of notification.
+    /// </summary>
+    public NotificationType Type => _observer is null ? default : (_isCompletion ? _observer.ErrorType : NotificationType.Value);
+
+    /// <summary>
+    /// Returns whether a value was successfully read from the message.
+    /// </summary>
+    public bool HasValue => _observer is not null && !_isCompletion;
+
+    /// <summary>
+    /// Returns whether this is a completion notification.
+    /// </summary>
+    public bool IsCompletion => _isCompletion;
+
+    /// <summary>
+    /// Gets the value read from the message.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">The notification is not a value as indicated by <see cref="HasValue"/>.</exception>
+    public T Value
+    {
+        get
+        {
+            if (!HasValue)
+            {
+                ThrowHelper.ThrowNotificationValueNotAvailable();
+            }
+            return _value;
+        }
+    }
+
+    /// <summary>
+    /// Gets the optional state object.
+    /// </summary>
+    public object? State => _observer?.ReaderState;
+
+    /// <summary>
+    /// Stops the observer. No more notifications will be received.
+    /// </summary>
+    /// <remarks>No completion notification will be sent for the dispose.</remarks>
+    public void Stop() => _observer?.StopByHandler();
+}

--- a/src/Tmds.DBus.Protocol/NotificationType.cs
+++ b/src/Tmds.DBus.Protocol/NotificationType.cs
@@ -1,0 +1,34 @@
+namespace Tmds.DBus.Protocol;
+
+/// <summary>
+/// Indicates the type of notification.
+/// </summary>
+public enum NotificationType
+{
+    // '0' is not used so that uninitialized values are not considered a valid notification type.
+
+    /// <summary>
+    /// A value was successfully read.
+    /// </summary>
+    Value = 1,
+    /// <summary>
+    /// The observer was disposed.
+    /// </summary>
+    ObserverDisposed = 2,
+    /// <summary>
+    /// The connection was closed.
+    /// </summary>
+    ConnectionClosed = 3,
+    /// <summary>
+    /// The connection failed.
+    /// </summary>
+    ConnectionFailed = 4,
+    /// <summary>
+    /// The reader failed.
+    /// </summary>
+    ReaderFailed = 5,
+    /// <summary>
+    /// The owner of the matched bus name changed.
+    /// </summary>
+    OwnerChanged = 6,
+}

--- a/src/Tmds.DBus.Protocol/ObserverDisposedException.cs
+++ b/src/Tmds.DBus.Protocol/ObserverDisposedException.cs
@@ -1,0 +1,7 @@
+namespace Tmds.DBus.Protocol;
+
+sealed class ObserverDisposedException : ObjectDisposedException
+{
+    public ObserverDisposedException() : base("Tmds.DBus.Protocol.Observer")
+    { }
+}

--- a/src/Tmds.DBus.Protocol/ObserverFlags.cs
+++ b/src/Tmds.DBus.Protocol/ObserverFlags.cs
@@ -11,28 +11,42 @@ public enum ObserverFlags
     /// </summary>
     None = 0,
     /// <summary>
-    /// Emit a completion exception when the connection is disposed.
+    /// Emit a completion notification (<see cref="NotificationType.ConnectionClosed"/>) when the connection is disposed.
     /// </summary>
-    /// <remarks>Use <see cref="ObserverHandler.IsConnectionDisposed"/> to check for this exception.</remarks>
+    [Obsolete("Use EmitOnConnectionClosed instead.")]
     EmitOnConnectionDispose = 1,
     /// <summary>
-    /// Emit a completion exception when the observer is disposed.
+    /// Emit a completion notification (<see cref="NotificationType.ConnectionClosed"/>) when the connection is closed.
     /// </summary>
-    /// <remarks>Use <see cref="ObserverHandler.IsObserverDisposed"/> to check for this exception.</remarks>
+    EmitOnConnectionClosed = 1,
+    /// <summary>
+    /// Emit a completion notification (<see cref="NotificationType.ObserverDisposed"/>) when the observer is disposed.
+    /// </summary>
     EmitOnObserverDispose = 2,
     /// <summary>
     /// Do not subscribe to the signal on the bus.
     /// </summary>
     NoSubscribe = 4,
     /// <summary>
-    /// Emit a completion exception when the owner of the matched bus name changes.
+    /// Emit a completion notification (<see cref="NotificationType.OwnerChanged"/>) when the owner of the matched bus name changes.
     /// </summary>
-    /// <remarks>Use <see cref="ObserverHandler.IsOwnerChanged"/> to check for this exception.</remarks>
     EmitOnOwnerChanged = 8,
+    /// <summary>
+    /// Emit a completion notification (<see cref="NotificationType.ConnectionFailed"/>) when the connection fails.
+    /// </summary>
+    EmitOnConnectionFailed = 16,
+    /// <summary>
+    /// Emit a completion notification (<see cref="NotificationType.ReaderFailed"/>) when the reader fails.
+    /// </summary>
+    EmitOnReaderFailed = 32,
 
     /// <summary>
-    /// Emit a completion exception when either the connection or observer is disposed.
+    /// Emit a completion notification when either the connection or observer is disposed.
     /// </summary>
-    /// <remarks>Use <see cref="ObserverHandler.IsDisposed"/> to check for this exception.</remarks>
+    [Obsolete("Use 'EmitOnConnectionClosed | EmitOnObserverDispose' instead.")]
     EmitOnDispose = EmitOnConnectionDispose | EmitOnObserverDispose,
+    /// <summary>
+    /// Emit completion notifications for all events.
+    /// </summary>
+    EmitAll = EmitOnConnectionClosed | EmitOnObserverDispose | EmitOnOwnerChanged | EmitOnConnectionFailed | EmitOnReaderFailed,
 }

--- a/src/Tmds.DBus.Protocol/ObserverHandler.cs
+++ b/src/Tmds.DBus.Protocol/ObserverHandler.cs
@@ -3,6 +3,7 @@ namespace Tmds.DBus.Protocol;
 /// <summary>
 /// Provides methods for checking completion exceptions emitted by message observers.
 /// </summary>
+[Obsolete("Use Notification.Type or Notification.IsCompletion instead.")]
 public static class ObserverHandler
 {
     /// <summary>
@@ -12,7 +13,7 @@ public static class ObserverHandler
     /// <returns><see langword="true"/> if the exception indicates the observer was disposed; otherwise, <see langword="false"/>.</returns>
     /// <remarks>This exception is emitted when <see cref="ObserverFlags.EmitOnObserverDispose"/> or <see cref="ObserverFlags.EmitOnDispose"/> is set.</remarks>
     public static bool IsObserverDisposed(Exception exception)
-        => object.ReferenceEquals(exception, InnerConnection.ObserverDisposedException);
+        => InnerConnection.DetermineNotificationType(exception, null) == NotificationType.ObserverDisposed;
 
     /// <summary>
     /// Checks if the exception indicates the connection was disposed.
@@ -21,9 +22,7 @@ public static class ObserverHandler
     /// <returns><see langword="true"/> if the exception indicates the connection was disposed; otherwise, <see langword="false"/>.</returns>
     /// <remarks>This exception is emitted when <see cref="ObserverFlags.EmitOnConnectionDispose"/> or <see cref="ObserverFlags.EmitOnDispose"/> is set.</remarks>
     public static bool IsConnectionDisposed(Exception exception)
-        // note: DBusConnection.DisposedException is only ever used as an InnerException of DisconnectedException,
-        //       so we directly check for that.
-        => object.ReferenceEquals(exception?.InnerException, DBusConnection.DisposedException);
+        => InnerConnection.DetermineNotificationType(exception, null) == NotificationType.ConnectionClosed;
 
     /// <summary>
     /// Checks if the exception indicates either the observer or connection was disposed.
@@ -32,7 +31,7 @@ public static class ObserverHandler
     /// <returns><see langword="true"/> if the exception indicates disposal; otherwise, <see langword="false"/>.</returns>
     /// <remarks>This exception is emitted when <see cref="ObserverFlags.EmitOnDispose"/>, <see cref="ObserverFlags.EmitOnObserverDispose"/>, or <see cref="ObserverFlags.EmitOnConnectionDispose"/> is set.</remarks>
     public static bool IsDisposed(Exception exception)
-        => IsObserverDisposed(exception) || IsConnectionDisposed(exception);
+        => InnerConnection.DetermineNotificationType(exception, null) is NotificationType.ObserverDisposed or NotificationType.ConnectionClosed;
 
     /// <summary>
     /// Checks if the exception indicates the owner of the matched bus name has changed.
@@ -41,5 +40,5 @@ public static class ObserverHandler
     /// <returns><see langword="true"/> if the exception indicates an owner change; otherwise, <see langword="false"/>.</returns>
     /// <remarks>This exception is emitted when <see cref="ObserverFlags.EmitOnOwnerChanged"/> is set.</remarks>
     public static bool IsOwnerChanged(Exception exception)
-        => exception is DBusOwnerChangedException;
+        => InnerConnection.DetermineNotificationType(exception, null) == NotificationType.OwnerChanged;
 }

--- a/src/Tmds.DBus.Protocol/ThrowHelper.cs
+++ b/src/Tmds.DBus.Protocol/ThrowHelper.cs
@@ -76,6 +76,18 @@ static class ThrowHelper
         throw new IOException("Connection closed by peer");
     }
 
+    [DoesNotReturn]
+    internal static void ThrowNotificationValueNotAvailable()
+    {
+        throw new InvalidOperationException("Value is not available. Check HasValue before accessing Value.");
+    }
+
+    [DoesNotReturn]
+    internal static void ThrowNotificationExceptionNotAvailable()
+    {
+        throw new InvalidOperationException("Exception is not available. Check IsCompletion before accessing Exception.");
+    }
+
     internal static string SignatureToStringNoThrow(ReadOnlySpan<byte> signature)
     {
         try

--- a/src/Tmds.DBus.Tool/ProtocolGenerator.cs
+++ b/src/Tmds.DBus.Tool/ProtocolGenerator.cs
@@ -573,10 +573,14 @@ namespace Tmds.DBus.Tool
 
                 EndBlock(); // method
 
-                // WatchPropertiesChangedAsync
-                AppendLine($"public ValueTask<IDisposable> WatchPropertiesChangedAsync(Action<Exception?, {propertiesInterfaceName}> handler, bool emitOnCapturedContext = true, ObserverFlags flags = ObserverFlags.None)");
+                // WatchPropertiesChangedAsync simple overload
+                AppendLine($"public ValueTask<IDisposable> WatchPropertiesChangedAsync(Action<{propertiesInterfaceName}> handler, bool emitOnCapturedContext = true)");
+                AppendLine($"    => WatchPropertiesChangedAsync(static (Notification<{propertiesInterfaceName}> n) => ((Action<{propertiesInterfaceName}>)n.State!)(n.Value), ObserverFlags.None, emitOnCapturedContext, handler);");
+
+                // WatchPropertiesChangedAsync with Notification
+                AppendLine($"public ValueTask<IDisposable> WatchPropertiesChangedAsync(Action<Notification<{propertiesInterfaceName}>> handler, ObserverFlags flags, bool emitOnCapturedContext = true, object? state = null)");
                 StartBlock();
-                AppendLine($"return Connection.WatchPropertiesChangedAsync(Destination, Path, DBusInterfaceName, (Message m, object? s) => ReadMessage(m), handler, this, emitOnCapturedContext, flags);");
+                AppendLine($"return Connection.WatchPropertiesChangedAsync(Destination, Path, DBusInterfaceName, (Message m, object? s) => ReadMessage(m), handler, flags, emitOnCapturedContext, state);");
                 AppendLine($"static {propertiesInterfaceName} ReadMessage(Message message)");
                 StartBlock();
                 AppendLine("var reader = message.GetBodyReader();");
@@ -657,17 +661,22 @@ namespace Tmds.DBus.Tool
 
             var args = signalXml.Elements("arg").Select(ToArgument).ToArray();
             string watchType = args.Length == 0 ? null : args.Length == 1 ? args[0].DotnetReadType : TupleOf(args.Select(arg => $"{arg.DotnetReadType} {arg.NameUpper}"));
-            string methodArg = watchType == null ? $"Action<Exception?>" : $"Action<Exception?, {watchType}>";
             string dotnetMethodName = "Watch" + Prettify(dbusSignalName) + "Async";
-            AppendLine($"public ValueTask<IDisposable> {dotnetMethodName}({methodArg} handler, bool emitOnCapturedContext = true, ObserverFlags flags = ObserverFlags.None)");
+
+            string simpleHandlerArg = watchType == null ? "Action" : $"Action<{watchType}>";
+            string simpleNotificationHandler = watchType == null ? "static (Notification n) => ((Action)n.State!)()" : $"static (Notification<{watchType}> n) => ((Action<{watchType}>)n.State!)(n.Value)";
+            AppendLine($"public ValueTask<IDisposable> {dotnetMethodName}({simpleHandlerArg} handler, bool emitOnCapturedContext = true)");
+            AppendLine($"    => {dotnetMethodName}({simpleNotificationHandler}, ObserverFlags.None, emitOnCapturedContext, handler);");
+            string handlerContextMethodArg = watchType == null ? "Action<Notification>" : $"Action<Notification<{watchType}>>";
+            AppendLine($"public ValueTask<IDisposable> {dotnetMethodName}({handlerContextMethodArg} handler, ObserverFlags flags, bool emitOnCapturedContext = true, object? state = null)");
             if (watchType == null)
             {
-                AppendLine($"    => Connection.WatchSignalAsync(Destination, Path, DBusInterfaceName, \"{dbusSignalName}\", handler, this, emitOnCapturedContext, flags);");
+                AppendLine($"    => Connection.WatchSignalAsync(Destination, Path, DBusInterfaceName, \"{dbusSignalName}\", handler, flags, emitOnCapturedContext, state);");
             }
             else
             {
                 string readMessageName = GetReadMessageMethodName(args, variant: false);
-                AppendLine($"    => Connection.WatchSignalAsync(Destination, Path, DBusInterfaceName, \"{dbusSignalName}\", (Message m, object? s) => MessageReader.{readMessageName}(m), handler, this, emitOnCapturedContext, flags);");
+                AppendLine($"    => Connection.WatchSignalAsync(Destination, Path, DBusInterfaceName, \"{dbusSignalName}\", (Message m, object? s) => MessageReader.{readMessageName}(m), handler, flags, emitOnCapturedContext, state);");
             }
         }
 

--- a/test/Tmds.DBus.Generator.Tests/CodeGenerationTests.VerifyGeneratedOutput.verified.txt
+++ b/test/Tmds.DBus.Generator.Tests/CodeGenerationTests.VerifyGeneratedOutput.verified.txt
@@ -315,12 +315,18 @@ namespace TestNamespace
                 return writer.CreateMessage();
             }
         }
-        public ValueTask<IDisposable> WatchResetAsync(Action<Exception?> handler, bool emitOnCapturedContext = true, ObserverFlags flags = ObserverFlags.None)
-            => Connection.WatchSignalAsync(Destination, Path, DBusInterfaceName, "Reset", handler, this, emitOnCapturedContext, flags);
-        public ValueTask<IDisposable> WatchErrorAsync(Action<Exception?, string> handler, bool emitOnCapturedContext = true, ObserverFlags flags = ObserverFlags.None)
-            => Connection.WatchSignalAsync(Destination, Path, DBusInterfaceName, "Error", (Message m, object? s) => MessageReader.Read_s(m), handler, this, emitOnCapturedContext, flags);
-        public ValueTask<IDisposable> WatchOperationCompleteAsync(Action<Exception?, (string Operation, double Result)> handler, bool emitOnCapturedContext = true, ObserverFlags flags = ObserverFlags.None)
-            => Connection.WatchSignalAsync(Destination, Path, DBusInterfaceName, "OperationComplete", (Message m, object? s) => MessageReader.Read_sd(m), handler, this, emitOnCapturedContext, flags);
+        public ValueTask<IDisposable> WatchResetAsync(Action handler, bool emitOnCapturedContext = true)
+            => WatchResetAsync(static (Notification n) => ((Action)n.State!)(), ObserverFlags.None, emitOnCapturedContext, handler);
+        public ValueTask<IDisposable> WatchResetAsync(Action<Notification> handler, ObserverFlags flags, bool emitOnCapturedContext = true, object? state = null)
+            => Connection.WatchSignalAsync(Destination, Path, DBusInterfaceName, "Reset", handler, flags, emitOnCapturedContext, state);
+        public ValueTask<IDisposable> WatchErrorAsync(Action<string> handler, bool emitOnCapturedContext = true)
+            => WatchErrorAsync(static (Notification<string> n) => ((Action<string>)n.State!)(n.Value), ObserverFlags.None, emitOnCapturedContext, handler);
+        public ValueTask<IDisposable> WatchErrorAsync(Action<Notification<string>> handler, ObserverFlags flags, bool emitOnCapturedContext = true, object? state = null)
+            => Connection.WatchSignalAsync(Destination, Path, DBusInterfaceName, "Error", (Message m, object? s) => MessageReader.Read_s(m), handler, flags, emitOnCapturedContext, state);
+        public ValueTask<IDisposable> WatchOperationCompleteAsync(Action<(string Operation, double Result)> handler, bool emitOnCapturedContext = true)
+            => WatchOperationCompleteAsync(static (Notification<(string Operation, double Result)> n) => ((Action<(string Operation, double Result)>)n.State!)(n.Value), ObserverFlags.None, emitOnCapturedContext, handler);
+        public ValueTask<IDisposable> WatchOperationCompleteAsync(Action<Notification<(string Operation, double Result)>> handler, ObserverFlags flags, bool emitOnCapturedContext = true, object? state = null)
+            => Connection.WatchSignalAsync(Destination, Path, DBusInterfaceName, "OperationComplete", (Message m, object? s) => MessageReader.Read_sd(m), handler, flags, emitOnCapturedContext, state);
         public Task<double> GetLastResultAsync()
             => Connection.CallMethodAsync(CreateGetPropertyMessage("LastResult"), (Message m, object? s) => MessageReader.Read_v_d(m), this);
         public Task<ObjectPath> GetCurrentPathAsync()
@@ -336,9 +342,11 @@ namespace TestNamespace
                 return CalculatorProperties.ReadFrom(ref reader, withInvalidated: false);
             }
         }
-        public ValueTask<IDisposable> WatchPropertiesChangedAsync(Action<Exception?, ICalculatorProperties> handler, bool emitOnCapturedContext = true, ObserverFlags flags = ObserverFlags.None)
+        public ValueTask<IDisposable> WatchPropertiesChangedAsync(Action<ICalculatorProperties> handler, bool emitOnCapturedContext = true)
+            => WatchPropertiesChangedAsync(static (Notification<ICalculatorProperties> n) => ((Action<ICalculatorProperties>)n.State!)(n.Value), ObserverFlags.None, emitOnCapturedContext, handler);
+        public ValueTask<IDisposable> WatchPropertiesChangedAsync(Action<Notification<ICalculatorProperties>> handler, ObserverFlags flags, bool emitOnCapturedContext = true, object? state = null)
         {
-            return Connection.WatchPropertiesChangedAsync(Destination, Path, DBusInterfaceName, (Message m, object? s) => ReadMessage(m), handler, this, emitOnCapturedContext, flags);
+            return Connection.WatchPropertiesChangedAsync(Destination, Path, DBusInterfaceName, (Message m, object? s) => ReadMessage(m), handler, flags, emitOnCapturedContext, state);
             static ICalculatorProperties ReadMessage(Message message)
             {
                 var reader = message.GetBodyReader();
@@ -521,8 +529,10 @@ namespace TestNamespace
                 return writer.CreateMessage();
             }
         }
-        public ValueTask<IDisposable> WatchChangedAsync(Action<Exception?> handler, bool emitOnCapturedContext = true, ObserverFlags flags = ObserverFlags.None)
-            => Connection.WatchSignalAsync(Destination, Path, DBusInterfaceName, "Changed", handler, this, emitOnCapturedContext, flags);
+        public ValueTask<IDisposable> WatchChangedAsync(Action handler, bool emitOnCapturedContext = true)
+            => WatchChangedAsync(static (Notification n) => ((Action)n.State!)(), ObserverFlags.None, emitOnCapturedContext, handler);
+        public ValueTask<IDisposable> WatchChangedAsync(Action<Notification> handler, ObserverFlags flags, bool emitOnCapturedContext = true, object? state = null)
+            => Connection.WatchSignalAsync(Destination, Path, DBusInterfaceName, "Changed", handler, flags, emitOnCapturedContext, state);
         public Task SetVolumeAsync(double value)
         {
             return Connection.CallMethodAsync(CreateMessage());
@@ -576,9 +586,11 @@ namespace TestNamespace
                 return SettingsProperties.ReadFrom(ref reader, withInvalidated: false);
             }
         }
-        public ValueTask<IDisposable> WatchPropertiesChangedAsync(Action<Exception?, ISettingsProperties> handler, bool emitOnCapturedContext = true, ObserverFlags flags = ObserverFlags.None)
+        public ValueTask<IDisposable> WatchPropertiesChangedAsync(Action<ISettingsProperties> handler, bool emitOnCapturedContext = true)
+            => WatchPropertiesChangedAsync(static (Notification<ISettingsProperties> n) => ((Action<ISettingsProperties>)n.State!)(n.Value), ObserverFlags.None, emitOnCapturedContext, handler);
+        public ValueTask<IDisposable> WatchPropertiesChangedAsync(Action<Notification<ISettingsProperties>> handler, ObserverFlags flags, bool emitOnCapturedContext = true, object? state = null)
         {
-            return Connection.WatchPropertiesChangedAsync(Destination, Path, DBusInterfaceName, (Message m, object? s) => ReadMessage(m), handler, this, emitOnCapturedContext, flags);
+            return Connection.WatchPropertiesChangedAsync(Destination, Path, DBusInterfaceName, (Message m, object? s) => ReadMessage(m), handler, flags, emitOnCapturedContext, state);
             static ISettingsProperties ReadMessage(Message message)
             {
                 var reader = message.GetBodyReader();

--- a/test/Tmds.DBus.Protocol.Tests/ConnectionTests.cs
+++ b/test/Tmds.DBus.Protocol.Tests/ConnectionTests.cs
@@ -139,7 +139,15 @@ namespace Tmds.DBus.Protocol.Tests
         }
 
         sealed class MySynchronizationContext : SynchronizationContext
-        { }
+        {
+            public int PostCount;
+
+            public override void Post(SendOrPostCallback d, object? state)
+            {
+                Interlocked.Increment(ref PostCount);
+                base.Post(d, state);
+            }
+        }
 
         [InlineData("tcp:host=localhost,port=1")]
         [InlineData("unix:path=/does/not/exist")]
@@ -528,18 +536,27 @@ namespace Tmds.DBus.Protocol.Tests
             var exceptionTcs = new TaskCompletionSource<Exception?>();
             var handlerCallCount = 0;
 
-            var proxy = new HelloWorld(conn1, conn2.UniqueName!);
-            var disposable = await proxy.WatchSignalAsync<string>(
-                conn2.UniqueName!,
-                HelloWorldConstants.Interface,
-                HelloWorldConstants.Path,
-                HelloWorldConstants.OnHelloWorld,
+            var rule = new MatchRule
+            {
+                Type = MessageType.Signal,
+                Sender = conn2.UniqueName,
+                Path = HelloWorldConstants.Path,
+                Member = HelloWorldConstants.OnHelloWorld,
+                Interface = HelloWorldConstants.Interface
+            };
+
+            await conn1.AddMatchAsync<string>(
+                rule,
                 reader: (Message m, object? s) => throw new InvalidOperationException("Reader error"),
-                handler: (Exception? ex, string msg) =>
+                handler: ctx =>
                 {
                     handlerCallCount++;
-                    exceptionTcs.TrySetResult(ex);
+                    if (ctx.IsCompletion)
+                    {
+                        exceptionTcs.TrySetResult(ctx.Exception);
+                    }
                 },
+                flags: ObserverFlags.EmitOnReaderFailed,
                 emitOnCapturedContext: false);
 
             // Send a signal that will trigger the reader exception
@@ -547,49 +564,52 @@ namespace Tmds.DBus.Protocol.Tests
 
             var exception = await exceptionTcs.Task.WaitAsync(TimeSpan.FromSeconds(5));
 
-            Assert.IsType<DBusConnectionClosedException>(exception);
-            Assert.IsType<InvalidOperationException>(exception.InnerException);
-            Assert.Equal("Reader error", exception.InnerException!.Message);
-            Assert.Equal(1, handlerCallCount);
+            var readException = Assert.IsType<DBusReadException>(exception);
+            Assert.IsType<InvalidOperationException>(readException.InnerException);
+            Assert.Equal("Reader error", readException.InnerException!.Message);
         }
 
         [Fact]
-        public async Task ObserverExceptionInValueHandlerDisposesObserver()
+        public async Task ObserverExceptionInValueHandlerDisconnectsConnection()
         {
             var connections = PairedConnection.CreatePair();
             using var conn1 = connections.Item1;
             using var conn2 = connections.Item2;
 
-            var exceptionTcs = new TaskCompletionSource<Exception?>();
             var handlerCallCount = 0;
 
-            var proxy = new HelloWorld(conn1, conn2.UniqueName!);
-            var disposable = await proxy.WatchSignalAsync<string>(
-                conn2.UniqueName!,
-                HelloWorldConstants.Interface,
-                HelloWorldConstants.Path,
-                HelloWorldConstants.OnHelloWorld,
+            var rule = new MatchRule
+            {
+                Type = MessageType.Signal,
+                Sender = conn2.UniqueName,
+                Path = HelloWorldConstants.Path,
+                Member = HelloWorldConstants.OnHelloWorld,
+                Interface = HelloWorldConstants.Interface
+            };
+
+            await conn1.AddMatchAsync<string>(
+                rule,
                 reader: (Message m, object? s) => m.GetBodyReader().ReadString(),
-                handler: (Exception? ex, string msg) =>
+                handler: ctx =>
                 {
                     handlerCallCount++;
-                    if (ex is null)
+                    if (ctx.HasValue)
                     {
                         throw new InvalidOperationException("Handler error");
                     }
-                    exceptionTcs.TrySetResult(ex);
                 },
-                emitOnCapturedContext: false);
+                emitOnCapturedContext: false,
+                flags: ObserverFlags.EmitOnConnectionFailed);
 
             // Send a signal that will trigger the handler exception
             SendHelloWorldSignal(conn2);
 
-            var exception = await exceptionTcs.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            // Wait for connection to be disconnected due to handler throwing
+            var exception = await conn1.DisconnectedAsync().WaitAsync(TimeSpan.FromSeconds(5));
 
-            Assert.IsType<DBusConnectionClosedException>(exception);
-            Assert.IsType<InvalidOperationException>(exception.InnerException);
-            Assert.Equal("Handler error", exception.InnerException!.Message);
-            Assert.Equal(2, handlerCallCount); // Called once with message, once with exception
+            Assert.IsType<InvalidOperationException>(exception);
+            Assert.Equal("Handler error", exception.Message);
+            Assert.Equal(2, handlerCallCount); // Called once with message, once with disconnect notification
         }
 
         [Theory]
@@ -633,6 +653,502 @@ namespace Tmds.DBus.Protocol.Tests
             // Verify the connection was disconnected with the handler exception
             Assert.NotNull(disconnectException);
             Assert.Same(testException, disconnectException);
+        }
+
+        [Fact]
+        public async Task Notification_HasValue_WhenSignalReceived()
+        {
+            var connections = PairedConnection.CreatePair();
+            using var conn1 = connections.Item1;
+            using var conn2 = connections.Item2;
+
+            var tcs = new TaskCompletionSource<Notification<string>>();
+
+            var rule = new MatchRule
+            {
+                Type = MessageType.Signal,
+                Sender = conn2.UniqueName,
+                Path = HelloWorldConstants.Path,
+                Member = HelloWorldConstants.OnHelloWorld,
+                Interface = HelloWorldConstants.Interface
+            };
+
+            await conn1.AddMatchAsync(
+                rule,
+                reader: (Message m, object? s) => m.GetBodyReader().ReadString(),
+                handler: ctx =>
+                {
+                    tcs.TrySetResult(ctx);
+                },
+                emitOnCapturedContext: false);
+
+            SendHelloWorldSignal(conn2);
+
+            var notification = await tcs.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+            Assert.True(notification.HasValue);
+            Assert.False(notification.IsCompletion);
+            Assert.Equal("hello world", notification.Value);
+            Assert.Equal(NotificationType.Value, notification.Type);
+            Assert.Throws<InvalidOperationException>(() => notification.Exception);
+        }
+
+        [Fact]
+        public async Task Notification_Stop_DisposesObserver()
+        {
+            var connections = PairedConnection.CreatePair();
+            using var conn1 = connections.Item1;
+            using var conn2 = connections.Item2;
+
+            var callCount = 0;
+            var tcs = new TaskCompletionSource<bool>();
+
+            var rule = new MatchRule
+            {
+                Type = MessageType.Signal,
+                Sender = conn2.UniqueName,
+                Path = HelloWorldConstants.Path,
+                Member = HelloWorldConstants.OnHelloWorld,
+                Interface = HelloWorldConstants.Interface
+            };
+
+            await conn1.AddMatchAsync(
+                rule,
+                reader: (Message m, object? s) => m.GetBodyReader().ReadString(),
+                handler: ctx =>
+                {
+                    callCount++;
+                    if (ctx.HasValue)
+                    {
+                        ctx.Stop();
+                        tcs.TrySetResult(true);
+                    }
+                },
+                emitOnCapturedContext: false);
+
+            SendHelloWorldSignal(conn2);
+
+            await tcs.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+            // Send another signal to verify observer is stopped
+            SendHelloWorldSignal(conn2);
+            await Task.Delay(100);
+
+            Assert.Equal(1, callCount);
+        }
+
+        [Fact]
+        public async Task Notification_StateObject_IsAccessible()
+        {
+            var connections = PairedConnection.CreatePair();
+            using var conn1 = connections.Item1;
+            using var conn2 = connections.Item2;
+
+            var expectedState = new { Data = "test-state" };
+            var tcs = new TaskCompletionSource<object?>();
+
+            var rule = new MatchRule
+            {
+                Type = MessageType.Signal,
+                Sender = conn2.UniqueName,
+                Path = HelloWorldConstants.Path,
+                Member = HelloWorldConstants.OnHelloWorld,
+                Interface = HelloWorldConstants.Interface
+            };
+
+            await conn1.AddMatchAsync(
+                rule,
+                reader: (Message m, object? s) => m.GetBodyReader().ReadString(),
+                handler: ctx =>
+                {
+                    tcs.TrySetResult(ctx.State);
+                },
+                state: expectedState,
+                emitOnCapturedContext: false);
+
+            SendHelloWorldSignal(conn2);
+
+            var actualState = await tcs.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+            Assert.Same(expectedState, actualState);
+        }
+
+        [Fact]
+        public async Task Notification_ReaderException_HasErrorContext()
+        {
+            var connections = PairedConnection.CreatePair();
+            using var conn1 = connections.Item1;
+            using var conn2 = connections.Item2;
+
+            var tcs = new TaskCompletionSource<Notification<string>>();
+
+            var rule = new MatchRule
+            {
+                Type = MessageType.Signal,
+                Sender = conn2.UniqueName,
+                Path = HelloWorldConstants.Path,
+                Member = HelloWorldConstants.OnHelloWorld,
+                Interface = HelloWorldConstants.Interface
+            };
+
+            await conn1.AddMatchAsync<string>(
+                rule,
+                reader: (Message m, object? s) => throw new InvalidOperationException("Reader failed"),
+                handler: ctx =>
+                {
+                    tcs.TrySetResult(ctx);
+                },
+                emitOnCapturedContext: false,
+                flags: ObserverFlags.EmitOnReaderFailed);
+
+            SendHelloWorldSignal(conn2);
+
+            var notification = await tcs.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+            Assert.False(notification.HasValue);
+            Assert.True(notification.IsCompletion);
+            Assert.NotNull(notification.Exception);
+            var readException = Assert.IsType<DBusReadException>(notification.Exception);
+            Assert.IsType<InvalidOperationException>(readException.InnerException);
+            Assert.Equal("Reader failed", readException.InnerException!.Message);
+            Assert.Equal(NotificationType.ReaderFailed, notification.Type);
+        }
+
+        [Fact]
+        public async Task Notification_ConnectionDisposed_HasCompletionContext()
+        {
+            var connections = PairedConnection.CreatePair();
+            using var conn1 = connections.Item1;
+            using var conn2 = connections.Item2;
+
+            var tcs = new TaskCompletionSource<Notification<string>>();
+
+            var rule = new MatchRule
+            {
+                Type = MessageType.Signal,
+                Sender = conn2.UniqueName,
+                Path = HelloWorldConstants.Path,
+                Member = HelloWorldConstants.OnHelloWorld,
+                Interface = HelloWorldConstants.Interface
+            };
+
+            await conn1.AddMatchAsync(
+                rule,
+                reader: (Message m, object? s) => m.GetBodyReader().ReadString(),
+                handler: ctx =>
+                {
+                    if (ctx.IsCompletion)
+                    {
+                        tcs.TrySetResult(ctx);
+                    }
+                },
+                flags: ObserverFlags.EmitOnConnectionClosed,
+                emitOnCapturedContext: false);
+
+            conn1.Dispose();
+
+            var notification = await tcs.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+            Assert.False(notification.HasValue);
+            Assert.True(notification.IsCompletion);
+            Assert.NotNull(notification.Exception);
+            Assert.Equal(NotificationType.ConnectionClosed, notification.Type);
+        }
+
+        [Fact]
+        public async Task Notification_ObserverStopped_HasCompletionContext()
+        {
+            var connections = PairedConnection.CreatePair();
+            using var conn1 = connections.Item1;
+            using var conn2 = connections.Item2;
+
+            var tcs = new TaskCompletionSource<Notification<string>>();
+
+            var rule = new MatchRule
+            {
+                Type = MessageType.Signal,
+                Sender = conn2.UniqueName,
+                Path = HelloWorldConstants.Path,
+                Member = HelloWorldConstants.OnHelloWorld,
+                Interface = HelloWorldConstants.Interface
+            };
+
+            var disposable = await conn1.AddMatchAsync(
+                rule,
+                reader: (Message m, object? s) => m.GetBodyReader().ReadString(),
+                handler: ctx =>
+                {
+                    if (ctx.IsCompletion)
+                    {
+                        tcs.TrySetResult(ctx);
+                    }
+                },
+                flags: ObserverFlags.EmitOnObserverDispose,
+                emitOnCapturedContext: false);
+
+            disposable.Dispose();
+
+            var notification = await tcs.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+            Assert.False(notification.HasValue);
+            Assert.True(notification.IsCompletion);
+            Assert.NotNull(notification.Exception);
+            Assert.Equal(NotificationType.ObserverDisposed, notification.Type);
+        }
+
+        [Fact]
+        public async Task Notification_ConnectionFailed_HasCompletionContext()
+        {
+            var connections = PairedConnection.CreatePair();
+            using var conn1 = connections.Item1;
+            using var conn2 = connections.Item2;
+
+            var tcs = new TaskCompletionSource<Notification<string>>();
+
+            var rule = new MatchRule
+            {
+                Type = MessageType.Signal,
+                Sender = conn2.UniqueName,
+                Path = HelloWorldConstants.Path,
+                Member = HelloWorldConstants.OnHelloWorld,
+                Interface = HelloWorldConstants.Interface
+            };
+
+            await conn1.AddMatchAsync(
+                rule,
+                reader: (Message m, object? s) => m.GetBodyReader().ReadString(),
+                handler: ctx =>
+                {
+                    if (ctx.IsCompletion)
+                    {
+                        tcs.TrySetResult(ctx);
+                    }
+                },
+                flags: ObserverFlags.EmitOnConnectionFailed,
+                emitOnCapturedContext: false);
+
+            // Dispose the peer to cause the connection to fail.
+            conn2.Dispose();
+
+            var notification = await tcs.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+            Assert.False(notification.HasValue);
+            Assert.True(notification.IsCompletion);
+            Assert.NotNull(notification.Exception);
+            Assert.Equal(NotificationType.ConnectionFailed, notification.Type);
+        }
+
+        [Fact]
+        public async Task Notification_ThrowingHandler_DisconnectsConnection()
+        {
+            var connections = PairedConnection.CreatePair();
+            using var conn1 = connections.Item1;
+            using var conn2 = connections.Item2;
+
+            var rule = new MatchRule
+            {
+                Type = MessageType.Signal,
+                Sender = conn2.UniqueName,
+                Path = HelloWorldConstants.Path,
+                Member = HelloWorldConstants.OnHelloWorld,
+                Interface = HelloWorldConstants.Interface
+            };
+
+            await conn1.AddMatchAsync(
+                rule,
+                reader: (Message m, object? s) => m.GetBodyReader().ReadString(),
+                handler: ctx =>
+                {
+                    if (ctx.HasValue)
+                    {
+                        throw new InvalidOperationException("Handler threw");
+                    }
+                },
+                emitOnCapturedContext: false);
+
+            SendHelloWorldSignal(conn2);
+
+            // Wait for connection to be disconnected
+            var disconnectReason = await conn1.DisconnectedAsync().WaitAsync(TimeSpan.FromSeconds(5));
+
+            Assert.NotNull(disconnectReason);
+            Assert.IsType<InvalidOperationException>(disconnectReason);
+            Assert.Equal("Handler threw", disconnectReason.Message);
+        }
+
+        [Fact]
+        public async Task Notification_NonGeneric_ReceivesSignal()
+        {
+            var connections = PairedConnection.CreatePair();
+            using var conn1 = connections.Item1;
+            using var conn2 = connections.Item2;
+
+            var tcs = new TaskCompletionSource<Notification>();
+
+            var rule = new MatchRule
+            {
+                Type = MessageType.Signal,
+                Sender = conn2.UniqueName,
+                Path = HelloWorldConstants.Path,
+                Member = HelloWorldConstants.OnHelloWorld,
+                Interface = HelloWorldConstants.Interface
+            };
+
+            await conn1.AddMatchAsync(
+                rule,
+                handler: ctx =>
+                {
+                    if (!ctx.IsCompletion)
+                    {
+                        tcs.TrySetResult(ctx);
+                    }
+                },
+                emitOnCapturedContext: false);
+
+            SendHelloWorldSignal(conn2);
+
+            var notification = await tcs.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+            Assert.False(notification.IsCompletion);
+            Assert.Equal(NotificationType.Value, notification.Type);
+            Assert.Throws<InvalidOperationException>(() => notification.Exception);
+        }
+
+        [Fact]
+        public async Task Notification_ValueProperty_ThrowsWhenNoValue()
+        {
+            var connections = PairedConnection.CreatePair();
+            using var conn1 = connections.Item1;
+            using var conn2 = connections.Item2;
+
+            var tcs = new TaskCompletionSource<Notification<string>>();
+
+            var rule = new MatchRule
+            {
+                Type = MessageType.Signal,
+                Sender = conn2.UniqueName,
+                Path = HelloWorldConstants.Path,
+                Member = HelloWorldConstants.OnHelloWorld,
+                Interface = HelloWorldConstants.Interface
+            };
+
+            var disposable = await conn1.AddMatchAsync(
+                rule,
+                reader: (Message m, object? s) => m.GetBodyReader().ReadString(),
+                handler: ctx =>
+                {
+                    if (ctx.IsCompletion)
+                    {
+                        tcs.TrySetResult(ctx);
+                    }
+                },
+                flags: ObserverFlags.EmitOnObserverDispose,
+                emitOnCapturedContext: false);
+
+            disposable.Dispose();
+
+            var notification = await tcs.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+            Assert.False(notification.HasValue);
+            Assert.Throws<InvalidOperationException>(() => notification.Value);
+        }
+
+        [Fact]
+        public async Task Notification_DelayedCompletion_WhenDisposedDuringHandler()
+        {
+            var connections = PairedConnection.CreatePair();
+            using var conn1 = connections.Item1;
+            using var conn2 = connections.Item2;
+
+            var notifications = new List<Notification<string>>();
+            var completionTcs = new TaskCompletionSource<Notification<string>>();
+            IDisposable? observerDisposable = null;
+
+            var rule = new MatchRule
+            {
+                Type = MessageType.Signal,
+                Sender = conn2.UniqueName,
+                Path = HelloWorldConstants.Path,
+                Member = HelloWorldConstants.OnHelloWorld,
+                Interface = HelloWorldConstants.Interface
+            };
+
+            observerDisposable = await conn1.AddMatchAsync(
+                rule,
+                reader: (Message m, object? s) => m.GetBodyReader().ReadString(),
+                handler: ctx =>
+                {
+                    notifications.Add(ctx);
+                    if (ctx.HasValue)
+                    {
+                        // Dispose the observer while the handler is executing.
+                        // The completion should be deferred until after this handler returns.
+                        observerDisposable!.Dispose();
+                    }
+                    if (ctx.IsCompletion)
+                    {
+                        completionTcs.TrySetResult(ctx);
+                    }
+                },
+                flags: ObserverFlags.EmitOnObserverDispose,
+                emitOnCapturedContext: false);
+
+            SendHelloWorldSignal(conn2);
+
+            var completion = await completionTcs.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+            Assert.Equal(2, notifications.Count);
+            Assert.True(notifications[0].HasValue);
+            Assert.Equal("hello world", notifications[0].Value);
+            Assert.True(notifications[1].IsCompletion);
+            Assert.Equal(NotificationType.ObserverDisposed, notifications[1].Type);
+        }
+
+        [Fact]
+        public async Task Notification_CompletionDeliveredViaSynchronizationContext()
+        {
+            var connections = PairedConnection.CreatePair();
+            using var conn1 = connections.Item1;
+            using var conn2 = connections.Item2;
+
+            var tcs = new TaskCompletionSource<Notification<string>>();
+            var syncCtx = new MySynchronizationContext();
+
+            var rule = new MatchRule
+            {
+                Type = MessageType.Signal,
+                Sender = conn2.UniqueName,
+                Path = HelloWorldConstants.Path,
+                Member = HelloWorldConstants.OnHelloWorld,
+                Interface = HelloWorldConstants.Interface
+            };
+
+            // Capture the sync context during AddMatchAsync.
+            SynchronizationContext.SetSynchronizationContext(syncCtx);
+
+            var disposable = await conn1.AddMatchAsync(
+                rule,
+                reader: (Message m, object? s) => m.GetBodyReader().ReadString(),
+                handler: ctx =>
+                {
+                    if (ctx.IsCompletion)
+                    {
+                        tcs.TrySetResult(ctx);
+                    }
+                },
+                flags: ObserverFlags.EmitOnObserverDispose,
+                emitOnCapturedContext: true);
+
+            // Clear the sync context so Dispose posts through the captured one.
+            SynchronizationContext.SetSynchronizationContext(null);
+
+            disposable.Dispose();
+
+            var notification = await tcs.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+            Assert.True(notification.IsCompletion);
+            Assert.Equal(NotificationType.ObserverDisposed, notification.Type);
+            Assert.True(syncCtx.PostCount > 0);
         }
     }
 }

--- a/test/Tmds.DBus.Protocol.Tests/SignalOwnerTests.cs
+++ b/test/Tmds.DBus.Protocol.Tests/SignalOwnerTests.cs
@@ -529,6 +529,117 @@ public class SignalOwnerTests
         }
     }
 
+    [Fact]
+    public async Task EmitOnOwnerChanged_DisposesObserverWhenOwnerChanges()
+    {
+        using var dbusDaemon = new DBusDaemon();
+        await dbusDaemon.StartAsync();
+
+        string wellKnownName = "tmds.OwnerChangeService";
+
+        using var serviceConnection = new DBusConnection(dbusDaemon.Address!);
+        await serviceConnection.ConnectAsync();
+        await serviceConnection.RequestNameAsync(wellKnownName, RequestNameOptions.AllowReplacement);
+
+        using var clientConnection = new DBusConnection(dbusDaemon.Address!);
+        await clientConnection.ConnectAsync();
+
+        var notificationTcs = new TaskCompletionSource<Notification<string>>();
+        var rule = new MatchRule
+        {
+            Type = MessageType.Signal,
+            Sender = wellKnownName,
+            Interface = "com.example.TestInterface",
+            Member = "TestSignal",
+            Path = "/com/example/Object"
+        };
+
+        await clientConnection.AddMatchAsync(rule,
+            reader: (Message m, object? s) => m.GetBodyReader().ReadString(),
+            handler: ctx =>
+            {
+                if (ctx.IsCompletion)
+                {
+                    notificationTcs.TrySetResult(ctx);
+                }
+            },
+            emitOnCapturedContext: false,
+            flags: ObserverFlags.EmitOnOwnerChanged);
+
+        // Another connection takes over the name, triggering NameOwnerChanged.
+        using var service2 = new DBusConnection(dbusDaemon.Address!);
+        await service2.ConnectAsync();
+        await service2.RequestNameAsync(wellKnownName, RequestNameOptions.ReplaceExisting);
+
+        var notification = await notificationTcs.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.True(notification.IsCompletion);
+        Assert.False(notification.HasValue);
+        Assert.Equal(NotificationType.OwnerChanged, notification.Type);
+    }
+
+    [Fact]
+    public async Task EmitOnOwnerChanged_NotTriggeredWithoutOwnerChange()
+    {
+        using var dbusDaemon = new DBusDaemon();
+        await dbusDaemon.StartAsync();
+
+        string wellKnownName = "tmds.StableService";
+
+        using var serviceConnection = new DBusConnection(dbusDaemon.Address!);
+        await serviceConnection.ConnectAsync();
+        await serviceConnection.RequestNameAsync(wellKnownName);
+
+        using var clientConnection = new DBusConnection(dbusDaemon.Address!);
+        await clientConnection.ConnectAsync();
+
+        var signalSemaphore = new SemaphoreSlim(0);
+        var ownerChangedReceived = false;
+        var rule = new MatchRule
+        {
+            Type = MessageType.Signal,
+            Sender = wellKnownName,
+            Interface = "com.example.TestInterface",
+            Member = "TestSignal",
+            Path = "/com/example/Object"
+        };
+
+        await clientConnection.AddMatchAsync(rule,
+            reader: (Message m, object? s) => m.GetBodyReader().ReadString(),
+            handler: ctx =>
+            {
+                if (ctx.HasValue)
+                {
+                    signalSemaphore.Release();
+                }
+                if (ctx.IsCompletion)
+                {
+                    ownerChangedReceived = true;
+                }
+            },
+            emitOnCapturedContext: false,
+            flags: ObserverFlags.EmitOnOwnerChanged);
+
+        // Send signal - owner hasn't changed so EmitOnOwnerChanged should not fire.
+        SendSignal(serviceConnection);
+        await signalSemaphore.WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.False(ownerChangedReceived);
+
+        static void SendSignal(DBusConnection conn)
+        {
+            using var writer = conn.GetMessageWriter();
+            writer.WriteSignalHeader(
+                path: "/com/example/Object",
+                @interface: "com.example.TestInterface",
+                member: "TestSignal",
+                signature: "s");
+            writer.WriteString("signal");
+            var buffer = writer.CreateMessage();
+            conn.TrySendMessage(buffer);
+        }
+    }
+
     [Theory]
     [InlineData(false)]
     [InlineData(true)]


### PR DESCRIPTION
Introduce Notification/Notification<T> structs and NotificationType enum replacing the Action<Exception?, T> callback.

Update the generator to use Notification<T> callbacks and also generate a simpler Action<T> overload.

Fixes https://github.com/tmds/Tmds.DBus/issues/424.