### PR TITLE
ProtocolGenerator: replace IReadableXxxProperties with unified IXxxProperties.

### DIFF
--- a/src/Tmds.DBus.Tool/ProtocolGenerator.cs
+++ b/src/Tmds.DBus.Tool/ProtocolGenerator.cs
@@ -982,8 +982,7 @@ namespace Tmds.DBus.Tool
                 AppendLine("MethodContext.ReplyError(\"org.freedesktop.DBus.Error.UnknownProperty\", $\"Unknown property: {Property}\");");
                 EndBlock();
 
-                // Handle method that reads from IReadableXxxProperties
-                AppendLine($"public ValueTask Handle(IReadable{name}Properties properties)");
+                AppendLine($"public ValueTask Handle(I{name}Properties properties)");
                 StartBlock();
                 AppendLine("switch (Property)");
                 StartBlock();
@@ -1018,8 +1017,7 @@ namespace Tmds.DBus.Tool
 
                 AppendLine("public void Dispose() => MethodContext.Dispose();");
 
-                // Handle method that reads all properties from IReadableXxxProperties
-                AppendLine($"public ValueTask Handle(IReadable{name}Properties properties)");
+                AppendLine($"public ValueTask Handle(I{name}Properties properties)");
                 StartBlock();
                 AppendLine("var writer = MethodContext.CreateReplyWriter(\"a{sv}\");");
                 AppendLine("var dictStart = writer.WriteDictionaryStart();");
@@ -1171,9 +1169,27 @@ namespace Tmds.DBus.Tool
                 AppendPropertyEnum(name, readableProperties);
             }
 
-            if (readableProperties.Any())
+            if (readableProperties.Any() || writableProperties.Any())
             {
-                AppendReadableInterface($"IReadable{name}Properties", readableProperties);
+                AppendLine($"interface I{name}Properties");
+                StartBlock();
+                foreach (var property in readableProperties)
+                {
+                    bool isWritable = writableProperties.Any(w => w.Name == property.Name);
+                    if (isWritable)
+                    {
+                        AppendLine($"{property.DotnetReadType} {property.NameUpper} {{ get; set; }}");
+                    }
+                    else
+                    {
+                        AppendLine($"{property.DotnetReadType} {property.NameUpper} {{ get; }}");
+                    }
+                }
+                foreach (var property in writeOnlyProperties)
+                {
+                    AppendLine($"{property.DotnetReadType} {property.NameUpper} {{ set; }}");
+                }
+                EndBlock();
             }
 
             if (generateHandlers)
@@ -1202,31 +1218,6 @@ namespace Tmds.DBus.Tool
                         string comma = i < writeOnlyProperties.Length - 1 ? "," : "";
                         AppendLine($"{property.NameUpper} = {nextValue + i}{comma}");
                     }
-                    EndBlock();
-                }
-
-                // IXxxProperties
-                if (readableProperties.Any() || writableProperties.Any())
-                {
-                    string propertiesInterfaceName = $"I{name}Properties";
-                    string baseInterface = readableProperties.Any() ? $" : IReadable{name}Properties" : "";
-                    AppendLine($"interface {propertiesInterfaceName}{baseInterface}");
-                    StartBlock();
-
-                    foreach (var property in readableProperties)
-                    {
-                        bool isWritable = writableProperties.Any(w => w.Name == property.Name);
-                        if (isWritable)
-                        {
-                            AppendLine($"new {property.DotnetReadType} {property.NameUpper} {{ get; set; }}");
-                        }
-                    }
-
-                    foreach (var property in writeOnlyProperties)
-                    {
-                        AppendLine($"{property.DotnetReadType} {property.NameUpper} {{ set; }}");
-                    }
-
                     EndBlock();
                 }
             }
@@ -1263,7 +1254,7 @@ namespace Tmds.DBus.Tool
                     }
                     EndBlock();
 
-                    AppendLine($"sealed class {propertiesClassName} : {changedInterfaceName}, IReadable{name}Properties");
+                    AppendLine($"sealed class {propertiesClassName} : {changedInterfaceName}, I{name}Properties");
                     StartBlock();
 
                     string flagType = readableProperties.Length <= 32 ? "uint" : "ulong";
@@ -1413,6 +1404,11 @@ namespace Tmds.DBus.Tool
                     AppendLine("return props;");
                     EndBlock();
 
+                    foreach (var property in writeOnlyProperties)
+                    {
+                        AppendLine($"{property.DotnetReadType} I{name}Properties.{property.NameUpper} {{ set {{ }} }}");
+                    }
+
                     EndBlock();
                 }
             }
@@ -1429,17 +1425,6 @@ namespace Tmds.DBus.Tool
                 var property = readableProperties[i];
                 string comma = i < readableProperties.Length - 1 ? "," : "";
                 AppendLine($"{property.NameUpper} = {i + 1}{comma}");
-            }
-            EndBlock();
-        }
-
-        private void AppendReadableInterface(string interfaceName, Argument[] readableProperties)
-        {
-            AppendLine($"interface {interfaceName}");
-            StartBlock();
-            foreach (var property in readableProperties)
-            {
-                AppendLine($"{property.DotnetReadType} {property.NameUpper} {{ get; }}");
             }
             EndBlock();
         }
@@ -1491,8 +1476,7 @@ namespace Tmds.DBus.Tool
                 AppendLine($"writer.WriteString(\"{interfaceName}\");");
             }
 
-            // Public overload: accepts IReadableXxxProperties with changed and invalidated spans
-            AppendLine($"public static void EmitPropertiesChanged(this DBusConnection c, ObjectPath p, IReadable{name}Properties properties, ReadOnlySpan<{propertyEnumName}> changed, ReadOnlySpan<{propertyEnumName}> invalidated = default)");
+            AppendLine($"public static void EmitPropertiesChanged(this DBusConnection c, ObjectPath p, I{name}Properties properties, ReadOnlySpan<{propertyEnumName}> changed, ReadOnlySpan<{propertyEnumName}> invalidated = default)");
             StartBlock();
             AppendWriteSignalHeader();
 
@@ -1539,7 +1523,7 @@ namespace Tmds.DBus.Tool
             EndBlock();
 
             // Public overload: single changed property
-            AppendLine($"public static void EmitPropertyChanged(this DBusConnection c, ObjectPath p, IReadable{name}Properties properties, {propertyEnumName} changed)");
+            AppendLine($"public static void EmitPropertyChanged(this DBusConnection c, ObjectPath p, I{name}Properties properties, {propertyEnumName} changed)");
             StartBlock();
             AppendLine("EmitPropertiesChanged(c, p, properties, stackalloc[] { changed }, default);");
             EndBlock();

--- a/test/Tmds.DBus.Generator.Tests/CodeGenerationTests.VerifyGeneratedOutput_HandlerOnly.verified.txt
+++ b/test/Tmds.DBus.Generator.Tests/CodeGenerationTests.VerifyGeneratedOutput_HandlerOnly.verified.txt
@@ -16,21 +16,17 @@ namespace TestNamespace
         CurrentEntry = 3,
         IsActive = 4
     }
-    interface IReadableCalculatorProperties
+    interface ICalculatorProperties
     {
         double LastResult { get; }
         ObjectPath CurrentPath { get; }
         (string, double) CurrentEntry { get; }
-        ValueTuple<bool> IsActive { get; }
+        ValueTuple<bool> IsActive { get; set; }
     }
     enum WritableCalculatorProperty
     {
         UnknownProperty = 0,
         IsActive = 4,
-    }
-    interface ICalculatorProperties : IReadableCalculatorProperties
-    {
-        new ValueTuple<bool> IsActive { get; set; }
     }
     interface ICalculatorHandler
     {
@@ -243,7 +239,7 @@ namespace TestNamespace
             {
                 MethodContext.ReplyError("org.freedesktop.DBus.Error.UnknownProperty", $"Unknown property: {Property}");
             }
-            public ValueTask Handle(IReadableCalculatorProperties properties)
+            public ValueTask Handle(ICalculatorProperties properties)
             {
                 switch (Property)
                 {
@@ -274,7 +270,7 @@ namespace TestNamespace
                 MethodContext = methodContext;
             }
             public void Dispose() => MethodContext.Dispose();
-            public ValueTask Handle(IReadableCalculatorProperties properties)
+            public ValueTask Handle(ICalculatorProperties properties)
             {
                 var writer = MethodContext.CreateReplyWriter("a{sv}");
                 var dictStart = writer.WriteDictionaryStart();
@@ -412,7 +408,7 @@ namespace TestNamespace
             writer.WriteDouble(result);
             c.TrySendMessage(writer.CreateMessage());
         }
-        public static void EmitPropertiesChanged(this DBusConnection c, ObjectPath p, IReadableCalculatorProperties properties, ReadOnlySpan<CalculatorProperty> changed, ReadOnlySpan<CalculatorProperty> invalidated = default)
+        public static void EmitPropertiesChanged(this DBusConnection c, ObjectPath p, ICalculatorProperties properties, ReadOnlySpan<CalculatorProperty> changed, ReadOnlySpan<CalculatorProperty> invalidated = default)
         {
             var writer = c.GetMessageWriter();
             writer.WriteSignalHeader(
@@ -471,7 +467,7 @@ namespace TestNamespace
             writer.WriteArrayEnd(arrayStart);
             c.TrySendMessage(writer.CreateMessage());
         }
-        public static void EmitPropertyChanged(this DBusConnection c, ObjectPath p, IReadableCalculatorProperties properties, CalculatorProperty changed)
+        public static void EmitPropertyChanged(this DBusConnection c, ObjectPath p, ICalculatorProperties properties, CalculatorProperty changed)
         {
             EmitPropertiesChanged(c, p, properties, stackalloc[] { changed }, default);
         }
@@ -539,21 +535,17 @@ namespace TestNamespace
         Theme = 1,
         Language = 2
     }
-    interface IReadableSettingsProperties
+    interface ISettingsProperties
     {
         string Theme { get; }
-        string Language { get; }
+        string Language { get; set; }
+        double Volume { set; }
     }
     enum WritableSettingsProperty
     {
         UnknownProperty = 0,
         Language = 2,
         Volume = 3
-    }
-    interface ISettingsProperties : IReadableSettingsProperties
-    {
-        new string Language { get; set; }
-        double Volume { set; }
     }
     interface ISettingsHandler
     {
@@ -628,7 +620,7 @@ namespace TestNamespace
             {
                 MethodContext.ReplyError("org.freedesktop.DBus.Error.UnknownProperty", $"Unknown property: {Property}");
             }
-            public ValueTask Handle(IReadableSettingsProperties properties)
+            public ValueTask Handle(ISettingsProperties properties)
             {
                 switch (Property)
                 {
@@ -653,7 +645,7 @@ namespace TestNamespace
                 MethodContext = methodContext;
             }
             public void Dispose() => MethodContext.Dispose();
-            public ValueTask Handle(IReadableSettingsProperties properties)
+            public ValueTask Handle(ISettingsProperties properties)
             {
                 var writer = MethodContext.CreateReplyWriter("a{sv}");
                 var dictStart = writer.WriteDictionaryStart();
@@ -762,7 +754,7 @@ namespace TestNamespace
                 member: "Changed");
             c.TrySendMessage(writer.CreateMessage());
         }
-        public static void EmitPropertiesChanged(this DBusConnection c, ObjectPath p, IReadableSettingsProperties properties, ReadOnlySpan<SettingsProperty> changed, ReadOnlySpan<SettingsProperty> invalidated = default)
+        public static void EmitPropertiesChanged(this DBusConnection c, ObjectPath p, ISettingsProperties properties, ReadOnlySpan<SettingsProperty> changed, ReadOnlySpan<SettingsProperty> invalidated = default)
         {
             var writer = c.GetMessageWriter();
             writer.WriteSignalHeader(
@@ -805,7 +797,7 @@ namespace TestNamespace
             writer.WriteArrayEnd(arrayStart);
             c.TrySendMessage(writer.CreateMessage());
         }
-        public static void EmitPropertyChanged(this DBusConnection c, ObjectPath p, IReadableSettingsProperties properties, SettingsProperty changed)
+        public static void EmitPropertyChanged(this DBusConnection c, ObjectPath p, ISettingsProperties properties, SettingsProperty changed)
         {
             EmitPropertiesChanged(c, p, properties, stackalloc[] { changed }, default);
         }

--- a/test/Tmds.DBus.Generator.Tests/CodeGenerationTests.VerifyGeneratedOutput_ProxyAndHandlerDifferentNameSpace.verified.txt
+++ b/test/Tmds.DBus.Generator.Tests/CodeGenerationTests.VerifyGeneratedOutput_ProxyAndHandlerDifferentNameSpace.verified.txt
@@ -16,12 +16,12 @@ namespace ProxyNamespace
         CurrentEntry = 3,
         IsActive = 4
     }
-    interface IReadableCalculatorProperties
+    interface ICalculatorProperties
     {
         double LastResult { get; }
         ObjectPath CurrentPath { get; }
         (string, double) CurrentEntry { get; }
-        ValueTuple<bool> IsActive { get; }
+        ValueTuple<bool> IsActive { get; set; }
     }
     interface INullableCalculatorProperties
     {
@@ -39,7 +39,7 @@ namespace ProxyNamespace
         bool HasCurrentEntryChanged { get; }
         bool HasIsActiveChanged { get; }
     }
-    sealed class CalculatorProperties : IChangedCalculatorProperties, IReadableCalculatorProperties
+    sealed class CalculatorProperties : IChangedCalculatorProperties, ICalculatorProperties
     {
         private uint __set;
         private uint __invalidated;
@@ -475,10 +475,11 @@ namespace ProxyNamespace
         Theme = 1,
         Language = 2
     }
-    interface IReadableSettingsProperties
+    interface ISettingsProperties
     {
         string Theme { get; }
-        string Language { get; }
+        string Language { get; set; }
+        double Volume { set; }
     }
     interface INullableSettingsProperties
     {
@@ -492,7 +493,7 @@ namespace ProxyNamespace
         bool HasThemeChanged { get; }
         bool HasLanguageChanged { get; }
     }
-    sealed class SettingsProperties : IChangedSettingsProperties, IReadableSettingsProperties
+    sealed class SettingsProperties : IChangedSettingsProperties, ISettingsProperties
     {
         private uint __set;
         private uint __invalidated;
@@ -593,6 +594,7 @@ namespace ProxyNamespace
             }
             return props;
         }
+        double ISettingsProperties.Volume { set { } }
     }
     sealed partial class Settings : Tmds.DBus.Protocol.DBusObject
     {
@@ -865,21 +867,17 @@ namespace HandlerNamespace
         CurrentEntry = 3,
         IsActive = 4
     }
-    interface IReadableCalculatorProperties
+    interface ICalculatorProperties
     {
         double LastResult { get; }
         ObjectPath CurrentPath { get; }
         (string, double) CurrentEntry { get; }
-        ValueTuple<bool> IsActive { get; }
+        ValueTuple<bool> IsActive { get; set; }
     }
     enum WritableCalculatorProperty
     {
         UnknownProperty = 0,
         IsActive = 4,
-    }
-    interface ICalculatorProperties : IReadableCalculatorProperties
-    {
-        new ValueTuple<bool> IsActive { get; set; }
     }
     interface ICalculatorHandler
     {
@@ -1092,7 +1090,7 @@ namespace HandlerNamespace
             {
                 MethodContext.ReplyError("org.freedesktop.DBus.Error.UnknownProperty", $"Unknown property: {Property}");
             }
-            public ValueTask Handle(IReadableCalculatorProperties properties)
+            public ValueTask Handle(ICalculatorProperties properties)
             {
                 switch (Property)
                 {
@@ -1123,7 +1121,7 @@ namespace HandlerNamespace
                 MethodContext = methodContext;
             }
             public void Dispose() => MethodContext.Dispose();
-            public ValueTask Handle(IReadableCalculatorProperties properties)
+            public ValueTask Handle(ICalculatorProperties properties)
             {
                 var writer = MethodContext.CreateReplyWriter("a{sv}");
                 var dictStart = writer.WriteDictionaryStart();
@@ -1261,7 +1259,7 @@ namespace HandlerNamespace
             writer.WriteDouble(result);
             c.TrySendMessage(writer.CreateMessage());
         }
-        public static void EmitPropertiesChanged(this DBusConnection c, ObjectPath p, IReadableCalculatorProperties properties, ReadOnlySpan<CalculatorProperty> changed, ReadOnlySpan<CalculatorProperty> invalidated = default)
+        public static void EmitPropertiesChanged(this DBusConnection c, ObjectPath p, ICalculatorProperties properties, ReadOnlySpan<CalculatorProperty> changed, ReadOnlySpan<CalculatorProperty> invalidated = default)
         {
             var writer = c.GetMessageWriter();
             writer.WriteSignalHeader(
@@ -1320,7 +1318,7 @@ namespace HandlerNamespace
             writer.WriteArrayEnd(arrayStart);
             c.TrySendMessage(writer.CreateMessage());
         }
-        public static void EmitPropertyChanged(this DBusConnection c, ObjectPath p, IReadableCalculatorProperties properties, CalculatorProperty changed)
+        public static void EmitPropertyChanged(this DBusConnection c, ObjectPath p, ICalculatorProperties properties, CalculatorProperty changed)
         {
             EmitPropertiesChanged(c, p, properties, stackalloc[] { changed }, default);
         }
@@ -1388,21 +1386,17 @@ namespace HandlerNamespace
         Theme = 1,
         Language = 2
     }
-    interface IReadableSettingsProperties
+    interface ISettingsProperties
     {
         string Theme { get; }
-        string Language { get; }
+        string Language { get; set; }
+        double Volume { set; }
     }
     enum WritableSettingsProperty
     {
         UnknownProperty = 0,
         Language = 2,
         Volume = 3
-    }
-    interface ISettingsProperties : IReadableSettingsProperties
-    {
-        new string Language { get; set; }
-        double Volume { set; }
     }
     interface ISettingsHandler
     {
@@ -1477,7 +1471,7 @@ namespace HandlerNamespace
             {
                 MethodContext.ReplyError("org.freedesktop.DBus.Error.UnknownProperty", $"Unknown property: {Property}");
             }
-            public ValueTask Handle(IReadableSettingsProperties properties)
+            public ValueTask Handle(ISettingsProperties properties)
             {
                 switch (Property)
                 {
@@ -1502,7 +1496,7 @@ namespace HandlerNamespace
                 MethodContext = methodContext;
             }
             public void Dispose() => MethodContext.Dispose();
-            public ValueTask Handle(IReadableSettingsProperties properties)
+            public ValueTask Handle(ISettingsProperties properties)
             {
                 var writer = MethodContext.CreateReplyWriter("a{sv}");
                 var dictStart = writer.WriteDictionaryStart();
@@ -1611,7 +1605,7 @@ namespace HandlerNamespace
                 member: "Changed");
             c.TrySendMessage(writer.CreateMessage());
         }
-        public static void EmitPropertiesChanged(this DBusConnection c, ObjectPath p, IReadableSettingsProperties properties, ReadOnlySpan<SettingsProperty> changed, ReadOnlySpan<SettingsProperty> invalidated = default)
+        public static void EmitPropertiesChanged(this DBusConnection c, ObjectPath p, ISettingsProperties properties, ReadOnlySpan<SettingsProperty> changed, ReadOnlySpan<SettingsProperty> invalidated = default)
         {
             var writer = c.GetMessageWriter();
             writer.WriteSignalHeader(
@@ -1654,7 +1648,7 @@ namespace HandlerNamespace
             writer.WriteArrayEnd(arrayStart);
             c.TrySendMessage(writer.CreateMessage());
         }
-        public static void EmitPropertyChanged(this DBusConnection c, ObjectPath p, IReadableSettingsProperties properties, SettingsProperty changed)
+        public static void EmitPropertyChanged(this DBusConnection c, ObjectPath p, ISettingsProperties properties, SettingsProperty changed)
         {
             EmitPropertiesChanged(c, p, properties, stackalloc[] { changed }, default);
         }

--- a/test/Tmds.DBus.Generator.Tests/CodeGenerationTests.VerifyGeneratedOutput_ProxyAndHandlerSameNamespace.verified.txt
+++ b/test/Tmds.DBus.Generator.Tests/CodeGenerationTests.VerifyGeneratedOutput_ProxyAndHandlerSameNamespace.verified.txt
@@ -16,21 +16,17 @@ namespace TestNamespace
         CurrentEntry = 3,
         IsActive = 4
     }
-    interface IReadableCalculatorProperties
+    interface ICalculatorProperties
     {
         double LastResult { get; }
         ObjectPath CurrentPath { get; }
         (string, double) CurrentEntry { get; }
-        ValueTuple<bool> IsActive { get; }
+        ValueTuple<bool> IsActive { get; set; }
     }
     enum WritableCalculatorProperty
     {
         UnknownProperty = 0,
         IsActive = 4,
-    }
-    interface ICalculatorProperties : IReadableCalculatorProperties
-    {
-        new ValueTuple<bool> IsActive { get; set; }
     }
     interface INullableCalculatorProperties
     {
@@ -48,7 +44,7 @@ namespace TestNamespace
         bool HasCurrentEntryChanged { get; }
         bool HasIsActiveChanged { get; }
     }
-    sealed class CalculatorProperties : IChangedCalculatorProperties, IReadableCalculatorProperties
+    sealed class CalculatorProperties : IChangedCalculatorProperties, ICalculatorProperties
     {
         private uint __set;
         private uint __invalidated;
@@ -689,7 +685,7 @@ namespace TestNamespace
             {
                 MethodContext.ReplyError("org.freedesktop.DBus.Error.UnknownProperty", $"Unknown property: {Property}");
             }
-            public ValueTask Handle(IReadableCalculatorProperties properties)
+            public ValueTask Handle(ICalculatorProperties properties)
             {
                 switch (Property)
                 {
@@ -720,7 +716,7 @@ namespace TestNamespace
                 MethodContext = methodContext;
             }
             public void Dispose() => MethodContext.Dispose();
-            public ValueTask Handle(IReadableCalculatorProperties properties)
+            public ValueTask Handle(ICalculatorProperties properties)
             {
                 var writer = MethodContext.CreateReplyWriter("a{sv}");
                 var dictStart = writer.WriteDictionaryStart();
@@ -858,7 +854,7 @@ namespace TestNamespace
             writer.WriteDouble(result);
             c.TrySendMessage(writer.CreateMessage());
         }
-        public static void EmitPropertiesChanged(this DBusConnection c, ObjectPath p, IReadableCalculatorProperties properties, ReadOnlySpan<CalculatorProperty> changed, ReadOnlySpan<CalculatorProperty> invalidated = default)
+        public static void EmitPropertiesChanged(this DBusConnection c, ObjectPath p, ICalculatorProperties properties, ReadOnlySpan<CalculatorProperty> changed, ReadOnlySpan<CalculatorProperty> invalidated = default)
         {
             var writer = c.GetMessageWriter();
             writer.WriteSignalHeader(
@@ -917,7 +913,7 @@ namespace TestNamespace
             writer.WriteArrayEnd(arrayStart);
             c.TrySendMessage(writer.CreateMessage());
         }
-        public static void EmitPropertyChanged(this DBusConnection c, ObjectPath p, IReadableCalculatorProperties properties, CalculatorProperty changed)
+        public static void EmitPropertyChanged(this DBusConnection c, ObjectPath p, ICalculatorProperties properties, CalculatorProperty changed)
         {
             EmitPropertiesChanged(c, p, properties, stackalloc[] { changed }, default);
         }
@@ -985,21 +981,17 @@ namespace TestNamespace
         Theme = 1,
         Language = 2
     }
-    interface IReadableSettingsProperties
+    interface ISettingsProperties
     {
         string Theme { get; }
-        string Language { get; }
+        string Language { get; set; }
+        double Volume { set; }
     }
     enum WritableSettingsProperty
     {
         UnknownProperty = 0,
         Language = 2,
         Volume = 3
-    }
-    interface ISettingsProperties : IReadableSettingsProperties
-    {
-        new string Language { get; set; }
-        double Volume { set; }
     }
     interface INullableSettingsProperties
     {
@@ -1013,7 +1005,7 @@ namespace TestNamespace
         bool HasThemeChanged { get; }
         bool HasLanguageChanged { get; }
     }
-    sealed class SettingsProperties : IChangedSettingsProperties, IReadableSettingsProperties
+    sealed class SettingsProperties : IChangedSettingsProperties, ISettingsProperties
     {
         private uint __set;
         private uint __invalidated;
@@ -1114,6 +1106,7 @@ namespace TestNamespace
             }
             return props;
         }
+        double ISettingsProperties.Volume { set { } }
     }
     sealed partial class Settings : Tmds.DBus.Protocol.DBusObject
     {
@@ -1326,7 +1319,7 @@ namespace TestNamespace
             {
                 MethodContext.ReplyError("org.freedesktop.DBus.Error.UnknownProperty", $"Unknown property: {Property}");
             }
-            public ValueTask Handle(IReadableSettingsProperties properties)
+            public ValueTask Handle(ISettingsProperties properties)
             {
                 switch (Property)
                 {
@@ -1351,7 +1344,7 @@ namespace TestNamespace
                 MethodContext = methodContext;
             }
             public void Dispose() => MethodContext.Dispose();
-            public ValueTask Handle(IReadableSettingsProperties properties)
+            public ValueTask Handle(ISettingsProperties properties)
             {
                 var writer = MethodContext.CreateReplyWriter("a{sv}");
                 var dictStart = writer.WriteDictionaryStart();
@@ -1460,7 +1453,7 @@ namespace TestNamespace
                 member: "Changed");
             c.TrySendMessage(writer.CreateMessage());
         }
-        public static void EmitPropertiesChanged(this DBusConnection c, ObjectPath p, IReadableSettingsProperties properties, ReadOnlySpan<SettingsProperty> changed, ReadOnlySpan<SettingsProperty> invalidated = default)
+        public static void EmitPropertiesChanged(this DBusConnection c, ObjectPath p, ISettingsProperties properties, ReadOnlySpan<SettingsProperty> changed, ReadOnlySpan<SettingsProperty> invalidated = default)
         {
             var writer = c.GetMessageWriter();
             writer.WriteSignalHeader(
@@ -1503,7 +1496,7 @@ namespace TestNamespace
             writer.WriteArrayEnd(arrayStart);
             c.TrySendMessage(writer.CreateMessage());
         }
-        public static void EmitPropertyChanged(this DBusConnection c, ObjectPath p, IReadableSettingsProperties properties, SettingsProperty changed)
+        public static void EmitPropertyChanged(this DBusConnection c, ObjectPath p, ISettingsProperties properties, SettingsProperty changed)
         {
             EmitPropertiesChanged(c, p, properties, stackalloc[] { changed }, default);
         }

--- a/test/Tmds.DBus.Generator.Tests/CodeGenerationTests.VerifyGeneratedOutput_ProxyOnly.verified.txt
+++ b/test/Tmds.DBus.Generator.Tests/CodeGenerationTests.VerifyGeneratedOutput_ProxyOnly.verified.txt
@@ -16,12 +16,12 @@ namespace TestNamespace
         CurrentEntry = 3,
         IsActive = 4
     }
-    interface IReadableCalculatorProperties
+    interface ICalculatorProperties
     {
         double LastResult { get; }
         ObjectPath CurrentPath { get; }
         (string, double) CurrentEntry { get; }
-        ValueTuple<bool> IsActive { get; }
+        ValueTuple<bool> IsActive { get; set; }
     }
     interface INullableCalculatorProperties
     {
@@ -39,7 +39,7 @@ namespace TestNamespace
         bool HasCurrentEntryChanged { get; }
         bool HasIsActiveChanged { get; }
     }
-    sealed class CalculatorProperties : IChangedCalculatorProperties, IReadableCalculatorProperties
+    sealed class CalculatorProperties : IChangedCalculatorProperties, ICalculatorProperties
     {
         private uint __set;
         private uint __invalidated;
@@ -475,10 +475,11 @@ namespace TestNamespace
         Theme = 1,
         Language = 2
     }
-    interface IReadableSettingsProperties
+    interface ISettingsProperties
     {
         string Theme { get; }
-        string Language { get; }
+        string Language { get; set; }
+        double Volume { set; }
     }
     interface INullableSettingsProperties
     {
@@ -492,7 +493,7 @@ namespace TestNamespace
         bool HasThemeChanged { get; }
         bool HasLanguageChanged { get; }
     }
-    sealed class SettingsProperties : IChangedSettingsProperties, IReadableSettingsProperties
+    sealed class SettingsProperties : IChangedSettingsProperties, ISettingsProperties
     {
         private uint __set;
         private uint __invalidated;
@@ -593,6 +594,7 @@ namespace TestNamespace
             }
             return props;
         }
+        double ISettingsProperties.Volume { set { } }
     }
     sealed partial class Settings : Tmds.DBus.Protocol.DBusObject
     {


### PR DESCRIPTION
Write-only properties are uncommon and having a separate IReadableXxxProperties interfaces makes (explicit interface) implementations more verbose.