### PR TITLE
ProtocolGenerator: use fully-qualified names to avoid conflicts with generated types.

### DIFF
--- a/src/Tmds.DBus.Tool/ProtocolGenerator.cs
+++ b/src/Tmds.DBus.Tool/ProtocolGenerator.cs
@@ -39,6 +39,15 @@ namespace Tmds.DBus.Tool
         private readonly HashSet<string> _interfacesWithProperties = new();
         private int _indentation = 0;
 
+        // Fully-qualified name prefixes for generated code.
+        private const string _proto = "global::Tmds.DBus.Protocol";
+        private const string _task = "global::System.Threading.Tasks.Task";
+        private const string _vtask = "global::System.Threading.Tasks.ValueTask";
+        private const string _action = "global::System.Action";
+        private const string _func = "global::System.Func";
+        private const string _idisposable = "global::System.IDisposable";
+        private const string _syncCtx = "global::System.Threading.SynchronizationContext";
+
         public ProtocolGenerator(ProtocolGeneratorSettings settings)
         {
             _settings = settings;
@@ -82,12 +91,6 @@ namespace Tmds.DBus.Tool
 
             AppendLine($"namespace {ns}");
             StartBlock();
-
-            AppendLine($"using System;");
-            AppendLine($"using Tmds.DBus.Protocol;");
-            AppendLine($"using System.Collections.Generic;");
-            AppendLine("using System.Threading.Tasks;");
-            AppendLine("using System.Runtime.CompilerServices;");
 
             bool anyProxies = false;
             foreach (var interf in interfaceDescriptions)
@@ -138,11 +141,6 @@ namespace Tmds.DBus.Tool
             AppendLine("namespace Tmds.DBus.Protocol");
             StartBlock();
 
-            AppendLine("using System;");
-            AppendLine("using System.Collections.Generic;");
-            AppendLine("using System.Threading;");
-            AppendLine("using System.Threading.Tasks;");
-
             // Add IIntrospectable to the generated handlers list for switch statement
             // Note: IIntrospectable is now handled directly in DBusHandler, not as a separate interface
             _generatedHandlers.Add(("Tmds.DBus.Protocol", "org.freedesktop.DBus.Introspectable", "IIntrospectable"));
@@ -154,7 +152,7 @@ namespace Tmds.DBus.Tool
 
             // Generate DBusInterface Flags enum inside DBusHandler
             AppendLine("// Identifies the D-Bus interfaces. Used with SupportsInterface to filter interfaces per path.");
-            AppendLine("[Flags]");
+            AppendLine("[global::System.Flags]");
             AppendLine("public enum DBusInterface");
             StartBlock();
             // Add Introspectable interface as first item
@@ -175,7 +173,7 @@ namespace Tmds.DBus.Tool
                 if (_interfaceXmls.TryGetValue(interfaceName, out var xml))
                 {
                     string enumName = InterfaceNameToEnumValueName(interfaceName);
-                    AppendLine($"private static ReadOnlyMemory<byte> {enumName}Xml {{ get; }} =");
+                    AppendLine($"private static global::System.ReadOnlyMemory<byte> {enumName}Xml {{ get; }} =");
                     _indentation++;
                     AppendLine("\"\"\"");
 
@@ -211,7 +209,7 @@ namespace Tmds.DBus.Tool
                 }
             }
 
-            AppendLine("private readonly SendOrPostCallback? _postDelegate;");
+            AppendLine("private readonly global::System.Threading.SendOrPostCallback? _postDelegate;");
             AppendLine("");
 
             // Add private const for OrgFreedesktopDBusIntrospectable
@@ -244,14 +242,14 @@ namespace Tmds.DBus.Tool
             AppendLine("public bool HandlesChildPaths { get; }");
             AppendLine("public DBusConnection Connection { get; }");
             AppendLine("// The SynchronizationContext on which method handlers are invoked.");
-            AppendLine("protected SynchronizationContext? SynchronizationContext { get; }");
+            AppendLine($"protected {_syncCtx}? SynchronizationContext {{ get; }}");
             AppendLine("");
             AppendLine("protected DBusHandler(DBusConnection connection, string path, bool handlesChildPaths, bool handleOnCapturedContext = true)");
-            AppendLine("    : this(connection, path, handlesChildPaths, handleOnCapturedContext ? SynchronizationContext.Current : null)");
+            AppendLine($"    : this(connection, path, handlesChildPaths, handleOnCapturedContext ? {_syncCtx}.Current : null)");
             StartBlock();
             EndBlock();
             AppendLine("");
-            AppendLine("protected DBusHandler(DBusConnection connection, string path, bool handlesChildPaths, SynchronizationContext? synchronizationContext)");
+            AppendLine($"protected DBusHandler(DBusConnection connection, string path, bool handlesChildPaths, {_syncCtx}? synchronizationContext)");
             StartBlock();
             AppendLine("Connection = connection;");
             AppendLine("Path = path;");
@@ -271,13 +269,13 @@ namespace Tmds.DBus.Tool
             EndBlock();
 
             AppendLine("// Override to add cross-cutting logic (e.g. logging, error handling) around method invocations.");
-            AppendLine("protected virtual async ValueTask InvokeAsync(DBusMethod method, MethodContext context)");
+            AppendLine($"protected virtual async {_vtask} InvokeAsync(DBusMethod method, MethodContext context)");
             StartBlock();
             AppendLine("try");
             StartBlock();
             AppendLine("await method.Invoke(context).ConfigureAwait(false);");
             EndBlock();
-            AppendLine("catch (Exception ex)");
+            AppendLine("catch (global::System.Exception ex)");
             StartBlock();
             AppendLine("HandleException(context, ex);");
             EndBlock();
@@ -285,7 +283,7 @@ namespace Tmds.DBus.Tool
             AppendLine("");
 
             AppendLine("// Override to customize exception handling for method invocations.");
-            AppendLine("protected virtual void HandleException(MethodContext context, Exception ex)");
+            AppendLine("protected virtual void HandleException(MethodContext context, global::System.Exception ex)");
             StartBlock();
             AppendLine("if (context.HandleException(ex, shouldDisconnect: false))");
             StartBlock();
@@ -295,7 +293,7 @@ namespace Tmds.DBus.Tool
             StartBlock();
             AppendLine("context.ReplyError(dbusEx.ErrorName, dbusEx.ErrorMessage);");
             EndBlock();
-            AppendLine("else if (ex is ArgumentException)");
+            AppendLine("else if (ex is global::System.ArgumentException)");
             StartBlock();
             AppendLine("context.ReplyError(\"org.freedesktop.DBus.Error.InvalidArgs\", ex.Message);");
             EndBlock();
@@ -307,7 +305,7 @@ namespace Tmds.DBus.Tool
             AppendLine("");
 
             AppendLine("// Override to filter interfaces for specific paths when the handler manages multiple paths.");
-            AppendLine("protected virtual bool SupportsInterface(DBusInterface dbusInterface, ReadOnlySpan<char> path)");
+            AppendLine("protected virtual bool SupportsInterface(DBusInterface dbusInterface, global::System.ReadOnlySpan<char> path)");
             StartBlock();
             AppendLine("return true;");
             EndBlock();
@@ -315,9 +313,9 @@ namespace Tmds.DBus.Tool
 
             // Add IntrospectAsync virtual method
             AppendLine("// Override to customize introspection, e.g. to include child node names.");
-            AppendLine("protected virtual ValueTask HandleIntrospectAsync(IntrospectContext context)");
+            AppendLine($"protected virtual {_vtask} HandleIntrospectAsync(IntrospectContext context)");
             StartBlock();
-            AppendLine("DBusInterface interfaces = GetSupportedInterfaces(context.MethodContext.Request.PathAsString.AsSpan());");
+            AppendLine("DBusInterface interfaces = GetSupportedInterfaces(global::System.MemoryExtensions.AsSpan(context.MethodContext.Request.PathAsString));");
             AppendLine("context.Reply(interfaces);");
             AppendLine("return default;");
             EndBlock();
@@ -325,7 +323,7 @@ namespace Tmds.DBus.Tool
 
             // Add IntrospectContext struct
             AppendLine("// Context for IntrospectAsync. Call Reply to send the introspection XML response.");
-            AppendLine("protected readonly struct IntrospectContext : IDisposable");
+            AppendLine($"protected readonly struct IntrospectContext : {_idisposable}");
             StartBlock();
             AppendLine("public MethodContext MethodContext { get; }");
             AppendLine("public IntrospectContext(MethodContext methodContext)");
@@ -333,12 +331,12 @@ namespace Tmds.DBus.Tool
             AppendLine("MethodContext = methodContext;");
             EndBlock();
             AppendLine("public void Dispose() => MethodContext.Dispose();");
-            AppendLine("public void Reply(DBusInterface interfaces, IList<string>? childNames = null)");
+            AppendLine("public void Reply(DBusInterface interfaces, global::System.Collections.Generic.IList<string>? childNames = null)");
             StartBlock();
 
             // Create an array for interface XMLs (interfaces + 1 for potential DBusProperties)
             int interfaceCount = allInterfaces.Count + 1;
-            AppendLine($"var interfaceXmls = new ReadOnlyMemory<byte>[{interfaceCount}];");
+            AppendLine($"var interfaceXmls = new global::System.ReadOnlyMemory<byte>[{interfaceCount}];");
             AppendLine("int count = 0;");
 
             // Check each interface flag and add corresponding XML
@@ -359,11 +357,11 @@ namespace Tmds.DBus.Tool
 
             AppendLine("if (childNames is not null)");
             StartBlock();
-            AppendLine("MethodContext.ReplyIntrospectXml(interfaceXmls.AsSpan(0, count), childNames);");
+            AppendLine("MethodContext.ReplyIntrospectXml(global::System.MemoryExtensions.AsSpan(interfaceXmls, 0, count), childNames);");
             EndBlock();
             AppendLine("else");
             StartBlock();
-            AppendLine("MethodContext.ReplyIntrospectXml(interfaceXmls.AsSpan(0, count));");
+            AppendLine("MethodContext.ReplyIntrospectXml(global::System.MemoryExtensions.AsSpan(interfaceXmls, 0, count));");
             EndBlock();
             EndBlock();
             EndBlock();
@@ -372,10 +370,10 @@ namespace Tmds.DBus.Tool
             // Generate DBusMethod struct inside DBusHandler
             AppendLine("internal readonly struct DBusMethod");
             StartBlock();
-            AppendLine("private readonly Func<object, MethodContext, ValueTask> _method;");
+            AppendLine($"private readonly {_func}<object, MethodContext, {_vtask}> _method;");
             AppendLine("private readonly object _target;");
             AppendLine("");
-            AppendLine("public DBusMethod(Func<object, MethodContext, ValueTask> method, object target)");
+            AppendLine($"public DBusMethod({_func}<object, MethodContext, {_vtask}> method, object target)");
             StartBlock();
             AppendLine("_method = method;");
             AppendLine("_target = target;");
@@ -383,17 +381,17 @@ namespace Tmds.DBus.Tool
             AppendLine("");
             AppendLine("public bool HasValue => _method is not null;");
             AppendLine("");
-            AppendLine("public ValueTask Invoke(MethodContext context)");
+            AppendLine($"public {_vtask} Invoke(MethodContext context)");
             StartBlock();
             AppendLine("return _method?.Invoke(_target, context) ?? default;");
             EndBlock();
             EndBlock();
             AppendLine("");
 
-            AppendLine("ValueTask IPathMethodHandler.HandleMethodAsync(MethodContext context)");
+            AppendLine($"{_vtask} IPathMethodHandler.HandleMethodAsync(MethodContext context)");
             StartBlock();
             AppendLine("DBusInterface dbusInterface = ParseInterface(context);");
-            AppendLine("DBusMethod method = (dbusInterface != OrgFreedesktopDBusIntrospectable && !SupportsInterface(dbusInterface, context.Request.PathAsString.AsSpan())) ? default : FindMethodHandler(context, dbusInterface);");
+            AppendLine("DBusMethod method = (dbusInterface != OrgFreedesktopDBusIntrospectable && !SupportsInterface(dbusInterface, global::System.MemoryExtensions.AsSpan(context.Request.PathAsString))) ? default : FindMethodHandler(context, dbusInterface);");
             AppendLine("if (!method.HasValue)");
             StartBlock();
             AppendLine("return default;");
@@ -401,9 +399,9 @@ namespace Tmds.DBus.Tool
             AppendLine("return HandleAsync(method, context);");
             EndBlock();
             AppendLine("");
-            AppendLine("private ValueTask HandleAsync(DBusMethod method, MethodContext context)");
+            AppendLine($"private {_vtask} HandleAsync(DBusMethod method, MethodContext context)");
             StartBlock();
-            AppendLine("SynchronizationContext? synchronizationContext = SynchronizationContext;");
+            AppendLine($"{_syncCtx}? synchronizationContext = SynchronizationContext;");
             AppendLine("if (synchronizationContext is null)");
             StartBlock();
             AppendLine("return InvokeAsync(method, context);");
@@ -416,7 +414,7 @@ namespace Tmds.DBus.Tool
             EndBlock();
             EndBlock();
             AppendLine("");
-            AppendLine("private async ValueTask InvokeAndDisposeAsync(DBusMethod method, MethodContext context)");
+            AppendLine($"private async {_vtask} InvokeAndDisposeAsync(DBusMethod method, MethodContext context)");
             StartBlock();
             AppendLine("try");
             StartBlock();
@@ -501,7 +499,7 @@ namespace Tmds.DBus.Tool
             EndBlock();
             AppendLine("");
 
-            AppendLine("protected DBusInterface GetSupportedInterfaces(ReadOnlySpan<char> path)");
+            AppendLine("protected DBusInterface GetSupportedInterfaces(global::System.ReadOnlySpan<char> path)");
             StartBlock();
             AppendLine("DBusInterface interfaces = default;");
 
@@ -539,7 +537,7 @@ namespace Tmds.DBus.Tool
             foreach (var interf in interfaceDescriptions)
             {
                 string interfaceName = interf.Name;
-                AppendLine($"public static {interfaceName} Create{interfaceName}(this DBusService service, ObjectPath path) => new {interfaceName}(service.Connection, service.Name, path);");
+                AppendLine($"public static {interfaceName} Create{interfaceName}(this {_proto}.DBusService service, {_proto}.ObjectPath path) => new {interfaceName}(service.Connection, service.Name, path);");
             }
             EndBlock();
         }
@@ -578,7 +576,7 @@ namespace Tmds.DBus.Tool
         private void AppendReadTypeMethod(string method, string signature)
         {
             string dotnetReturnType = GetDotnetReadType(signature);
-            AppendLine($"public static {dotnetReturnType} {method}(this ref Reader reader)");
+            AppendLine($"public static {dotnetReturnType} {method}(this ref {_proto}.Reader reader)");
             StartBlock();
             SignatureReader reader = new SignatureReader(Encoding.UTF8.GetBytes(signature));
             if (reader.TryRead(out DBusType type, out ReadOnlySpan<byte> innerSignature))
@@ -607,8 +605,8 @@ namespace Tmds.DBus.Tool
                         string keyTypeSignature = GetSignature(keyType, keyInnerSignature);
                         string valueTypeSignature = GetSignature(valueType, valueInnerSignature);
 
-                        AppendLine($"Dictionary<{dotnetKeyType}, {dotnetValueType}> dictionary = new();");
-                        AppendLine($"ArrayEnd dictEnd = reader.ReadDictionaryStart();");
+                        AppendLine($"global::System.Collections.Generic.Dictionary<{dotnetKeyType}, {dotnetValueType}> dictionary = new();");
+                        AppendLine($"{_proto}.ArrayEnd dictEnd = reader.ReadDictionaryStart();");
 
                         AppendLine($"while (reader.HasNext(dictEnd))");
                         StartBlock();
@@ -623,8 +621,8 @@ namespace Tmds.DBus.Tool
                     {
                         string dotnetItemType = GetDotnetReadType(itemType, itemInnerSignature);
 
-                        AppendLine($"List<{dotnetItemType}> list = new();");
-                        AppendLine($"ArrayEnd arrayEnd = reader.ReadArrayStart({GetDBusTypeEnumValue(itemType)});");
+                        AppendLine($"global::System.Collections.Generic.List<{dotnetItemType}> list = new();");
+                        AppendLine($"{_proto}.ArrayEnd arrayEnd = reader.ReadArrayStart({GetDBusTypeEnumValue(itemType)});");
 
                         AppendLine($"while (reader.HasNext(arrayEnd))");
                         StartBlock();
@@ -662,7 +660,7 @@ namespace Tmds.DBus.Tool
         private void AppendWriteTypeMethod(string method, bool variant, string signature)
         {
             string dotnetArgType = GetDotnetWriteType(signature);
-            AppendLine($"public static void {method}(this ref MessageWriter writer, {dotnetArgType} value)");
+            AppendLine($"public static void {method}(this ref {_proto}.MessageWriter writer, {dotnetArgType} value)");
             StartBlock();
             if (variant)
             {
@@ -696,7 +694,7 @@ namespace Tmds.DBus.Tool
                             string keyTypeSignature = GetSignature(keyType, keyInnerSignature);
                             string valueTypeSignature = GetSignature(valueType, valueInnerSignature);
 
-                            AppendLine($"ArrayStart arrayStart = writer.WriteDictionaryStart();");
+                            AppendLine($"{_proto}.ArrayStart arrayStart = writer.WriteDictionaryStart();");
                             AppendLine($"foreach (var item in value)");
                             StartBlock();
                             AppendLine($"writer.WriteDictionaryEntryStart();");
@@ -709,7 +707,7 @@ namespace Tmds.DBus.Tool
                         {
                             string dotnetItemSignature = GetSignature(itemType, itemInnerSignature);
 
-                            AppendLine($"ArrayStart arrayStart = writer.WriteArrayStart({GetDBusTypeEnumValue(itemType)});");
+                            AppendLine($"{_proto}.ArrayStart arrayStart = writer.WriteArrayStart({GetDBusTypeEnumValue(itemType)});");
                             AppendLine($"foreach (var item in value)");
                             StartBlock();
                             AppendLine($"{CallWriteArgumentType(dotnetItemSignature, "item")};");
@@ -787,7 +785,7 @@ namespace Tmds.DBus.Tool
             }
 
             // Add FindMethodHandler method to Helper class
-            AppendLine($"public static DBusHandler.DBusMethod FindMethodHandler(object handler, MethodContext context)");
+            AppendLine($"public static {_proto}.DBusHandler.DBusMethod FindMethodHandler(object handler, {_proto}.MethodContext context)");
             StartBlock();
             AppendLine("var request = context.Request;");
 
@@ -801,13 +799,13 @@ namespace Tmds.DBus.Tool
 
                 if (readableProperties.Any())
                 {
-                    AppendLine("(\"Get\", \"ss\") => new DBusHandler.DBusMethod(static (o, c) => ((I" + handlerName + ")o).HandleGetPropertyAsync(new GetPropertyContext(c)), handler),");
-                    AppendLine("(\"GetAll\", \"s\") => new DBusHandler.DBusMethod(static (o, c) => ((I" + handlerName + ")o).HandleGetAllPropertiesAsync(new GetAllPropertiesContext(c)), handler),");
+                    AppendLine($"(\"Get\", \"ss\") => new {_proto}.DBusHandler.DBusMethod(static (o, c) => ((I{handlerName})o).HandleGetPropertyAsync(new GetPropertyContext(c)), handler),");
+                    AppendLine($"(\"GetAll\", \"s\") => new {_proto}.DBusHandler.DBusMethod(static (o, c) => ((I{handlerName})o).HandleGetAllPropertiesAsync(new GetAllPropertiesContext(c)), handler),");
                 }
 
                 if (writableProperties.Any())
                 {
-                    AppendLine("(\"Set\", \"ssv\") => new DBusHandler.DBusMethod(static (o, c) => ((I" + handlerName + ")o).HandleSetPropertyAsync(new SetPropertyContext(c)), handler),");
+                    AppendLine($"(\"Set\", \"ssv\") => new {_proto}.DBusHandler.DBusMethod(static (o, c) => ((I{handlerName})o).HandleSetPropertyAsync(new SetPropertyContext(c)), handler),");
                 }
 
                 AppendLine("_ => default");
@@ -830,7 +828,7 @@ namespace Tmds.DBus.Tool
                     var inArgs = method.Elements("arg").Where(arg => (arg.Attribute("direction")?.Value ?? "in") == "in").Select(ToArgument).ToArray();
                     string signature = string.Join("", inArgs.Select(a => a.Signature));
 
-                    AppendLine($"(\"{dbusMethodName}\", \"{signature}\") => new DBusHandler.DBusMethod(static (o, c) => Handle{dotnetMethodName}Async((I{handlerName})o, c), handler),");
+                    AppendLine($"(\"{dbusMethodName}\", \"{signature}\") => new {_proto}.DBusHandler.DBusMethod(static (o, c) => Handle{dotnetMethodName}Async((I{handlerName})o, c), handler),");
                 }
 
                 AppendLine("_ => default");
@@ -853,7 +851,7 @@ namespace Tmds.DBus.Tool
                 var inArgs = method.Elements("arg").Where(arg => (arg.Attribute("direction")?.Value ?? "in") == "in").Select(ToArgument).ToArray();
                 var outArgs = method.Elements("arg").Where(arg => arg.Attribute("direction")?.Value == "out").Select(ToArgument).ToArray();
 
-                AppendLine($"static async ValueTask Handle{dotnetMethodName}Async(I{handlerName} handler, MethodContext context)");
+                AppendLine($"static async {_vtask} Handle{dotnetMethodName}Async(I{handlerName} handler, {_proto}.MethodContext context)");
                 StartBlock();
 
                 // Read args
@@ -879,7 +877,7 @@ namespace Tmds.DBus.Tool
                     string resultType = outArgs[0].DotnetReadType;
                     AppendLine($"var result = await handler.{dotnetMethodName}Async({callArgs}).ConfigureAwait(false);");
                     AppendLine("WriteReply(context, result);");
-                    AppendLine($"static void WriteReply(MethodContext context, {resultType} result)");
+                    AppendLine($"static void WriteReply({_proto}.MethodContext context, {resultType} result)");
                     StartBlock();
                     AppendLine($"var writer = context.CreateReplyWriter(\"{outSignature}\");");
                     AppendLine($"{CallWriteArgumentType(outArgs[0].Signature, "result")};");
@@ -892,7 +890,7 @@ namespace Tmds.DBus.Tool
                     string tupleType = TupleOf(outArgs.Select(a => $"{a.DotnetReadType} {a.NameUpper}"));
                     AppendLine($"var result = await handler.{dotnetMethodName}Async({callArgs}).ConfigureAwait(false);");
                     AppendLine("WriteReply(context, result);");
-                    AppendLine($"static void WriteReply(MethodContext context, {tupleType} result)");
+                    AppendLine($"static void WriteReply({_proto}.MethodContext context, {tupleType} result)");
                     StartBlock();
                     AppendLine($"var writer = context.CreateReplyWriter(\"{outSignature}\");");
                     foreach (var outArg in outArgs)
@@ -915,14 +913,14 @@ namespace Tmds.DBus.Tool
 
             if (readableProperties.Any())
             {
-                AppendLine("ValueTask HandleGetPropertyAsync(GetPropertyContext context);");
+                AppendLine($"{_vtask} HandleGetPropertyAsync(GetPropertyContext context);");
 
-                AppendLine("ValueTask HandleGetAllPropertiesAsync(GetAllPropertiesContext context);");
+                AppendLine($"{_vtask} HandleGetAllPropertiesAsync(GetAllPropertiesContext context);");
             }
 
             if (writableProperties.Any())
             {
-                AppendLine("ValueTask HandleSetPropertyAsync(SetPropertyContext context);");
+                AppendLine($"{_vtask} HandleSetPropertyAsync(SetPropertyContext context);");
             }
 
             foreach (var method in interfaceXml.Elements("method"))
@@ -936,16 +934,16 @@ namespace Tmds.DBus.Tool
                 string returnType;
                 if (outArgs.Length == 0)
                 {
-                    returnType = "ValueTask";
+                    returnType = _vtask;
                 }
                 else if (outArgs.Length == 1)
                 {
-                    returnType = $"ValueTask<{outArgs[0].DotnetReadType}>";
+                    returnType = $"{_vtask}<{outArgs[0].DotnetReadType}>";
                 }
                 else
                 {
                     string tupleType = TupleOf(outArgs.Select(a => $"{a.DotnetReadType} {a.NameUpper}"));
-                    returnType = $"ValueTask<{tupleType}>";
+                    returnType = $"{_vtask}<{tupleType}>";
                 }
                 AppendLine($"{returnType} {dotnetMethodName}Async({parameters});");
             }
@@ -954,12 +952,12 @@ namespace Tmds.DBus.Tool
             {
                 // Generate GetPropertyContext
                 string propertyEnumName = $"{name}Property";
-                AppendLine("readonly struct GetPropertyContext : IDisposable");
+                AppendLine($"readonly struct GetPropertyContext : {_idisposable}");
                 StartBlock();
 
-                AppendLine("public MethodContext MethodContext { get; }");
+                AppendLine($"public {_proto}.MethodContext MethodContext {{ get; }}");
                 AppendLine($"public {propertyEnumName} Property {{ get; }}");
-                AppendLine("public GetPropertyContext(MethodContext methodContext)");
+                AppendLine($"public GetPropertyContext({_proto}.MethodContext methodContext)");
                 StartBlock();
                 AppendLine("MethodContext = methodContext;");
                 AppendLine("var reader = methodContext.Request.GetBodyReader();");
@@ -975,7 +973,7 @@ namespace Tmds.DBus.Tool
                     string writeMethodName = GetWriteTypeMethodName(property.Signature, variant: true);
                     AppendLine($"public void Reply{property.NameUpper}({property.DotnetReadType} value)");
                     StartBlock();
-                    AppendLine($"System.Diagnostics.Debug.Assert(Property == {propertyEnumName}.{property.NameUpper});");
+                    AppendLine($"global::System.Diagnostics.Debug.Assert(Property == {propertyEnumName}.{property.NameUpper});");
                     AppendLine("var writer = MethodContext.CreateReplyWriter(\"v\");");
                     AppendLine($"writer.{writeMethodName}(value);");
                     AppendLine("MethodContext.Reply(writer.CreateMessage());");
@@ -988,7 +986,7 @@ namespace Tmds.DBus.Tool
                 AppendLine("MethodContext.ReplyError(\"org.freedesktop.DBus.Error.UnknownProperty\", $\"Unknown property: {Property}\");");
                 EndBlock();
 
-                AppendLine($"public ValueTask Handle(I{name}Properties properties)");
+                AppendLine($"public {_vtask} Handle(I{name}Properties properties)");
                 StartBlock();
                 AppendLine("switch (Property)");
                 StartBlock();
@@ -1012,18 +1010,18 @@ namespace Tmds.DBus.Tool
                 EndBlock();
 
                 // Generate GetAllPropertiesContext
-                AppendLine("readonly struct GetAllPropertiesContext : IDisposable");
+                AppendLine($"readonly struct GetAllPropertiesContext : {_idisposable}");
                 StartBlock();
 
-                AppendLine("public MethodContext MethodContext { get; }");
-                AppendLine("public GetAllPropertiesContext(MethodContext methodContext)");
+                AppendLine($"public {_proto}.MethodContext MethodContext {{ get; }}");
+                AppendLine($"public GetAllPropertiesContext({_proto}.MethodContext methodContext)");
                 StartBlock();
                 AppendLine("MethodContext = methodContext;");
                 EndBlock();
 
                 AppendLine("public void Dispose() => MethodContext.Dispose();");
 
-                AppendLine($"public ValueTask Handle(I{name}Properties properties)");
+                AppendLine($"public {_vtask} Handle(I{name}Properties properties)");
                 StartBlock();
                 AppendLine("var writer = MethodContext.CreateReplyWriter(\"a{sv}\");");
                 AppendLine("var dictStart = writer.WriteDictionaryStart();");
@@ -1042,7 +1040,7 @@ namespace Tmds.DBus.Tool
                 // Handle overload that accepts all gettable properties as nullable individual arguments (alphabetically sorted)
                 var sortedReadableProperties = readableProperties.OrderBy(p => p.NameUpper).ToArray();
                 string handleArgs = string.Join(", ", sortedReadableProperties.Select(p => $"{GetNullableType(p.DotnetWriteType)} {p.NameLower} = default"));
-                AppendLine($"public ValueTask Handle({handleArgs})");
+                AppendLine($"public {_vtask} Handle({handleArgs})");
                 StartBlock();
                 AppendLine("var writer = MethodContext.CreateReplyWriter(\"a{sv}\");");
                 AppendLine("var dictStart = writer.WriteDictionaryStart();");
@@ -1069,12 +1067,12 @@ namespace Tmds.DBus.Tool
             {
                 // Generate SetPropertyContext
                 string writablePropertyEnumName = $"Writable{name}Property";
-                AppendLine("readonly struct SetPropertyContext : IDisposable");
+                AppendLine($"readonly struct SetPropertyContext : {_idisposable}");
                 StartBlock();
 
-                AppendLine("public MethodContext MethodContext { get; }");
+                AppendLine($"public {_proto}.MethodContext MethodContext {{ get; }}");
                 AppendLine($"public {writablePropertyEnumName} Property {{ get; }}");
-                AppendLine("public SetPropertyContext(MethodContext methodContext)");
+                AppendLine($"public SetPropertyContext({_proto}.MethodContext methodContext)");
                 StartBlock();
                 AppendLine("MethodContext = methodContext;");
                 AppendLine("var reader = methodContext.Request.GetBodyReader();");
@@ -1117,7 +1115,7 @@ namespace Tmds.DBus.Tool
                 EndBlock();
 
                 // Handle method that sets on IXxxProperties
-                AppendLine($"public ValueTask Handle(I{name}Properties properties)");
+                AppendLine($"public {_vtask} Handle(I{name}Properties properties)");
                 StartBlock();
                 AppendLine("switch (Property)");
                 StartBlock();
@@ -1272,7 +1270,7 @@ namespace Tmds.DBus.Tool
 
                         AppendLine($"private byte[] __set = new byte[{byteCount}];");
                         AppendLine($"private byte[] __invalidated = new byte[{byteCount}];");
-                        AppendLine($"private static ReadOnlySpan<byte> PropertiesAllSet => new byte[] {{ {allSetLiteral} }}; // {readableProperties.Length} properties");
+                        AppendLine($"private static global::System.ReadOnlySpan<byte> PropertiesAllSet => new byte[] {{ {allSetLiteral} }}; // {readableProperties.Length} properties");
                         AppendLine($"private static int FlagIndex({propertyEnumName} property) => ((int)property - 1) / 8;");
                         AppendLine($"private static byte FlagMask({propertyEnumName} property) => (byte)(1 << (((int)property - 1) % 8));");
                     }
@@ -1302,7 +1300,7 @@ namespace Tmds.DBus.Tool
 
                     AppendLine($"public {propertiesClassName}() {{ }}");
                     AppendLine("#nullable disable");
-                    AppendLine("[System.Diagnostics.CodeAnalysis.SetsRequiredMembers]");
+                    AppendLine("[global::System.Diagnostics.CodeAnalysis.SetsRequiredMembers]");
                     AppendLine($"private {propertiesClassName}(bool _) {{ }}");
                     AppendLine("#nullable enable");
 
@@ -1310,7 +1308,7 @@ namespace Tmds.DBus.Tool
                     StartBlock();
                     AppendLine("if (!HasFlag(__set, property))");
                     StartBlock();
-                    AppendLine("throw new InvalidOperationException(\"Property is not set.\");");
+                    AppendLine("throw new global::System.InvalidOperationException(\"Property is not set.\");");
                     EndBlock();
                     EndBlock();
 
@@ -1392,7 +1390,7 @@ namespace Tmds.DBus.Tool
 
                     if (useByteArray)
                     {
-                        AppendLine($"public bool AreAllPropertiesSet() => __set.AsSpan().SequenceEqual(PropertiesAllSet);");
+                        AppendLine($"public bool AreAllPropertiesSet() => global::System.MemoryExtensions.SequenceEqual(PropertiesAllSet, __set);");
                     }
                     else
                     {
@@ -1405,19 +1403,19 @@ namespace Tmds.DBus.Tool
                     StartBlock();
                     if (useByteArray)
                     {
-                        AppendLine("throw new DBusUnexpectedValueException($\"Not all properties have been set ({BitConverter.ToString(__set)}).\");");
+                        AppendLine($"throw new {_proto}.DBusUnexpectedValueException(\"Not all properties have been set (\" + global::System.BitConverter.ToString(__set) + \").\");");
                     }
                     else
                     {
-                        AppendLine("throw new DBusUnexpectedValueException($\"Not all properties have been set (0x{__set:x}).\");");
+                        AppendLine($"throw new {_proto}.DBusUnexpectedValueException($\"Not all properties have been set (0x{{__set:x}}).\");");
                     }
                     EndBlock();
                     EndBlock();
 
-                    AppendLine($"public static {propertiesClassName} ReadFrom(ref Reader reader, bool withInvalidated)");
+                    AppendLine($"public static {propertiesClassName} ReadFrom(ref {_proto}.Reader reader, bool withInvalidated)");
                     StartBlock();
                     AppendLine($"var props = CreateUninitialized();");
-                    AppendLine("ArrayEnd arrayEnd = reader.ReadArrayStart(DBusType.Struct);");
+                    AppendLine($"{_proto}.ArrayEnd arrayEnd = reader.ReadArrayStart({GetDBusTypeEnumValue(DBusType.Struct)});");
                     AppendLine("while (reader.HasNext(arrayEnd))");
                     StartBlock();
 
@@ -1446,7 +1444,7 @@ namespace Tmds.DBus.Tool
 
                     AppendLine("if (withInvalidated)");
                     StartBlock();
-                    AppendLine("ArrayEnd invalidatedEnd = reader.ReadArrayStart(DBusType.String);");
+                    AppendLine($"{_proto}.ArrayEnd invalidatedEnd = reader.ReadArrayStart({GetDBusTypeEnumValue(DBusType.String)});");
                     AppendLine("while (reader.HasNext(invalidatedEnd))");
                     StartBlock();
                     AppendLine("var propertyName = reader.ReadString();");
@@ -1554,7 +1552,7 @@ namespace Tmds.DBus.Tool
                 AppendLine($"writer.WriteString(\"{interfaceName}\");");
             }
 
-            AppendLine($"public static void EmitPropertiesChanged(this DBusConnection c, ObjectPath p, I{name}Properties properties, ReadOnlySpan<{propertyEnumName}> changed, ReadOnlySpan<{propertyEnumName}> invalidated = default)");
+            AppendLine($"public static void EmitPropertiesChanged(this {_proto}.DBusConnection c, {_proto}.ObjectPath p, I{name}Properties properties, global::System.ReadOnlySpan<{propertyEnumName}> changed, global::System.ReadOnlySpan<{propertyEnumName}> invalidated = default)");
             StartBlock();
             AppendWriteSignalHeader();
 
@@ -1580,7 +1578,7 @@ namespace Tmds.DBus.Tool
             AppendLine("writer.WriteDictionaryEnd(dictStart);");
 
             // Write invalidated property names as as
-            AppendLine("var arrayStart = writer.WriteArrayStart(DBusType.String);");
+            AppendLine($"var arrayStart = writer.WriteArrayStart({GetDBusTypeEnumValue(DBusType.String)});");
             AppendLine("foreach (var property in invalidated)");
             StartBlock();
             AppendLine("switch (property)");
@@ -1601,7 +1599,7 @@ namespace Tmds.DBus.Tool
             EndBlock();
 
             // Public overload: single changed property
-            AppendLine($"public static void EmitPropertyChanged(this DBusConnection c, ObjectPath p, I{name}Properties properties, {propertyEnumName} changed)");
+            AppendLine($"public static void EmitPropertyChanged(this {_proto}.DBusConnection c, {_proto}.ObjectPath p, I{name}Properties properties, {propertyEnumName} changed)");
             StartBlock();
             AppendLine("EmitPropertiesChanged(c, p, properties, stackalloc[] { changed }, default);");
             EndBlock();
@@ -1609,7 +1607,7 @@ namespace Tmds.DBus.Tool
             // Overload with all properties as nullable individual arguments (alphabetically sorted)
             var sortedProperties = properties.OrderBy(p => p.NameUpper).ToArray();
             string emitArgs = string.Join(", ", sortedProperties.Select(p => $"{GetNullableType(p.DotnetWriteType)} {p.NameLower} = default"));
-            AppendLine($"public static void Emit{name}PropertiesChanged(this DBusConnection c, ObjectPath p, {emitArgs}, ReadOnlySpan<{propertyEnumName}> invalidated = default)");
+            AppendLine($"public static void Emit{name}PropertiesChanged(this {_proto}.DBusConnection c, {_proto}.ObjectPath p, {emitArgs}, global::System.ReadOnlySpan<{propertyEnumName}> invalidated = default)");
             StartBlock();
             AppendWriteSignalHeader();
             AppendLine("var dictStart = writer.WriteDictionaryStart();");
@@ -1625,7 +1623,7 @@ namespace Tmds.DBus.Tool
                 EndBlock();
             }
             AppendLine("writer.WriteDictionaryEnd(dictStart);");
-            AppendLine("var arrayStart = writer.WriteArrayStart(DBusType.String);");
+            AppendLine($"var arrayStart = writer.WriteArrayStart({GetDBusTypeEnumValue(DBusType.String)});");
             AppendLine("foreach (var property in invalidated)");
             StartBlock();
             AppendLine("switch (property)");
@@ -1659,7 +1657,7 @@ namespace Tmds.DBus.Tool
 
             string signature = string.Join("", args.Select(a => a.Signature));
 
-            AppendLine($"public static void {dotnetMethodName}(this DBusConnection c, ObjectPath p{parameters})");
+            AppendLine($"public static void {dotnetMethodName}(this {_proto}.DBusConnection c, {_proto}.ObjectPath p{parameters})");
             StartBlock();
             AppendLine("var writer = c.GetMessageWriter();");
             AppendLine("writer.WriteSignalHeader(");
@@ -1689,13 +1687,13 @@ namespace Tmds.DBus.Tool
             string nullableInterfaceName = $"INullable{propertiesClassName}";
             string changedInterfaceName = $"IChanged{propertiesClassName}";
 
-            AppendLine($"sealed partial class {name} : Tmds.DBus.Protocol.DBusObject");
+            AppendLine($"sealed partial class {name} : {_proto}.DBusObject");
             StartBlock();
 
             string interfaceName = (string)interfaceXml.Attribute("name");
             AppendLine($"public const string DBusInterfaceName = \"{interfaceName}\";");
 
-            AppendLine($"public {name}(Tmds.DBus.Protocol.DBusConnection connection, string destination, ObjectPath path)");
+            AppendLine($"public {name}({_proto}.DBusConnection connection, string destination, {_proto}.ObjectPath path)");
             AppendLine("    : base(connection, destination, path)");
             AppendLine("{ }");
 
@@ -1718,19 +1716,19 @@ namespace Tmds.DBus.Tool
             {
                 foreach (var property in readableProperties)
                 {
-                    AppendLine($"public Task<{property.DotnetReadType}> Get{property.NameUpper}Async()");
+                    AppendLine($"public {_task}<{property.DotnetReadType}> Get{property.NameUpper}Async()");
                     _indentation++;
                     string readMessageName = GetReadMessageMethodName(new[] { property }, variant: true);
-                    AppendLine($"=> Connection.CallMethodAsync(CreateGetPropertyMessage(\"{property.Name}\"), (Message m, object? s) => MessageReader.{readMessageName}(m), this);");
+                    AppendLine($"=> Connection.CallMethodAsync(CreateGetPropertyMessage(\"{property.Name}\"), ({_proto}.Message m, object? s) => MessageReader.{readMessageName}(m), this);");
                     _indentation--;
                 }
 
                 // GetPropertiesAsync
-                AppendLine($"public Task<{propertiesClassName}> GetPropertiesAsync()");
+                AppendLine($"public {_task}<{propertiesClassName}> GetPropertiesAsync()");
                 StartBlock();
-                AppendLine($"return Connection.CallMethodAsync(CreateGetAllPropertiesMessage(), (Message m, object? s) => ReadMessage(m), this);");
+                AppendLine($"return Connection.CallMethodAsync(CreateGetAllPropertiesMessage(), ({_proto}.Message m, object? s) => ReadMessage(m), this);");
 
-                AppendLine($"static {propertiesClassName} ReadMessage(Message message)");
+                AppendLine($"static {propertiesClassName} ReadMessage({_proto}.Message message)");
                 StartBlock();
                 AppendLine("var reader = message.GetBodyReader();");
                 AppendLine($"return {propertiesClassName}.ReadFrom(ref reader, withInvalidated: false);");
@@ -1739,11 +1737,11 @@ namespace Tmds.DBus.Tool
                 EndBlock(); // method
 
                 // GetNullablePropertiesAsync
-                AppendLine($"public Task<{nullableInterfaceName}> GetNullablePropertiesAsync()");
+                AppendLine($"public {_task}<{nullableInterfaceName}> GetNullablePropertiesAsync()");
                 StartBlock();
-                AppendLine($"return Connection.CallMethodAsync(CreateGetAllPropertiesMessage(), (Message m, object? s) => ReadMessage(m), this);");
+                AppendLine($"return Connection.CallMethodAsync(CreateGetAllPropertiesMessage(), ({_proto}.Message m, object? s) => ReadMessage(m), this);");
 
-                AppendLine($"static {nullableInterfaceName} ReadMessage(Message message)");
+                AppendLine($"static {nullableInterfaceName} ReadMessage({_proto}.Message message)");
                 StartBlock();
                 AppendLine("var reader = message.GetBodyReader();");
                 AppendLine($"return {propertiesClassName}.ReadFrom(ref reader, withInvalidated: false);");
@@ -1752,26 +1750,26 @@ namespace Tmds.DBus.Tool
                 EndBlock(); // method
 
                 // WatchPropertiesChangedAsync simple overload
-                AppendLine($"public ValueTask<IDisposable> WatchPropertiesChangedAsync(Action<{changedInterfaceName}> handler, bool emitOnCapturedContext = true)");
-                AppendLine($"    => WatchPropertiesChangedAsync(static (Notification<{changedInterfaceName}> n) => ((Action<{changedInterfaceName}>)n.State!)(n.Value), ObserverFlags.None, emitOnCapturedContext, handler);");
-                AppendLine($"public ValueTask<IDisposable> WatchPropertiesChangedAsync(Func<{changedInterfaceName}, ValueTask> handler, bool emitOnCapturedContext = true)");
-                AppendLine($"    => WatchPropertiesChangedAsync(static (Notification<{changedInterfaceName}> n) => ((Func<{changedInterfaceName}, ValueTask>)n.State!)(n.Value), ObserverFlags.None, emitOnCapturedContext, handler);");
+                AppendLine($"public {_vtask}<{_idisposable}> WatchPropertiesChangedAsync({_action}<{changedInterfaceName}> handler, bool emitOnCapturedContext = true)");
+                AppendLine($"    => WatchPropertiesChangedAsync(static ({_proto}.Notification<{changedInterfaceName}> n) => (({_action}<{changedInterfaceName}>)n.State!)(n.Value), {_proto}.ObserverFlags.None, emitOnCapturedContext, handler);");
+                AppendLine($"public {_vtask}<{_idisposable}> WatchPropertiesChangedAsync({_func}<{changedInterfaceName}, {_vtask}> handler, bool emitOnCapturedContext = true)");
+                AppendLine($"    => WatchPropertiesChangedAsync(static ({_proto}.Notification<{changedInterfaceName}> n) => (({_func}<{changedInterfaceName}, {_vtask}>)n.State!)(n.Value), {_proto}.ObserverFlags.None, emitOnCapturedContext, handler);");
 
                 // WatchPropertiesChangedAsync with Notification
-                AppendLine($"public ValueTask<IDisposable> WatchPropertiesChangedAsync(Action<Notification<{changedInterfaceName}>> handler, ObserverFlags flags, bool emitOnCapturedContext = true, object? state = null)");
+                AppendLine($"public {_vtask}<{_idisposable}> WatchPropertiesChangedAsync({_action}<{_proto}.Notification<{changedInterfaceName}>> handler, {_proto}.ObserverFlags flags, bool emitOnCapturedContext = true, object? state = null)");
                 StartBlock();
-                AppendLine($"return Connection.WatchPropertiesChangedAsync(Destination, Path, DBusInterfaceName, (Message m, object? s) => ReadMessage(m), handler, flags, emitOnCapturedContext, state);");
-                AppendLine($"static {changedInterfaceName} ReadMessage(Message message)");
+                AppendLine($"return Connection.WatchPropertiesChangedAsync(Destination, Path, DBusInterfaceName, ({_proto}.Message m, object? s) => ReadMessage(m), handler, flags, emitOnCapturedContext, state);");
+                AppendLine($"static {changedInterfaceName} ReadMessage({_proto}.Message message)");
                 StartBlock();
                 AppendLine("var reader = message.GetBodyReader();");
                 AppendLine("reader.ReadString(); // interface");
                 AppendLine($"return {propertiesClassName}.ReadFrom(ref reader, withInvalidated: true);");
                 EndBlock();
                 EndBlock();
-                AppendLine($"public ValueTask<IDisposable> WatchPropertiesChangedAsync(Func<Notification<{changedInterfaceName}>, ValueTask> handler, ObserverFlags flags, bool emitOnCapturedContext = true, object? state = null)");
+                AppendLine($"public {_vtask}<{_idisposable}> WatchPropertiesChangedAsync({_func}<{_proto}.Notification<{changedInterfaceName}>, {_vtask}> handler, {_proto}.ObserverFlags flags, bool emitOnCapturedContext = true, object? state = null)");
                 StartBlock();
-                AppendLine($"return Connection.WatchPropertiesChangedAsync(Destination, Path, DBusInterfaceName, (Message m, object? s) => ReadMessage(m), handler, flags, emitOnCapturedContext, state);");
-                AppendLine($"static {changedInterfaceName} ReadMessage(Message message)");
+                AppendLine($"return Connection.WatchPropertiesChangedAsync(Destination, Path, DBusInterfaceName, ({_proto}.Message m, object? s) => ReadMessage(m), handler, flags, emitOnCapturedContext, state);");
+                AppendLine($"static {changedInterfaceName} ReadMessage({_proto}.Message message)");
                 StartBlock();
                 AppendLine("var reader = message.GetBodyReader();");
                 AppendLine("reader.ReadString(); // interface");
@@ -1780,7 +1778,7 @@ namespace Tmds.DBus.Tool
                 EndBlock();
 
                 // CreateGetPropertyMessage helper
-                AppendLine("private MessageBuffer CreateGetPropertyMessage(string property)");
+                AppendLine($"private {_proto}.MessageBuffer CreateGetPropertyMessage(string property)");
                 StartBlock();
                 AppendLine("var writer = Connection.GetMessageWriter();");
                 AppendLine("writer.WriteMethodCallHeader(");
@@ -1795,7 +1793,7 @@ namespace Tmds.DBus.Tool
                 EndBlock();
 
                 // CreateGetAllPropertiesMessage helper
-                AppendLine("private MessageBuffer CreateGetAllPropertiesMessage()");
+                AppendLine($"private {_proto}.MessageBuffer CreateGetAllPropertiesMessage()");
                 StartBlock();
                 AppendLine("var writer = Connection.GetMessageWriter();");
                 AppendLine("writer.WriteMethodCallHeader(");
@@ -1815,10 +1813,10 @@ namespace Tmds.DBus.Tool
         private void AppendPropertySetMethod(Argument property)
         {
             string methodName = $"Set{property.NameUpper}Async";
-            AppendLine($"public Task {methodName}({property.DotnetWriteType} value)");
+            AppendLine($"public {_task} {methodName}({property.DotnetWriteType} value)");
             StartBlock();
             AppendLine($"return Connection.CallMethodAsync(CreateMessage());");
-            AppendLine("MessageBuffer CreateMessage()");
+            AppendLine($"{_proto}.MessageBuffer CreateMessage()");
             StartBlock();
             AppendLine("var writer = Connection.GetMessageWriter();");
             AppendLine("writer.WriteMethodCallHeader(");
@@ -1862,16 +1860,16 @@ namespace Tmds.DBus.Tool
             string? watchType = args.Length == 0 ? null : args.Length == 1 ? args[0].DotnetReadType : TupleOf(args.Select(arg => $"{arg.DotnetReadType} {arg.NameUpper}"));
             string dotnetMethodName = "Watch" + Prettify(dbusSignalName) + "Async";
 
-            string simpleHandlerArg = watchType == null ? "Action" : $"Action<{watchType}>";
-            string simpleNotificationHandler = watchType == null ? "static (Notification n) => ((Action)n.State!)()" : $"static (Notification<{watchType}> n) => ((Action<{watchType}>)n.State!)(n.Value)";
-            AppendLine($"public ValueTask<IDisposable> {dotnetMethodName}({simpleHandlerArg} handler, bool emitOnCapturedContext = true)");
-            AppendLine($"    => {dotnetMethodName}({simpleNotificationHandler}, ObserverFlags.None, emitOnCapturedContext, handler);");
-            string simpleFuncHandlerArg = watchType == null ? "Func<ValueTask>" : $"Func<{watchType}, ValueTask>";
-            string simpleFuncNotificationHandler = watchType == null ? "static (Notification n) => ((Func<ValueTask>)n.State!)()" : $"static (Notification<{watchType}> n) => ((Func<{watchType}, ValueTask>)n.State!)(n.Value)";
-            AppendLine($"public ValueTask<IDisposable> {dotnetMethodName}({simpleFuncHandlerArg} handler, bool emitOnCapturedContext = true)");
-            AppendLine($"    => {dotnetMethodName}({simpleFuncNotificationHandler}, ObserverFlags.None, emitOnCapturedContext, handler);");
-            string handlerContextMethodArg = watchType == null ? "Action<Notification>" : $"Action<Notification<{watchType}>>";
-            AppendLine($"public ValueTask<IDisposable> {dotnetMethodName}({handlerContextMethodArg} handler, ObserverFlags flags, bool emitOnCapturedContext = true, object? state = null)");
+            string simpleHandlerArg = watchType == null ? _action : $"{_action}<{watchType}>";
+            string simpleNotificationHandler = watchType == null ? $"static ({_proto}.Notification n) => (({_action})n.State!)()" : $"static ({_proto}.Notification<{watchType}> n) => (({_action}<{watchType}>)n.State!)(n.Value)";
+            AppendLine($"public {_vtask}<{_idisposable}> {dotnetMethodName}({simpleHandlerArg} handler, bool emitOnCapturedContext = true)");
+            AppendLine($"    => {dotnetMethodName}({simpleNotificationHandler}, {_proto}.ObserverFlags.None, emitOnCapturedContext, handler);");
+            string simpleFuncHandlerArg = watchType == null ? $"{_func}<{_vtask}>" : $"{_func}<{watchType}, {_vtask}>";
+            string simpleFuncNotificationHandler = watchType == null ? $"static ({_proto}.Notification n) => (({_func}<{_vtask}>)n.State!)()" : $"static ({_proto}.Notification<{watchType}> n) => (({_func}<{watchType}, {_vtask}>)n.State!)(n.Value)";
+            AppendLine($"public {_vtask}<{_idisposable}> {dotnetMethodName}({simpleFuncHandlerArg} handler, bool emitOnCapturedContext = true)");
+            AppendLine($"    => {dotnetMethodName}({simpleFuncNotificationHandler}, {_proto}.ObserverFlags.None, emitOnCapturedContext, handler);");
+            string handlerContextMethodArg = watchType == null ? $"{_action}<{_proto}.Notification>" : $"{_action}<{_proto}.Notification<{watchType}>>";
+            AppendLine($"public {_vtask}<{_idisposable}> {dotnetMethodName}({handlerContextMethodArg} handler, {_proto}.ObserverFlags flags, bool emitOnCapturedContext = true, object? state = null)");
             if (watchType == null)
             {
                 AppendLine($"    => Connection.WatchSignalAsync(Destination, Path, DBusInterfaceName, \"{dbusSignalName}\", handler, flags, emitOnCapturedContext, state);");
@@ -1879,10 +1877,10 @@ namespace Tmds.DBus.Tool
             else
             {
                 string readMessageName = GetReadMessageMethodName(args, variant: false);
-                AppendLine($"    => Connection.WatchSignalAsync(Destination, Path, DBusInterfaceName, \"{dbusSignalName}\", (Message m, object? s) => MessageReader.{readMessageName}(m), handler, flags, emitOnCapturedContext, state);");
+                AppendLine($"    => Connection.WatchSignalAsync(Destination, Path, DBusInterfaceName, \"{dbusSignalName}\", ({_proto}.Message m, object? s) => MessageReader.{readMessageName}(m), handler, flags, emitOnCapturedContext, state);");
             }
-            string funcHandlerContextMethodArg = watchType == null ? "Func<Notification, ValueTask>" : $"Func<Notification<{watchType}>, ValueTask>";
-            AppendLine($"public ValueTask<IDisposable> {dotnetMethodName}({funcHandlerContextMethodArg} handler, ObserverFlags flags, bool emitOnCapturedContext = true, object? state = null)");
+            string funcHandlerContextMethodArg = watchType == null ? $"{_func}<{_proto}.Notification, {_vtask}>" : $"{_func}<{_proto}.Notification<{watchType}>, {_vtask}>";
+            AppendLine($"public {_vtask}<{_idisposable}> {dotnetMethodName}({funcHandlerContextMethodArg} handler, {_proto}.ObserverFlags flags, bool emitOnCapturedContext = true, object? state = null)");
             if (watchType == null)
             {
                 AppendLine($"    => Connection.WatchSignalAsync(Destination, Path, DBusInterfaceName, \"{dbusSignalName}\", handler, flags, emitOnCapturedContext, state);");
@@ -1890,7 +1888,7 @@ namespace Tmds.DBus.Tool
             else
             {
                 string readMessageName = GetReadMessageMethodName(args, variant: false);
-                AppendLine($"    => Connection.WatchSignalAsync(Destination, Path, DBusInterfaceName, \"{dbusSignalName}\", (Message m, object? s) => MessageReader.{readMessageName}(m), handler, flags, emitOnCapturedContext, state);");
+                AppendLine($"    => Connection.WatchSignalAsync(Destination, Path, DBusInterfaceName, \"{dbusSignalName}\", ({_proto}.Message m, object? s) => MessageReader.{readMessageName}(m), handler, flags, emitOnCapturedContext, state);");
             }
         }
 
@@ -2008,7 +2006,7 @@ namespace Tmds.DBus.Tool
             var inArgs = methodXml.Elements("arg").Where(arg => (arg.Attribute("direction")?.Value ?? "in") == "in").Select(ToArgument).ToArray();
             var outArgs = methodXml.Elements("arg").Where(arg => arg.Attribute("direction")?.Value == "out").Select(ToArgument).ToArray();
             string? dotnetReturnType = outArgs.Length == 0 ? null : outArgs.Length == 1 ? outArgs[0].DotnetReadType : TupleOf(outArgs.Select(arg => $"{arg.DotnetReadType} {arg.NameUpper}"));
-            string retType = dotnetReturnType == null ? "Task" : $"Task<{dotnetReturnType}>";
+            string retType = dotnetReturnType == null ? _task : $"{_task}<{dotnetReturnType}>";
 
             string args = TupleOf(inArgs.Select(arg => $"{arg.DotnetWriteType} {arg.NameLower}"));
 
@@ -2018,14 +2016,14 @@ namespace Tmds.DBus.Tool
             if (dotnetReturnType != null)
             {
                 string readMessageName = GetReadMessageMethodName(outArgs, variant: false);
-                AppendLine($"return Connection.CallMethodAsync(CreateMessage(), (Message m, object? s) => MessageReader.{readMessageName}(m), this);");
+                AppendLine($"return Connection.CallMethodAsync(CreateMessage(), ({_proto}.Message m, object? s) => MessageReader.{readMessageName}(m), this);");
             }
             else
             {
                 AppendLine($"return Connection.CallMethodAsync(CreateMessage());");
             }
 
-            AppendLine("MessageBuffer CreateMessage()");
+            AppendLine($"{_proto}.MessageBuffer CreateMessage()");
             StartBlock();
             AppendLine("var writer = Connection.GetMessageWriter();");
             AppendLine("writer.WriteMethodCallHeader(");
@@ -2054,7 +2052,7 @@ namespace Tmds.DBus.Tool
         private void AppendReadMessageMethod(string name, bool variant, Argument[] args)
         {
             string? dotnetReturnType = args.Length == 0 ? null : args.Length == 1 ? args[0].DotnetReadType : TupleOf(args.Select(arg => arg.DotnetReadType));
-            AppendLine($"public static {dotnetReturnType} {name}(Message message)");
+            AppendLine($"public static {dotnetReturnType} {name}({_proto}.Message message)");
             StartBlock();
             string signature = string.Join("", args.Select(a => a.Signature));
             AppendLine("var reader = message.GetBodyReader();");
@@ -2079,25 +2077,26 @@ namespace Tmds.DBus.Tool
 
         private static string GetDBusTypeEnumValue(DBusType type)
         {
+            string fqn = $"{_proto}.DBusType";
             return type switch
             {
-                DBusType.Byte => $"{nameof(DBusType)}.{nameof(DBusType.Byte)}",
-                DBusType.Bool => $"{nameof(DBusType)}.{nameof(DBusType.Bool)}",
-                DBusType.Int16 => $"{nameof(DBusType)}.{nameof(DBusType.Int16)}",
-                DBusType.UInt16 => $"{nameof(DBusType)}.{nameof(DBusType.UInt16)}",
-                DBusType.Int32 => $"{nameof(DBusType)}.{nameof(DBusType.Int32)}",
-                DBusType.UInt32 => $"{nameof(DBusType)}.{nameof(DBusType.UInt32)}",
-                DBusType.Int64 => $"{nameof(DBusType)}.{nameof(DBusType.Int64)}",
-                DBusType.UInt64 => $"{nameof(DBusType)}.{nameof(DBusType.UInt64)}",
-                DBusType.Double => $"{nameof(DBusType)}.{nameof(DBusType.Double)}",
-                DBusType.String => $"{nameof(DBusType)}.{nameof(DBusType.String)}",
-                DBusType.ObjectPath => $"{nameof(DBusType)}.{nameof(DBusType.ObjectPath)}",
-                DBusType.Signature => $"{nameof(DBusType)}.{nameof(DBusType.Signature)}",
-                DBusType.Array => $"{nameof(DBusType)}.{nameof(DBusType.Array)}",
-                DBusType.Struct => $"{nameof(DBusType)}.{nameof(DBusType.Struct)}",
-                DBusType.Variant => $"{nameof(DBusType)}.{nameof(DBusType.Variant)}",
-                DBusType.DictEntry => $"{nameof(DBusType)}.{nameof(DBusType.DictEntry)}",
-                DBusType.UnixFd => $"{nameof(DBusType)}.{nameof(DBusType.UnixFd)}",
+                DBusType.Byte => $"{fqn}.{nameof(DBusType.Byte)}",
+                DBusType.Bool => $"{fqn}.{nameof(DBusType.Bool)}",
+                DBusType.Int16 => $"{fqn}.{nameof(DBusType.Int16)}",
+                DBusType.UInt16 => $"{fqn}.{nameof(DBusType.UInt16)}",
+                DBusType.Int32 => $"{fqn}.{nameof(DBusType.Int32)}",
+                DBusType.UInt32 => $"{fqn}.{nameof(DBusType.UInt32)}",
+                DBusType.Int64 => $"{fqn}.{nameof(DBusType.Int64)}",
+                DBusType.UInt64 => $"{fqn}.{nameof(DBusType.UInt64)}",
+                DBusType.Double => $"{fqn}.{nameof(DBusType.Double)}",
+                DBusType.String => $"{fqn}.{nameof(DBusType.String)}",
+                DBusType.ObjectPath => $"{fqn}.{nameof(DBusType.ObjectPath)}",
+                DBusType.Signature => $"{fqn}.{nameof(DBusType.Signature)}",
+                DBusType.Array => $"{fqn}.{nameof(DBusType.Array)}",
+                DBusType.Struct => $"{fqn}.{nameof(DBusType.Struct)}",
+                DBusType.Variant => $"{fqn}.{nameof(DBusType.Variant)}",
+                DBusType.DictEntry => $"{fqn}.{nameof(DBusType.DictEntry)}",
+                DBusType.UnixFd => $"{fqn}.{nameof(DBusType.UnixFd)}",
                 _ => throw new ArgumentOutOfRangeException(type.ToString())
             };
         }
@@ -2202,7 +2201,7 @@ namespace Tmds.DBus.Tool
                 case "v":
                     return $"reader.{nameof(Reader.ReadVariantValue)}()";
                 case "h":
-                    return $"reader.{nameof(Reader.ReadHandle)}<{typeof(SafeFileHandle).FullName}>()";
+                    return $"reader.{nameof(Reader.ReadHandle)}<global::{typeof(SafeFileHandle).FullName}>()";
 
                 case "ay":
                     return $"reader.{nameof(Reader.ReadArrayOfByte)}()";
@@ -2231,7 +2230,7 @@ namespace Tmds.DBus.Tool
                 case "av":
                     return $"reader.{nameof(Reader.ReadArrayOfVariantValue)}()";
                 case "ah":
-                    return $"reader.{nameof(Reader.ReadArrayOfHandle)}<{typeof(SafeFileHandle).FullName}>()";
+                    return $"reader.{nameof(Reader.ReadArrayOfHandle)}<global::{typeof(SafeFileHandle).FullName}>()";
 
                 case "a{sv}":
                     return $"reader.{nameof(Reader.ReadDictionaryOfStringToVariantValue)}()";
@@ -2314,13 +2313,13 @@ namespace Tmds.DBus.Tool
                case DBusType.String:
                     return "string";
                case DBusType.ObjectPath:
-                   return "ObjectPath";
+                   return $"{_proto}.ObjectPath";
                case DBusType.Signature:
-                   return "Signature";
+                   return $"{_proto}.Signature";
                case DBusType.Variant:
-                   return "VariantValue";
+                   return $"{_proto}.VariantValue";
                case DBusType.UnixFd:
-                   return typeof(SafeHandle).FullName;
+                   return $"global::{typeof(SafeHandle).FullName}";
 
                case DBusType.Array:
                     {
@@ -2343,7 +2342,7 @@ namespace Tmds.DBus.Tool
                             }
                             string dotnetKeyType = GetDotnetType(keyType, keyInnerSignature, readNotWrite);
                             string dotnetValueType = GetDotnetType(valueType, valueInnerSignature, readNotWrite);
-                            return $"Dictionary<{dotnetKeyType}, {dotnetValueType}>";
+                            return $"global::System.Collections.Generic.Dictionary<{dotnetKeyType}, {dotnetValueType}>";
                         }
                         else
                         {
@@ -2361,7 +2360,7 @@ namespace Tmds.DBus.Tool
                         }
                         if (fields.Count == 1)
                         {
-                            return $"ValueTuple<{string.Join(", ", fields)}>";
+                            return $"global::System.ValueTuple<{string.Join(", ", fields)}>";
                         }
                         return $"({string.Join(", ", fields)})";
                     }

--- a/test/Tmds.DBus.Generator.Tests/CodeGenerationTests.VerifyGeneratedOutput_HandlerOnly.verified.txt
+++ b/test/Tmds.DBus.Generator.Tests/CodeGenerationTests.VerifyGeneratedOutput_HandlerOnly.verified.txt
@@ -3,11 +3,6 @@
 #nullable enable
 namespace TestNamespace
 {
-    using System;
-    using Tmds.DBus.Protocol;
-    using System.Collections.Generic;
-    using System.Threading.Tasks;
-    using System.Runtime.CompilerServices;
     enum CalculatorProperty
     {
         UnknownProperty = 0,
@@ -19,9 +14,9 @@ namespace TestNamespace
     interface ICalculatorProperties
     {
         double LastResult { get; }
-        ObjectPath CurrentPath { get; }
+        global::Tmds.DBus.Protocol.ObjectPath CurrentPath { get; }
         (string, double) CurrentEntry { get; }
-        ValueTuple<bool> IsActive { get; set; }
+        global::System.ValueTuple<bool> IsActive { get; set; }
     }
     enum WritableCalculatorProperty
     {
@@ -43,56 +38,56 @@ namespace TestNamespace
                     _ => 0
                 };
             }
-            public static DBusHandler.DBusMethod FindMethodHandler(object handler, MethodContext context)
+            public static global::Tmds.DBus.Protocol.DBusHandler.DBusMethod FindMethodHandler(object handler, global::Tmds.DBus.Protocol.MethodContext context)
             {
                 var request = context.Request;
                 if (context.IsPropertiesInterfaceRequest)
                 {
                     return (request.MemberAsString, request.SignatureAsString) switch
                     {
-                        ("Get", "ss") => new DBusHandler.DBusMethod(static (o, c) => ((ICalculatorHandler)o).HandleGetPropertyAsync(new GetPropertyContext(c)), handler),
-                        ("GetAll", "s") => new DBusHandler.DBusMethod(static (o, c) => ((ICalculatorHandler)o).HandleGetAllPropertiesAsync(new GetAllPropertiesContext(c)), handler),
-                        ("Set", "ssv") => new DBusHandler.DBusMethod(static (o, c) => ((ICalculatorHandler)o).HandleSetPropertyAsync(new SetPropertyContext(c)), handler),
+                        ("Get", "ss") => new global::Tmds.DBus.Protocol.DBusHandler.DBusMethod(static (o, c) => ((ICalculatorHandler)o).HandleGetPropertyAsync(new GetPropertyContext(c)), handler),
+                        ("GetAll", "s") => new global::Tmds.DBus.Protocol.DBusHandler.DBusMethod(static (o, c) => ((ICalculatorHandler)o).HandleGetAllPropertiesAsync(new GetAllPropertiesContext(c)), handler),
+                        ("Set", "ssv") => new global::Tmds.DBus.Protocol.DBusHandler.DBusMethod(static (o, c) => ((ICalculatorHandler)o).HandleSetPropertyAsync(new SetPropertyContext(c)), handler),
                         _ => default
                     };
                 }
                 return (request.MemberAsString, request.SignatureAsString) switch
                 {
-                    ("Clear", "") => new DBusHandler.DBusMethod(static (o, c) => HandleClearAsync((ICalculatorHandler)o, c), handler),
-                    ("GetResult", "") => new DBusHandler.DBusMethod(static (o, c) => HandleGetResultAsync((ICalculatorHandler)o, c), handler),
-                    ("GetStats", "") => new DBusHandler.DBusMethod(static (o, c) => HandleGetStatsAsync((ICalculatorHandler)o, c), handler),
-                    ("Store", "d") => new DBusHandler.DBusMethod(static (o, c) => HandleStoreAsync((ICalculatorHandler)o, c), handler),
-                    ("Square", "d") => new DBusHandler.DBusMethod(static (o, c) => HandleSquareAsync((ICalculatorHandler)o, c), handler),
-                    ("DivMod", "i") => new DBusHandler.DBusMethod(static (o, c) => HandleDivModAsync((ICalculatorHandler)o, c), handler),
-                    ("LogOperation", "sd") => new DBusHandler.DBusMethod(static (o, c) => HandleLogOperationAsync((ICalculatorHandler)o, c), handler),
-                    ("Add", "dd") => new DBusHandler.DBusMethod(static (o, c) => HandleAddAsync((ICalculatorHandler)o, c), handler),
-                    ("Compare", "dd") => new DBusHandler.DBusMethod(static (o, c) => HandleCompareAsync((ICalculatorHandler)o, c), handler),
-                    ("GetEntry", "s") => new DBusHandler.DBusMethod(static (o, c) => HandleGetEntryAsync((ICalculatorHandler)o, c), handler),
-                    ("SetEntry", "(sd)") => new DBusHandler.DBusMethod(static (o, c) => HandleSetEntryAsync((ICalculatorHandler)o, c), handler),
+                    ("Clear", "") => new global::Tmds.DBus.Protocol.DBusHandler.DBusMethod(static (o, c) => HandleClearAsync((ICalculatorHandler)o, c), handler),
+                    ("GetResult", "") => new global::Tmds.DBus.Protocol.DBusHandler.DBusMethod(static (o, c) => HandleGetResultAsync((ICalculatorHandler)o, c), handler),
+                    ("GetStats", "") => new global::Tmds.DBus.Protocol.DBusHandler.DBusMethod(static (o, c) => HandleGetStatsAsync((ICalculatorHandler)o, c), handler),
+                    ("Store", "d") => new global::Tmds.DBus.Protocol.DBusHandler.DBusMethod(static (o, c) => HandleStoreAsync((ICalculatorHandler)o, c), handler),
+                    ("Square", "d") => new global::Tmds.DBus.Protocol.DBusHandler.DBusMethod(static (o, c) => HandleSquareAsync((ICalculatorHandler)o, c), handler),
+                    ("DivMod", "i") => new global::Tmds.DBus.Protocol.DBusHandler.DBusMethod(static (o, c) => HandleDivModAsync((ICalculatorHandler)o, c), handler),
+                    ("LogOperation", "sd") => new global::Tmds.DBus.Protocol.DBusHandler.DBusMethod(static (o, c) => HandleLogOperationAsync((ICalculatorHandler)o, c), handler),
+                    ("Add", "dd") => new global::Tmds.DBus.Protocol.DBusHandler.DBusMethod(static (o, c) => HandleAddAsync((ICalculatorHandler)o, c), handler),
+                    ("Compare", "dd") => new global::Tmds.DBus.Protocol.DBusHandler.DBusMethod(static (o, c) => HandleCompareAsync((ICalculatorHandler)o, c), handler),
+                    ("GetEntry", "s") => new global::Tmds.DBus.Protocol.DBusHandler.DBusMethod(static (o, c) => HandleGetEntryAsync((ICalculatorHandler)o, c), handler),
+                    ("SetEntry", "(sd)") => new global::Tmds.DBus.Protocol.DBusHandler.DBusMethod(static (o, c) => HandleSetEntryAsync((ICalculatorHandler)o, c), handler),
                     _ => default
                 };
             }
-            static async ValueTask HandleClearAsync(ICalculatorHandler handler, MethodContext context)
+            static async global::System.Threading.Tasks.ValueTask HandleClearAsync(ICalculatorHandler handler, global::Tmds.DBus.Protocol.MethodContext context)
             {
                 await handler.ClearAsync().ConfigureAwait(false);
                 context.Reply(context.CreateReplyWriter(null).CreateMessage());
             }
-            static async ValueTask HandleGetResultAsync(ICalculatorHandler handler, MethodContext context)
+            static async global::System.Threading.Tasks.ValueTask HandleGetResultAsync(ICalculatorHandler handler, global::Tmds.DBus.Protocol.MethodContext context)
             {
                 var result = await handler.GetResultAsync().ConfigureAwait(false);
                 WriteReply(context, result);
-                static void WriteReply(MethodContext context, double result)
+                static void WriteReply(global::Tmds.DBus.Protocol.MethodContext context, double result)
                 {
                     var writer = context.CreateReplyWriter("d");
                     writer.WriteDouble(result);
                     context.Reply(writer.CreateMessage());
                 }
             }
-            static async ValueTask HandleGetStatsAsync(ICalculatorHandler handler, MethodContext context)
+            static async global::System.Threading.Tasks.ValueTask HandleGetStatsAsync(ICalculatorHandler handler, global::Tmds.DBus.Protocol.MethodContext context)
             {
                 var result = await handler.GetStatsAsync().ConfigureAwait(false);
                 WriteReply(context, result);
-                static void WriteReply(MethodContext context, (uint Count, double Total) result)
+                static void WriteReply(global::Tmds.DBus.Protocol.MethodContext context, (uint Count, double Total) result)
                 {
                     var writer = context.CreateReplyWriter("ud");
                     writer.WriteUInt32(result.Count);
@@ -100,30 +95,30 @@ namespace TestNamespace
                     context.Reply(writer.CreateMessage());
                 }
             }
-            static async ValueTask HandleStoreAsync(ICalculatorHandler handler, MethodContext context)
+            static async global::System.Threading.Tasks.ValueTask HandleStoreAsync(ICalculatorHandler handler, global::Tmds.DBus.Protocol.MethodContext context)
             {
                 var value = MessageReader.Read_d(context.Request);
                 await handler.StoreAsync(value).ConfigureAwait(false);
                 context.Reply(context.CreateReplyWriter(null).CreateMessage());
             }
-            static async ValueTask HandleSquareAsync(ICalculatorHandler handler, MethodContext context)
+            static async global::System.Threading.Tasks.ValueTask HandleSquareAsync(ICalculatorHandler handler, global::Tmds.DBus.Protocol.MethodContext context)
             {
                 var input = MessageReader.Read_d(context.Request);
                 var result = await handler.SquareAsync(input).ConfigureAwait(false);
                 WriteReply(context, result);
-                static void WriteReply(MethodContext context, double result)
+                static void WriteReply(global::Tmds.DBus.Protocol.MethodContext context, double result)
                 {
                     var writer = context.CreateReplyWriter("d");
                     writer.WriteDouble(result);
                     context.Reply(writer.CreateMessage());
                 }
             }
-            static async ValueTask HandleDivModAsync(ICalculatorHandler handler, MethodContext context)
+            static async global::System.Threading.Tasks.ValueTask HandleDivModAsync(ICalculatorHandler handler, global::Tmds.DBus.Protocol.MethodContext context)
             {
                 var dividend = MessageReader.Read_i(context.Request);
                 var result = await handler.DivModAsync(dividend).ConfigureAwait(false);
                 WriteReply(context, result);
-                static void WriteReply(MethodContext context, (int Quotient, int Remainder) result)
+                static void WriteReply(global::Tmds.DBus.Protocol.MethodContext context, (int Quotient, int Remainder) result)
                 {
                     var writer = context.CreateReplyWriter("ii");
                     writer.WriteInt32(result.Quotient);
@@ -131,30 +126,30 @@ namespace TestNamespace
                     context.Reply(writer.CreateMessage());
                 }
             }
-            static async ValueTask HandleLogOperationAsync(ICalculatorHandler handler, MethodContext context)
+            static async global::System.Threading.Tasks.ValueTask HandleLogOperationAsync(ICalculatorHandler handler, global::Tmds.DBus.Protocol.MethodContext context)
             {
                 var (operation, value) = MessageReader.Read_sd(context.Request);
                 await handler.LogOperationAsync(operation, value).ConfigureAwait(false);
                 context.Reply(context.CreateReplyWriter(null).CreateMessage());
             }
-            static async ValueTask HandleAddAsync(ICalculatorHandler handler, MethodContext context)
+            static async global::System.Threading.Tasks.ValueTask HandleAddAsync(ICalculatorHandler handler, global::Tmds.DBus.Protocol.MethodContext context)
             {
                 var (a, b) = MessageReader.Read_dd(context.Request);
                 var result = await handler.AddAsync(a, b).ConfigureAwait(false);
                 WriteReply(context, result);
-                static void WriteReply(MethodContext context, double result)
+                static void WriteReply(global::Tmds.DBus.Protocol.MethodContext context, double result)
                 {
                     var writer = context.CreateReplyWriter("d");
                     writer.WriteDouble(result);
                     context.Reply(writer.CreateMessage());
                 }
             }
-            static async ValueTask HandleCompareAsync(ICalculatorHandler handler, MethodContext context)
+            static async global::System.Threading.Tasks.ValueTask HandleCompareAsync(ICalculatorHandler handler, global::Tmds.DBus.Protocol.MethodContext context)
             {
                 var (a, b) = MessageReader.Read_dd(context.Request);
                 var result = await handler.CompareAsync(a, b).ConfigureAwait(false);
                 WriteReply(context, result);
-                static void WriteReply(MethodContext context, (bool Equal, double Difference) result)
+                static void WriteReply(global::Tmds.DBus.Protocol.MethodContext context, (bool Equal, double Difference) result)
                 {
                     var writer = context.CreateReplyWriter("bd");
                     writer.WriteBool(result.Equal);
@@ -162,44 +157,44 @@ namespace TestNamespace
                     context.Reply(writer.CreateMessage());
                 }
             }
-            static async ValueTask HandleGetEntryAsync(ICalculatorHandler handler, MethodContext context)
+            static async global::System.Threading.Tasks.ValueTask HandleGetEntryAsync(ICalculatorHandler handler, global::Tmds.DBus.Protocol.MethodContext context)
             {
                 var key = MessageReader.Read_s(context.Request);
                 var result = await handler.GetEntryAsync(key).ConfigureAwait(false);
                 WriteReply(context, result);
-                static void WriteReply(MethodContext context, (string, double) result)
+                static void WriteReply(global::Tmds.DBus.Protocol.MethodContext context, (string, double) result)
                 {
                     var writer = context.CreateReplyWriter("(sd)");
                     writer.Write_rsdz(result);
                     context.Reply(writer.CreateMessage());
                 }
             }
-            static async ValueTask HandleSetEntryAsync(ICalculatorHandler handler, MethodContext context)
+            static async global::System.Threading.Tasks.ValueTask HandleSetEntryAsync(ICalculatorHandler handler, global::Tmds.DBus.Protocol.MethodContext context)
             {
                 var entry = MessageReader.Read_rsdz(context.Request);
                 await handler.SetEntryAsync(entry).ConfigureAwait(false);
                 context.Reply(context.CreateReplyWriter(null).CreateMessage());
             }
         }
-        ValueTask HandleGetPropertyAsync(GetPropertyContext context);
-        ValueTask HandleGetAllPropertiesAsync(GetAllPropertiesContext context);
-        ValueTask HandleSetPropertyAsync(SetPropertyContext context);
-        ValueTask ClearAsync();
-        ValueTask<double> GetResultAsync();
-        ValueTask<(uint Count, double Total)> GetStatsAsync();
-        ValueTask StoreAsync(double value);
-        ValueTask<double> SquareAsync(double input);
-        ValueTask<(int Quotient, int Remainder)> DivModAsync(int dividend);
-        ValueTask LogOperationAsync(string operation, double value);
-        ValueTask<double> AddAsync(double a, double b);
-        ValueTask<(bool Equal, double Difference)> CompareAsync(double a, double b);
-        ValueTask<(string, double)> GetEntryAsync(string key);
-        ValueTask SetEntryAsync((string, double) entry);
-        readonly struct GetPropertyContext : IDisposable
+        global::System.Threading.Tasks.ValueTask HandleGetPropertyAsync(GetPropertyContext context);
+        global::System.Threading.Tasks.ValueTask HandleGetAllPropertiesAsync(GetAllPropertiesContext context);
+        global::System.Threading.Tasks.ValueTask HandleSetPropertyAsync(SetPropertyContext context);
+        global::System.Threading.Tasks.ValueTask ClearAsync();
+        global::System.Threading.Tasks.ValueTask<double> GetResultAsync();
+        global::System.Threading.Tasks.ValueTask<(uint Count, double Total)> GetStatsAsync();
+        global::System.Threading.Tasks.ValueTask StoreAsync(double value);
+        global::System.Threading.Tasks.ValueTask<double> SquareAsync(double input);
+        global::System.Threading.Tasks.ValueTask<(int Quotient, int Remainder)> DivModAsync(int dividend);
+        global::System.Threading.Tasks.ValueTask LogOperationAsync(string operation, double value);
+        global::System.Threading.Tasks.ValueTask<double> AddAsync(double a, double b);
+        global::System.Threading.Tasks.ValueTask<(bool Equal, double Difference)> CompareAsync(double a, double b);
+        global::System.Threading.Tasks.ValueTask<(string, double)> GetEntryAsync(string key);
+        global::System.Threading.Tasks.ValueTask SetEntryAsync((string, double) entry);
+        readonly struct GetPropertyContext : global::System.IDisposable
         {
-            public MethodContext MethodContext { get; }
+            public global::Tmds.DBus.Protocol.MethodContext MethodContext { get; }
             public CalculatorProperty Property { get; }
-            public GetPropertyContext(MethodContext methodContext)
+            public GetPropertyContext(global::Tmds.DBus.Protocol.MethodContext methodContext)
             {
                 MethodContext = methodContext;
                 var reader = methodContext.Request.GetBodyReader();
@@ -209,28 +204,28 @@ namespace TestNamespace
             public void Dispose() => MethodContext.Dispose();
             public void ReplyLastResult(double value)
             {
-                System.Diagnostics.Debug.Assert(Property == CalculatorProperty.LastResult);
+                global::System.Diagnostics.Debug.Assert(Property == CalculatorProperty.LastResult);
                 var writer = MethodContext.CreateReplyWriter("v");
                 writer.Write_v_d(value);
                 MethodContext.Reply(writer.CreateMessage());
             }
-            public void ReplyCurrentPath(ObjectPath value)
+            public void ReplyCurrentPath(global::Tmds.DBus.Protocol.ObjectPath value)
             {
-                System.Diagnostics.Debug.Assert(Property == CalculatorProperty.CurrentPath);
+                global::System.Diagnostics.Debug.Assert(Property == CalculatorProperty.CurrentPath);
                 var writer = MethodContext.CreateReplyWriter("v");
                 writer.Write_v_o(value);
                 MethodContext.Reply(writer.CreateMessage());
             }
             public void ReplyCurrentEntry((string, double) value)
             {
-                System.Diagnostics.Debug.Assert(Property == CalculatorProperty.CurrentEntry);
+                global::System.Diagnostics.Debug.Assert(Property == CalculatorProperty.CurrentEntry);
                 var writer = MethodContext.CreateReplyWriter("v");
                 writer.Write_v_rsdz(value);
                 MethodContext.Reply(writer.CreateMessage());
             }
-            public void ReplyIsActive(ValueTuple<bool> value)
+            public void ReplyIsActive(global::System.ValueTuple<bool> value)
             {
-                System.Diagnostics.Debug.Assert(Property == CalculatorProperty.IsActive);
+                global::System.Diagnostics.Debug.Assert(Property == CalculatorProperty.IsActive);
                 var writer = MethodContext.CreateReplyWriter("v");
                 writer.Write_v_rbz(value);
                 MethodContext.Reply(writer.CreateMessage());
@@ -239,7 +234,7 @@ namespace TestNamespace
             {
                 MethodContext.ReplyError("org.freedesktop.DBus.Error.UnknownProperty", $"Unknown property: {Property}");
             }
-            public ValueTask Handle(ICalculatorProperties properties)
+            public global::System.Threading.Tasks.ValueTask Handle(ICalculatorProperties properties)
             {
                 switch (Property)
                 {
@@ -262,15 +257,15 @@ namespace TestNamespace
                 return default;
             }
         }
-        readonly struct GetAllPropertiesContext : IDisposable
+        readonly struct GetAllPropertiesContext : global::System.IDisposable
         {
-            public MethodContext MethodContext { get; }
-            public GetAllPropertiesContext(MethodContext methodContext)
+            public global::Tmds.DBus.Protocol.MethodContext MethodContext { get; }
+            public GetAllPropertiesContext(global::Tmds.DBus.Protocol.MethodContext methodContext)
             {
                 MethodContext = methodContext;
             }
             public void Dispose() => MethodContext.Dispose();
-            public ValueTask Handle(ICalculatorProperties properties)
+            public global::System.Threading.Tasks.ValueTask Handle(ICalculatorProperties properties)
             {
                 var writer = MethodContext.CreateReplyWriter("a{sv}");
                 var dictStart = writer.WriteDictionaryStart();
@@ -290,7 +285,7 @@ namespace TestNamespace
                 MethodContext.Reply(writer.CreateMessage());
                 return default;
             }
-            public ValueTask Handle((string, double)? currentEntry = default, ObjectPath? currentPath = default, ValueTuple<bool>? isActive = default, double? lastResult = default)
+            public global::System.Threading.Tasks.ValueTask Handle((string, double)? currentEntry = default, global::Tmds.DBus.Protocol.ObjectPath? currentPath = default, global::System.ValueTuple<bool>? isActive = default, double? lastResult = default)
             {
                 var writer = MethodContext.CreateReplyWriter("a{sv}");
                 var dictStart = writer.WriteDictionaryStart();
@@ -304,7 +299,7 @@ namespace TestNamespace
                 {
                     writer.WriteDictionaryEntryStart();
                     writer.WriteString("CurrentPath");
-                    writer.Write_v_o((ObjectPath)currentPath);
+                    writer.Write_v_o((global::Tmds.DBus.Protocol.ObjectPath)currentPath);
                 }
                 if (currentEntry is not null)
                 {
@@ -316,18 +311,18 @@ namespace TestNamespace
                 {
                     writer.WriteDictionaryEntryStart();
                     writer.WriteString("IsActive");
-                    writer.Write_v_rbz((ValueTuple<bool>)isActive);
+                    writer.Write_v_rbz((global::System.ValueTuple<bool>)isActive);
                 }
                 writer.WriteDictionaryEnd(dictStart);
                 MethodContext.Reply(writer.CreateMessage());
                 return default;
             }
         }
-        readonly struct SetPropertyContext : IDisposable
+        readonly struct SetPropertyContext : global::System.IDisposable
         {
-            public MethodContext MethodContext { get; }
+            public global::Tmds.DBus.Protocol.MethodContext MethodContext { get; }
             public WritableCalculatorProperty Property { get; }
-            public SetPropertyContext(MethodContext methodContext)
+            public SetPropertyContext(global::Tmds.DBus.Protocol.MethodContext methodContext)
             {
                 MethodContext = methodContext;
                 var reader = methodContext.Request.GetBodyReader();
@@ -335,7 +330,7 @@ namespace TestNamespace
                 Property = (WritableCalculatorProperty)Helper.GetPropertyValue(reader.ReadString());
             }
             public void Dispose() => MethodContext.Dispose();
-            public ValueTuple<bool> ReadIsActive()
+            public global::System.ValueTuple<bool> ReadIsActive()
             {
                 var reader = MethodContext.Request.GetBodyReader();
                 reader.ReadStringAsSpan(); // Skip interface name
@@ -355,7 +350,7 @@ namespace TestNamespace
             {
                 MethodContext.ReplyError("org.freedesktop.DBus.Error.PropertyReadOnly", $"Property is read-only: {Property}");
             }
-            public ValueTask Handle(ICalculatorProperties properties)
+            public global::System.Threading.Tasks.ValueTask Handle(ICalculatorProperties properties)
             {
                 switch (Property)
                 {
@@ -376,7 +371,7 @@ namespace TestNamespace
     }
     static class CalculatorSignal
     {
-        public static void EmitReset(this DBusConnection c, ObjectPath p)
+        public static void EmitReset(this global::Tmds.DBus.Protocol.DBusConnection c, global::Tmds.DBus.Protocol.ObjectPath p)
         {
             var writer = c.GetMessageWriter();
             writer.WriteSignalHeader(
@@ -385,7 +380,7 @@ namespace TestNamespace
                 member: "Reset");
             c.TrySendMessage(writer.CreateMessage());
         }
-        public static void EmitError(this DBusConnection c, ObjectPath p, string message)
+        public static void EmitError(this global::Tmds.DBus.Protocol.DBusConnection c, global::Tmds.DBus.Protocol.ObjectPath p, string message)
         {
             var writer = c.GetMessageWriter();
             writer.WriteSignalHeader(
@@ -396,7 +391,7 @@ namespace TestNamespace
             writer.WriteString(message);
             c.TrySendMessage(writer.CreateMessage());
         }
-        public static void EmitOperationComplete(this DBusConnection c, ObjectPath p, string operation, double result)
+        public static void EmitOperationComplete(this global::Tmds.DBus.Protocol.DBusConnection c, global::Tmds.DBus.Protocol.ObjectPath p, string operation, double result)
         {
             var writer = c.GetMessageWriter();
             writer.WriteSignalHeader(
@@ -408,7 +403,7 @@ namespace TestNamespace
             writer.WriteDouble(result);
             c.TrySendMessage(writer.CreateMessage());
         }
-        public static void EmitPropertiesChanged(this DBusConnection c, ObjectPath p, ICalculatorProperties properties, ReadOnlySpan<CalculatorProperty> changed, ReadOnlySpan<CalculatorProperty> invalidated = default)
+        public static void EmitPropertiesChanged(this global::Tmds.DBus.Protocol.DBusConnection c, global::Tmds.DBus.Protocol.ObjectPath p, ICalculatorProperties properties, global::System.ReadOnlySpan<CalculatorProperty> changed, global::System.ReadOnlySpan<CalculatorProperty> invalidated = default)
         {
             var writer = c.GetMessageWriter();
             writer.WriteSignalHeader(
@@ -445,7 +440,7 @@ namespace TestNamespace
                 }
             }
             writer.WriteDictionaryEnd(dictStart);
-            var arrayStart = writer.WriteArrayStart(DBusType.String);
+            var arrayStart = writer.WriteArrayStart(global::Tmds.DBus.Protocol.DBusType.String);
             foreach (var property in invalidated)
             {
                 switch (property)
@@ -467,11 +462,11 @@ namespace TestNamespace
             writer.WriteArrayEnd(arrayStart);
             c.TrySendMessage(writer.CreateMessage());
         }
-        public static void EmitPropertyChanged(this DBusConnection c, ObjectPath p, ICalculatorProperties properties, CalculatorProperty changed)
+        public static void EmitPropertyChanged(this global::Tmds.DBus.Protocol.DBusConnection c, global::Tmds.DBus.Protocol.ObjectPath p, ICalculatorProperties properties, CalculatorProperty changed)
         {
             EmitPropertiesChanged(c, p, properties, stackalloc[] { changed }, default);
         }
-        public static void EmitCalculatorPropertiesChanged(this DBusConnection c, ObjectPath p, (string, double)? currentEntry = default, ObjectPath? currentPath = default, ValueTuple<bool>? isActive = default, double? lastResult = default, ReadOnlySpan<CalculatorProperty> invalidated = default)
+        public static void EmitCalculatorPropertiesChanged(this global::Tmds.DBus.Protocol.DBusConnection c, global::Tmds.DBus.Protocol.ObjectPath p, (string, double)? currentEntry = default, global::Tmds.DBus.Protocol.ObjectPath? currentPath = default, global::System.ValueTuple<bool>? isActive = default, double? lastResult = default, global::System.ReadOnlySpan<CalculatorProperty> invalidated = default)
         {
             var writer = c.GetMessageWriter();
             writer.WriteSignalHeader(
@@ -491,7 +486,7 @@ namespace TestNamespace
             {
                 writer.WriteDictionaryEntryStart();
                 writer.WriteString("CurrentPath");
-                writer.Write_v_o((ObjectPath)currentPath);
+                writer.Write_v_o((global::Tmds.DBus.Protocol.ObjectPath)currentPath);
             }
             if (currentEntry is not null)
             {
@@ -503,10 +498,10 @@ namespace TestNamespace
             {
                 writer.WriteDictionaryEntryStart();
                 writer.WriteString("IsActive");
-                writer.Write_v_rbz((ValueTuple<bool>)isActive);
+                writer.Write_v_rbz((global::System.ValueTuple<bool>)isActive);
             }
             writer.WriteDictionaryEnd(dictStart);
-            var arrayStart = writer.WriteArrayStart(DBusType.String);
+            var arrayStart = writer.WriteArrayStart(global::Tmds.DBus.Protocol.DBusType.String);
             foreach (var property in invalidated)
             {
                 switch (property)
@@ -561,40 +556,40 @@ namespace TestNamespace
                     _ => 0
                 };
             }
-            public static DBusHandler.DBusMethod FindMethodHandler(object handler, MethodContext context)
+            public static global::Tmds.DBus.Protocol.DBusHandler.DBusMethod FindMethodHandler(object handler, global::Tmds.DBus.Protocol.MethodContext context)
             {
                 var request = context.Request;
                 if (context.IsPropertiesInterfaceRequest)
                 {
                     return (request.MemberAsString, request.SignatureAsString) switch
                     {
-                        ("Get", "ss") => new DBusHandler.DBusMethod(static (o, c) => ((ISettingsHandler)o).HandleGetPropertyAsync(new GetPropertyContext(c)), handler),
-                        ("GetAll", "s") => new DBusHandler.DBusMethod(static (o, c) => ((ISettingsHandler)o).HandleGetAllPropertiesAsync(new GetAllPropertiesContext(c)), handler),
-                        ("Set", "ssv") => new DBusHandler.DBusMethod(static (o, c) => ((ISettingsHandler)o).HandleSetPropertyAsync(new SetPropertyContext(c)), handler),
+                        ("Get", "ss") => new global::Tmds.DBus.Protocol.DBusHandler.DBusMethod(static (o, c) => ((ISettingsHandler)o).HandleGetPropertyAsync(new GetPropertyContext(c)), handler),
+                        ("GetAll", "s") => new global::Tmds.DBus.Protocol.DBusHandler.DBusMethod(static (o, c) => ((ISettingsHandler)o).HandleGetAllPropertiesAsync(new GetAllPropertiesContext(c)), handler),
+                        ("Set", "ssv") => new global::Tmds.DBus.Protocol.DBusHandler.DBusMethod(static (o, c) => ((ISettingsHandler)o).HandleSetPropertyAsync(new SetPropertyContext(c)), handler),
                         _ => default
                     };
                 }
                 return (request.MemberAsString, request.SignatureAsString) switch
                 {
-                    ("Save", "") => new DBusHandler.DBusMethod(static (o, c) => HandleSaveAsync((ISettingsHandler)o, c), handler),
+                    ("Save", "") => new global::Tmds.DBus.Protocol.DBusHandler.DBusMethod(static (o, c) => HandleSaveAsync((ISettingsHandler)o, c), handler),
                     _ => default
                 };
             }
-            static async ValueTask HandleSaveAsync(ISettingsHandler handler, MethodContext context)
+            static async global::System.Threading.Tasks.ValueTask HandleSaveAsync(ISettingsHandler handler, global::Tmds.DBus.Protocol.MethodContext context)
             {
                 await handler.SaveAsync().ConfigureAwait(false);
                 context.Reply(context.CreateReplyWriter(null).CreateMessage());
             }
         }
-        ValueTask HandleGetPropertyAsync(GetPropertyContext context);
-        ValueTask HandleGetAllPropertiesAsync(GetAllPropertiesContext context);
-        ValueTask HandleSetPropertyAsync(SetPropertyContext context);
-        ValueTask SaveAsync();
-        readonly struct GetPropertyContext : IDisposable
+        global::System.Threading.Tasks.ValueTask HandleGetPropertyAsync(GetPropertyContext context);
+        global::System.Threading.Tasks.ValueTask HandleGetAllPropertiesAsync(GetAllPropertiesContext context);
+        global::System.Threading.Tasks.ValueTask HandleSetPropertyAsync(SetPropertyContext context);
+        global::System.Threading.Tasks.ValueTask SaveAsync();
+        readonly struct GetPropertyContext : global::System.IDisposable
         {
-            public MethodContext MethodContext { get; }
+            public global::Tmds.DBus.Protocol.MethodContext MethodContext { get; }
             public SettingsProperty Property { get; }
-            public GetPropertyContext(MethodContext methodContext)
+            public GetPropertyContext(global::Tmds.DBus.Protocol.MethodContext methodContext)
             {
                 MethodContext = methodContext;
                 var reader = methodContext.Request.GetBodyReader();
@@ -604,14 +599,14 @@ namespace TestNamespace
             public void Dispose() => MethodContext.Dispose();
             public void ReplyTheme(string value)
             {
-                System.Diagnostics.Debug.Assert(Property == SettingsProperty.Theme);
+                global::System.Diagnostics.Debug.Assert(Property == SettingsProperty.Theme);
                 var writer = MethodContext.CreateReplyWriter("v");
                 writer.Write_v_s(value);
                 MethodContext.Reply(writer.CreateMessage());
             }
             public void ReplyLanguage(string value)
             {
-                System.Diagnostics.Debug.Assert(Property == SettingsProperty.Language);
+                global::System.Diagnostics.Debug.Assert(Property == SettingsProperty.Language);
                 var writer = MethodContext.CreateReplyWriter("v");
                 writer.Write_v_s(value);
                 MethodContext.Reply(writer.CreateMessage());
@@ -620,7 +615,7 @@ namespace TestNamespace
             {
                 MethodContext.ReplyError("org.freedesktop.DBus.Error.UnknownProperty", $"Unknown property: {Property}");
             }
-            public ValueTask Handle(ISettingsProperties properties)
+            public global::System.Threading.Tasks.ValueTask Handle(ISettingsProperties properties)
             {
                 switch (Property)
                 {
@@ -637,15 +632,15 @@ namespace TestNamespace
                 return default;
             }
         }
-        readonly struct GetAllPropertiesContext : IDisposable
+        readonly struct GetAllPropertiesContext : global::System.IDisposable
         {
-            public MethodContext MethodContext { get; }
-            public GetAllPropertiesContext(MethodContext methodContext)
+            public global::Tmds.DBus.Protocol.MethodContext MethodContext { get; }
+            public GetAllPropertiesContext(global::Tmds.DBus.Protocol.MethodContext methodContext)
             {
                 MethodContext = methodContext;
             }
             public void Dispose() => MethodContext.Dispose();
-            public ValueTask Handle(ISettingsProperties properties)
+            public global::System.Threading.Tasks.ValueTask Handle(ISettingsProperties properties)
             {
                 var writer = MethodContext.CreateReplyWriter("a{sv}");
                 var dictStart = writer.WriteDictionaryStart();
@@ -659,7 +654,7 @@ namespace TestNamespace
                 MethodContext.Reply(writer.CreateMessage());
                 return default;
             }
-            public ValueTask Handle(string? language = default, string? theme = default)
+            public global::System.Threading.Tasks.ValueTask Handle(string? language = default, string? theme = default)
             {
                 var writer = MethodContext.CreateReplyWriter("a{sv}");
                 var dictStart = writer.WriteDictionaryStart();
@@ -680,11 +675,11 @@ namespace TestNamespace
                 return default;
             }
         }
-        readonly struct SetPropertyContext : IDisposable
+        readonly struct SetPropertyContext : global::System.IDisposable
         {
-            public MethodContext MethodContext { get; }
+            public global::Tmds.DBus.Protocol.MethodContext MethodContext { get; }
             public WritableSettingsProperty Property { get; }
-            public SetPropertyContext(MethodContext methodContext)
+            public SetPropertyContext(global::Tmds.DBus.Protocol.MethodContext methodContext)
             {
                 MethodContext = methodContext;
                 var reader = methodContext.Request.GetBodyReader();
@@ -720,7 +715,7 @@ namespace TestNamespace
             {
                 MethodContext.ReplyError("org.freedesktop.DBus.Error.PropertyReadOnly", $"Property is read-only: {Property}");
             }
-            public ValueTask Handle(ISettingsProperties properties)
+            public global::System.Threading.Tasks.ValueTask Handle(ISettingsProperties properties)
             {
                 switch (Property)
                 {
@@ -745,7 +740,7 @@ namespace TestNamespace
     }
     static class SettingsSignal
     {
-        public static void EmitChanged(this DBusConnection c, ObjectPath p)
+        public static void EmitChanged(this global::Tmds.DBus.Protocol.DBusConnection c, global::Tmds.DBus.Protocol.ObjectPath p)
         {
             var writer = c.GetMessageWriter();
             writer.WriteSignalHeader(
@@ -754,7 +749,7 @@ namespace TestNamespace
                 member: "Changed");
             c.TrySendMessage(writer.CreateMessage());
         }
-        public static void EmitPropertiesChanged(this DBusConnection c, ObjectPath p, ISettingsProperties properties, ReadOnlySpan<SettingsProperty> changed, ReadOnlySpan<SettingsProperty> invalidated = default)
+        public static void EmitPropertiesChanged(this global::Tmds.DBus.Protocol.DBusConnection c, global::Tmds.DBus.Protocol.ObjectPath p, ISettingsProperties properties, global::System.ReadOnlySpan<SettingsProperty> changed, global::System.ReadOnlySpan<SettingsProperty> invalidated = default)
         {
             var writer = c.GetMessageWriter();
             writer.WriteSignalHeader(
@@ -781,7 +776,7 @@ namespace TestNamespace
                 }
             }
             writer.WriteDictionaryEnd(dictStart);
-            var arrayStart = writer.WriteArrayStart(DBusType.String);
+            var arrayStart = writer.WriteArrayStart(global::Tmds.DBus.Protocol.DBusType.String);
             foreach (var property in invalidated)
             {
                 switch (property)
@@ -797,11 +792,11 @@ namespace TestNamespace
             writer.WriteArrayEnd(arrayStart);
             c.TrySendMessage(writer.CreateMessage());
         }
-        public static void EmitPropertyChanged(this DBusConnection c, ObjectPath p, ISettingsProperties properties, SettingsProperty changed)
+        public static void EmitPropertyChanged(this global::Tmds.DBus.Protocol.DBusConnection c, global::Tmds.DBus.Protocol.ObjectPath p, ISettingsProperties properties, SettingsProperty changed)
         {
             EmitPropertiesChanged(c, p, properties, stackalloc[] { changed }, default);
         }
-        public static void EmitSettingsPropertiesChanged(this DBusConnection c, ObjectPath p, string? language = default, string? theme = default, ReadOnlySpan<SettingsProperty> invalidated = default)
+        public static void EmitSettingsPropertiesChanged(this global::Tmds.DBus.Protocol.DBusConnection c, global::Tmds.DBus.Protocol.ObjectPath p, string? language = default, string? theme = default, global::System.ReadOnlySpan<SettingsProperty> invalidated = default)
         {
             var writer = c.GetMessageWriter();
             writer.WriteSignalHeader(
@@ -824,7 +819,7 @@ namespace TestNamespace
                 writer.Write_v_s((string)language);
             }
             writer.WriteDictionaryEnd(dictStart);
-            var arrayStart = writer.WriteArrayStart(DBusType.String);
+            var arrayStart = writer.WriteArrayStart(global::Tmds.DBus.Protocol.DBusType.String);
             foreach (var property in invalidated)
             {
                 switch (property)
@@ -845,7 +840,7 @@ namespace TestNamespace
     {
         internal static class Helper
         {
-            public static DBusHandler.DBusMethod FindMethodHandler(object handler, MethodContext context)
+            public static global::Tmds.DBus.Protocol.DBusHandler.DBusMethod FindMethodHandler(object handler, global::Tmds.DBus.Protocol.MethodContext context)
             {
                 var request = context.Request;
                 return default;
@@ -854,64 +849,64 @@ namespace TestNamespace
     }
     file static class MessageReader
     {
-        public static double Read_d(Message message)
+        public static double Read_d(global::Tmds.DBus.Protocol.Message message)
         {
             var reader = message.GetBodyReader();
             return reader.ReadDouble();
         }
-        public static int Read_i(Message message)
+        public static int Read_i(global::Tmds.DBus.Protocol.Message message)
         {
             var reader = message.GetBodyReader();
             return reader.ReadInt32();
         }
-        public static (string, double) Read_sd(Message message)
+        public static (string, double) Read_sd(global::Tmds.DBus.Protocol.Message message)
         {
             var reader = message.GetBodyReader();
             var arg0 = reader.ReadString();
             var arg1 = reader.ReadDouble();
             return (arg0, arg1);
         }
-        public static (double, double) Read_dd(Message message)
+        public static (double, double) Read_dd(global::Tmds.DBus.Protocol.Message message)
         {
             var reader = message.GetBodyReader();
             var arg0 = reader.ReadDouble();
             var arg1 = reader.ReadDouble();
             return (arg0, arg1);
         }
-        public static string Read_s(Message message)
+        public static string Read_s(global::Tmds.DBus.Protocol.Message message)
         {
             var reader = message.GetBodyReader();
             return reader.ReadString();
         }
-        public static (string, double) Read_rsdz(Message message)
+        public static (string, double) Read_rsdz(global::Tmds.DBus.Protocol.Message message)
         {
             var reader = message.GetBodyReader();
             return reader.Read_rsdz();
         }
-        public static ValueTuple<bool> Read_v_rbz(Message message)
+        public static global::System.ValueTuple<bool> Read_v_rbz(global::Tmds.DBus.Protocol.Message message)
         {
             var reader = message.GetBodyReader();
             reader.ReadSignature("(b)"u8);
             return reader.Read_rbz();
         }
-        public static double Read_v_d(Message message)
+        public static double Read_v_d(global::Tmds.DBus.Protocol.Message message)
         {
             var reader = message.GetBodyReader();
             reader.ReadSignature("d"u8);
             return reader.ReadDouble();
         }
-        public static string Read_v_s(Message message)
+        public static string Read_v_s(global::Tmds.DBus.Protocol.Message message)
         {
             var reader = message.GetBodyReader();
             reader.ReadSignature("s"u8);
             return reader.ReadString();
         }
-        public static ValueTuple<bool> Read_rbz(this ref Reader reader)
+        public static global::System.ValueTuple<bool> Read_rbz(this ref global::Tmds.DBus.Protocol.Reader reader)
         {
             reader.AlignStruct();
-            return new ValueTuple<bool>(reader.ReadBool());
+            return new global::System.ValueTuple<bool>(reader.ReadBool());
         }
-        public static (string, double) Read_rsdz(this ref Reader reader)
+        public static (string, double) Read_rsdz(this ref global::Tmds.DBus.Protocol.Reader reader)
         {
             reader.AlignStruct();
             return (reader.ReadString(), reader.ReadDouble());
@@ -919,38 +914,38 @@ namespace TestNamespace
     }
     file static class MessageWriterExtensions
     {
-        public static void Write_rsdz(this ref MessageWriter writer, (string, double) value)
+        public static void Write_rsdz(this ref global::Tmds.DBus.Protocol.MessageWriter writer, (string, double) value)
         {
             writer.WriteStructureStart();
             writer.WriteString(value.Item1);
             writer.WriteDouble(value.Item2);
         }
-        public static void Write_v_d(this ref MessageWriter writer, double value)
+        public static void Write_v_d(this ref global::Tmds.DBus.Protocol.MessageWriter writer, double value)
         {
             writer.WriteSignature("d");
             writer.WriteDouble(value);
         }
-        public static void Write_v_o(this ref MessageWriter writer, ObjectPath value)
+        public static void Write_v_o(this ref global::Tmds.DBus.Protocol.MessageWriter writer, global::Tmds.DBus.Protocol.ObjectPath value)
         {
             writer.WriteSignature("o");
             writer.WriteObjectPath(value);
         }
-        public static void Write_v_rsdz(this ref MessageWriter writer, (string, double) value)
+        public static void Write_v_rsdz(this ref global::Tmds.DBus.Protocol.MessageWriter writer, (string, double) value)
         {
             writer.WriteSignature("(sd)");
             writer.Write_rsdz(value);
         }
-        public static void Write_v_rbz(this ref MessageWriter writer, ValueTuple<bool> value)
+        public static void Write_v_rbz(this ref global::Tmds.DBus.Protocol.MessageWriter writer, global::System.ValueTuple<bool> value)
         {
             writer.WriteSignature("(b)");
             writer.Write_rbz(value);
         }
-        public static void Write_rbz(this ref MessageWriter writer, ValueTuple<bool> value)
+        public static void Write_rbz(this ref global::Tmds.DBus.Protocol.MessageWriter writer, global::System.ValueTuple<bool> value)
         {
             writer.WriteStructureStart();
             writer.WriteBool(value.Item1);
         }
-        public static void Write_v_s(this ref MessageWriter writer, string value)
+        public static void Write_v_s(this ref global::Tmds.DBus.Protocol.MessageWriter writer, string value)
         {
             writer.WriteSignature("s");
             writer.WriteString(value);
@@ -963,14 +958,10 @@ namespace TestNamespace
 #nullable enable
 namespace Tmds.DBus.Protocol
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Threading;
-    using System.Threading.Tasks;
     abstract class DBusHandler : IPathMethodHandler
     {
         // Identifies the D-Bus interfaces. Used with SupportsInterface to filter interfaces per path.
-        [Flags]
+        [global::System.Flags]
         public enum DBusInterface
         {
             // OrgFreedesktopDBusIntrospectable = 1,
@@ -978,7 +969,7 @@ namespace Tmds.DBus.Protocol
             OrgExampleMarker = 4,
             OrgExampleSettings = 8,
         }
-        private static ReadOnlyMemory<byte> OrgExampleCalculatorXml { get; } =
+        private static global::System.ReadOnlyMemory<byte> OrgExampleCalculatorXml { get; } =
             """
             <interface name="org.example.Calculator">
               <method name="Clear" />
@@ -1038,12 +1029,12 @@ namespace Tmds.DBus.Protocol
             </interface>
 
             """u8.ToArray();
-        private static ReadOnlyMemory<byte> OrgExampleMarkerXml { get; } =
+        private static global::System.ReadOnlyMemory<byte> OrgExampleMarkerXml { get; } =
             """
             <interface name="org.example.Marker" />
 
             """u8.ToArray();
-        private static ReadOnlyMemory<byte> OrgExampleSettingsXml { get; } =
+        private static global::System.ReadOnlyMemory<byte> OrgExampleSettingsXml { get; } =
             """
             <interface name="org.example.Settings">
               <method name="Save" />
@@ -1054,19 +1045,19 @@ namespace Tmds.DBus.Protocol
             </interface>
 
             """u8.ToArray();
-        private readonly SendOrPostCallback? _postDelegate;
+        private readonly global::System.Threading.SendOrPostCallback? _postDelegate;
         private const DBusInterface OrgFreedesktopDBusIntrospectable = (DBusInterface)1;
         private const DBusInterface InterfacesWithProperties = DBusInterface.OrgExampleCalculator | DBusInterface.OrgExampleSettings;
         public string Path { get; }
         public bool HandlesChildPaths { get; }
         public DBusConnection Connection { get; }
         // The SynchronizationContext on which method handlers are invoked.
-        protected SynchronizationContext? SynchronizationContext { get; }
+        protected global::System.Threading.SynchronizationContext? SynchronizationContext { get; }
         protected DBusHandler(DBusConnection connection, string path, bool handlesChildPaths, bool handleOnCapturedContext = true)
-            : this(connection, path, handlesChildPaths, handleOnCapturedContext ? SynchronizationContext.Current : null)
+            : this(connection, path, handlesChildPaths, handleOnCapturedContext ? global::System.Threading.SynchronizationContext.Current : null)
         {
         }
-        protected DBusHandler(DBusConnection connection, string path, bool handlesChildPaths, SynchronizationContext? synchronizationContext)
+        protected DBusHandler(DBusConnection connection, string path, bool handlesChildPaths, global::System.Threading.SynchronizationContext? synchronizationContext)
         {
             Connection = connection;
             Path = path;
@@ -1084,19 +1075,19 @@ namespace Tmds.DBus.Protocol
             }
         }
         // Override to add cross-cutting logic (e.g. logging, error handling) around method invocations.
-        protected virtual async ValueTask InvokeAsync(DBusMethod method, MethodContext context)
+        protected virtual async global::System.Threading.Tasks.ValueTask InvokeAsync(DBusMethod method, MethodContext context)
         {
             try
             {
                 await method.Invoke(context).ConfigureAwait(false);
             }
-            catch (Exception ex)
+            catch (global::System.Exception ex)
             {
                 HandleException(context, ex);
             }
         }
         // Override to customize exception handling for method invocations.
-        protected virtual void HandleException(MethodContext context, Exception ex)
+        protected virtual void HandleException(MethodContext context, global::System.Exception ex)
         {
             if (context.HandleException(ex, shouldDisconnect: false))
             {
@@ -1106,7 +1097,7 @@ namespace Tmds.DBus.Protocol
             {
                 context.ReplyError(dbusEx.ErrorName, dbusEx.ErrorMessage);
             }
-            else if (ex is ArgumentException)
+            else if (ex is global::System.ArgumentException)
             {
                 context.ReplyError("org.freedesktop.DBus.Error.InvalidArgs", ex.Message);
             }
@@ -1116,19 +1107,19 @@ namespace Tmds.DBus.Protocol
             }
         }
         // Override to filter interfaces for specific paths when the handler manages multiple paths.
-        protected virtual bool SupportsInterface(DBusInterface dbusInterface, ReadOnlySpan<char> path)
+        protected virtual bool SupportsInterface(DBusInterface dbusInterface, global::System.ReadOnlySpan<char> path)
         {
             return true;
         }
         // Override to customize introspection, e.g. to include child node names.
-        protected virtual ValueTask HandleIntrospectAsync(IntrospectContext context)
+        protected virtual global::System.Threading.Tasks.ValueTask HandleIntrospectAsync(IntrospectContext context)
         {
-            DBusInterface interfaces = GetSupportedInterfaces(context.MethodContext.Request.PathAsString.AsSpan());
+            DBusInterface interfaces = GetSupportedInterfaces(global::System.MemoryExtensions.AsSpan(context.MethodContext.Request.PathAsString));
             context.Reply(interfaces);
             return default;
         }
         // Context for IntrospectAsync. Call Reply to send the introspection XML response.
-        protected readonly struct IntrospectContext : IDisposable
+        protected readonly struct IntrospectContext : global::System.IDisposable
         {
             public MethodContext MethodContext { get; }
             public IntrospectContext(MethodContext methodContext)
@@ -1136,9 +1127,9 @@ namespace Tmds.DBus.Protocol
                 MethodContext = methodContext;
             }
             public void Dispose() => MethodContext.Dispose();
-            public void Reply(DBusInterface interfaces, IList<string>? childNames = null)
+            public void Reply(DBusInterface interfaces, global::System.Collections.Generic.IList<string>? childNames = null)
             {
-                var interfaceXmls = new ReadOnlyMemory<byte>[4];
+                var interfaceXmls = new global::System.ReadOnlyMemory<byte>[4];
                 int count = 0;
                 if ((interfaces & DBusInterface.OrgExampleCalculator) != 0)
                 {
@@ -1158,42 +1149,42 @@ namespace Tmds.DBus.Protocol
                 }
                 if (childNames is not null)
                 {
-                    MethodContext.ReplyIntrospectXml(interfaceXmls.AsSpan(0, count), childNames);
+                    MethodContext.ReplyIntrospectXml(global::System.MemoryExtensions.AsSpan(interfaceXmls, 0, count), childNames);
                 }
                 else
                 {
-                    MethodContext.ReplyIntrospectXml(interfaceXmls.AsSpan(0, count));
+                    MethodContext.ReplyIntrospectXml(global::System.MemoryExtensions.AsSpan(interfaceXmls, 0, count));
                 }
             }
         }
         internal readonly struct DBusMethod
         {
-            private readonly Func<object, MethodContext, ValueTask> _method;
+            private readonly global::System.Func<object, MethodContext, global::System.Threading.Tasks.ValueTask> _method;
             private readonly object _target;
-            public DBusMethod(Func<object, MethodContext, ValueTask> method, object target)
+            public DBusMethod(global::System.Func<object, MethodContext, global::System.Threading.Tasks.ValueTask> method, object target)
             {
                 _method = method;
                 _target = target;
             }
             public bool HasValue => _method is not null;
-            public ValueTask Invoke(MethodContext context)
+            public global::System.Threading.Tasks.ValueTask Invoke(MethodContext context)
             {
                 return _method?.Invoke(_target, context) ?? default;
             }
         }
-        ValueTask IPathMethodHandler.HandleMethodAsync(MethodContext context)
+        global::System.Threading.Tasks.ValueTask IPathMethodHandler.HandleMethodAsync(MethodContext context)
         {
             DBusInterface dbusInterface = ParseInterface(context);
-            DBusMethod method = (dbusInterface != OrgFreedesktopDBusIntrospectable && !SupportsInterface(dbusInterface, context.Request.PathAsString.AsSpan())) ? default : FindMethodHandler(context, dbusInterface);
+            DBusMethod method = (dbusInterface != OrgFreedesktopDBusIntrospectable && !SupportsInterface(dbusInterface, global::System.MemoryExtensions.AsSpan(context.Request.PathAsString))) ? default : FindMethodHandler(context, dbusInterface);
             if (!method.HasValue)
             {
                 return default;
             }
             return HandleAsync(method, context);
         }
-        private ValueTask HandleAsync(DBusMethod method, MethodContext context)
+        private global::System.Threading.Tasks.ValueTask HandleAsync(DBusMethod method, MethodContext context)
         {
-            SynchronizationContext? synchronizationContext = SynchronizationContext;
+            global::System.Threading.SynchronizationContext? synchronizationContext = SynchronizationContext;
             if (synchronizationContext is null)
             {
                 return InvokeAsync(method, context);
@@ -1205,7 +1196,7 @@ namespace Tmds.DBus.Protocol
                 return default;
             }
         }
-        private async ValueTask InvokeAndDisposeAsync(DBusMethod method, MethodContext context)
+        private async global::System.Threading.Tasks.ValueTask InvokeAndDisposeAsync(DBusMethod method, MethodContext context)
         {
             try
             {
@@ -1266,7 +1257,7 @@ namespace Tmds.DBus.Protocol
             };
             return result;
         }
-        protected DBusInterface GetSupportedInterfaces(ReadOnlySpan<char> path)
+        protected DBusInterface GetSupportedInterfaces(global::System.ReadOnlySpan<char> path)
         {
             DBusInterface interfaces = default;
             if (SupportsInterface(DBusInterface.OrgExampleCalculator, path) && this is TestNamespace.ICalculatorHandler)

--- a/test/Tmds.DBus.Generator.Tests/CodeGenerationTests.VerifyGeneratedOutput_ManyProperties.verified.txt
+++ b/test/Tmds.DBus.Generator.Tests/CodeGenerationTests.VerifyGeneratedOutput_ManyProperties.verified.txt
@@ -3,11 +3,6 @@
 #nullable enable
 namespace TestNamespace
 {
-    using System;
-    using Tmds.DBus.Protocol;
-    using System.Collections.Generic;
-    using System.Threading.Tasks;
-    using System.Runtime.CompilerServices;
     enum ManyPropertiesProperty
     {
         UnknownProperty = 0,
@@ -287,19 +282,19 @@ namespace TestNamespace
     {
         private byte[] __set = new byte[9];
         private byte[] __invalidated = new byte[9];
-        private static ReadOnlySpan<byte> PropertiesAllSet => new byte[] { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x01 }; // 65 properties
+        private static global::System.ReadOnlySpan<byte> PropertiesAllSet => new byte[] { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x01 }; // 65 properties
         private static int FlagIndex(ManyPropertiesProperty property) => ((int)property - 1) / 8;
         private static byte FlagMask(ManyPropertiesProperty property) => (byte)(1 << (((int)property - 1) % 8));
         public ManyPropertiesProperties() { }
         #nullable disable
-        [System.Diagnostics.CodeAnalysis.SetsRequiredMembers]
+        [global::System.Diagnostics.CodeAnalysis.SetsRequiredMembers]
         private ManyPropertiesProperties(bool _) { }
         #nullable enable
         private void EnsureSet(ManyPropertiesProperty property)
         {
             if (!HasFlag(__set, property))
             {
-                throw new InvalidOperationException("Property is not set.");
+                throw new global::System.InvalidOperationException("Property is not set.");
             }
         }
         private string _prop1 = default!;
@@ -969,18 +964,18 @@ namespace TestNamespace
                 __invalidated[FlagIndex(property)] |= FlagMask(property);
             }
         }
-        public bool AreAllPropertiesSet() => __set.AsSpan().SequenceEqual(PropertiesAllSet);
+        public bool AreAllPropertiesSet() => global::System.MemoryExtensions.SequenceEqual(PropertiesAllSet, __set);
         public void EnsureAllPropertiesSet()
         {
             if (!AreAllPropertiesSet())
             {
-                throw new DBusUnexpectedValueException($"Not all properties have been set ({BitConverter.ToString(__set)}).");
+                throw new global::Tmds.DBus.Protocol.DBusUnexpectedValueException("Not all properties have been set (" + global::System.BitConverter.ToString(__set) + ").");
             }
         }
-        public static ManyPropertiesProperties ReadFrom(ref Reader reader, bool withInvalidated)
+        public static ManyPropertiesProperties ReadFrom(ref global::Tmds.DBus.Protocol.Reader reader, bool withInvalidated)
         {
             var props = CreateUninitialized();
-            ArrayEnd arrayEnd = reader.ReadArrayStart(DBusType.Struct);
+            global::Tmds.DBus.Protocol.ArrayEnd arrayEnd = reader.ReadArrayStart(global::Tmds.DBus.Protocol.DBusType.Struct);
             while (reader.HasNext(arrayEnd))
             {
                 var property = reader.ReadString();
@@ -1253,7 +1248,7 @@ namespace TestNamespace
             }
             if (withInvalidated)
             {
-                ArrayEnd invalidatedEnd = reader.ReadArrayStart(DBusType.String);
+                global::Tmds.DBus.Protocol.ArrayEnd invalidatedEnd = reader.ReadArrayStart(global::Tmds.DBus.Protocol.DBusType.String);
                 while (reader.HasNext(invalidatedEnd))
                 {
                     var propertyName = reader.ReadString();
@@ -1460,185 +1455,185 @@ namespace TestNamespace
             return props;
         }
     }
-    sealed partial class ManyProperties : Tmds.DBus.Protocol.DBusObject
+    sealed partial class ManyProperties : global::Tmds.DBus.Protocol.DBusObject
     {
         public const string DBusInterfaceName = "org.example.ManyProperties";
-        public ManyProperties(Tmds.DBus.Protocol.DBusConnection connection, string destination, ObjectPath path)
+        public ManyProperties(global::Tmds.DBus.Protocol.DBusConnection connection, string destination, global::Tmds.DBus.Protocol.ObjectPath path)
             : base(connection, destination, path)
         { }
-        public Task<string> GetProp1Async()
-            => Connection.CallMethodAsync(CreateGetPropertyMessage("Prop1"), (Message m, object? s) => MessageReader.Read_v_s(m), this);
-        public Task<string> GetProp2Async()
-            => Connection.CallMethodAsync(CreateGetPropertyMessage("Prop2"), (Message m, object? s) => MessageReader.Read_v_s(m), this);
-        public Task<string> GetProp3Async()
-            => Connection.CallMethodAsync(CreateGetPropertyMessage("Prop3"), (Message m, object? s) => MessageReader.Read_v_s(m), this);
-        public Task<string> GetProp4Async()
-            => Connection.CallMethodAsync(CreateGetPropertyMessage("Prop4"), (Message m, object? s) => MessageReader.Read_v_s(m), this);
-        public Task<string> GetProp5Async()
-            => Connection.CallMethodAsync(CreateGetPropertyMessage("Prop5"), (Message m, object? s) => MessageReader.Read_v_s(m), this);
-        public Task<string> GetProp6Async()
-            => Connection.CallMethodAsync(CreateGetPropertyMessage("Prop6"), (Message m, object? s) => MessageReader.Read_v_s(m), this);
-        public Task<string> GetProp7Async()
-            => Connection.CallMethodAsync(CreateGetPropertyMessage("Prop7"), (Message m, object? s) => MessageReader.Read_v_s(m), this);
-        public Task<string> GetProp8Async()
-            => Connection.CallMethodAsync(CreateGetPropertyMessage("Prop8"), (Message m, object? s) => MessageReader.Read_v_s(m), this);
-        public Task<string> GetProp9Async()
-            => Connection.CallMethodAsync(CreateGetPropertyMessage("Prop9"), (Message m, object? s) => MessageReader.Read_v_s(m), this);
-        public Task<string> GetProp10Async()
-            => Connection.CallMethodAsync(CreateGetPropertyMessage("Prop10"), (Message m, object? s) => MessageReader.Read_v_s(m), this);
-        public Task<string> GetProp11Async()
-            => Connection.CallMethodAsync(CreateGetPropertyMessage("Prop11"), (Message m, object? s) => MessageReader.Read_v_s(m), this);
-        public Task<string> GetProp12Async()
-            => Connection.CallMethodAsync(CreateGetPropertyMessage("Prop12"), (Message m, object? s) => MessageReader.Read_v_s(m), this);
-        public Task<string> GetProp13Async()
-            => Connection.CallMethodAsync(CreateGetPropertyMessage("Prop13"), (Message m, object? s) => MessageReader.Read_v_s(m), this);
-        public Task<string> GetProp14Async()
-            => Connection.CallMethodAsync(CreateGetPropertyMessage("Prop14"), (Message m, object? s) => MessageReader.Read_v_s(m), this);
-        public Task<string> GetProp15Async()
-            => Connection.CallMethodAsync(CreateGetPropertyMessage("Prop15"), (Message m, object? s) => MessageReader.Read_v_s(m), this);
-        public Task<string> GetProp16Async()
-            => Connection.CallMethodAsync(CreateGetPropertyMessage("Prop16"), (Message m, object? s) => MessageReader.Read_v_s(m), this);
-        public Task<string> GetProp17Async()
-            => Connection.CallMethodAsync(CreateGetPropertyMessage("Prop17"), (Message m, object? s) => MessageReader.Read_v_s(m), this);
-        public Task<string> GetProp18Async()
-            => Connection.CallMethodAsync(CreateGetPropertyMessage("Prop18"), (Message m, object? s) => MessageReader.Read_v_s(m), this);
-        public Task<string> GetProp19Async()
-            => Connection.CallMethodAsync(CreateGetPropertyMessage("Prop19"), (Message m, object? s) => MessageReader.Read_v_s(m), this);
-        public Task<string> GetProp20Async()
-            => Connection.CallMethodAsync(CreateGetPropertyMessage("Prop20"), (Message m, object? s) => MessageReader.Read_v_s(m), this);
-        public Task<string> GetProp21Async()
-            => Connection.CallMethodAsync(CreateGetPropertyMessage("Prop21"), (Message m, object? s) => MessageReader.Read_v_s(m), this);
-        public Task<string> GetProp22Async()
-            => Connection.CallMethodAsync(CreateGetPropertyMessage("Prop22"), (Message m, object? s) => MessageReader.Read_v_s(m), this);
-        public Task<string> GetProp23Async()
-            => Connection.CallMethodAsync(CreateGetPropertyMessage("Prop23"), (Message m, object? s) => MessageReader.Read_v_s(m), this);
-        public Task<string> GetProp24Async()
-            => Connection.CallMethodAsync(CreateGetPropertyMessage("Prop24"), (Message m, object? s) => MessageReader.Read_v_s(m), this);
-        public Task<string> GetProp25Async()
-            => Connection.CallMethodAsync(CreateGetPropertyMessage("Prop25"), (Message m, object? s) => MessageReader.Read_v_s(m), this);
-        public Task<string> GetProp26Async()
-            => Connection.CallMethodAsync(CreateGetPropertyMessage("Prop26"), (Message m, object? s) => MessageReader.Read_v_s(m), this);
-        public Task<string> GetProp27Async()
-            => Connection.CallMethodAsync(CreateGetPropertyMessage("Prop27"), (Message m, object? s) => MessageReader.Read_v_s(m), this);
-        public Task<string> GetProp28Async()
-            => Connection.CallMethodAsync(CreateGetPropertyMessage("Prop28"), (Message m, object? s) => MessageReader.Read_v_s(m), this);
-        public Task<string> GetProp29Async()
-            => Connection.CallMethodAsync(CreateGetPropertyMessage("Prop29"), (Message m, object? s) => MessageReader.Read_v_s(m), this);
-        public Task<string> GetProp30Async()
-            => Connection.CallMethodAsync(CreateGetPropertyMessage("Prop30"), (Message m, object? s) => MessageReader.Read_v_s(m), this);
-        public Task<string> GetProp31Async()
-            => Connection.CallMethodAsync(CreateGetPropertyMessage("Prop31"), (Message m, object? s) => MessageReader.Read_v_s(m), this);
-        public Task<string> GetProp32Async()
-            => Connection.CallMethodAsync(CreateGetPropertyMessage("Prop32"), (Message m, object? s) => MessageReader.Read_v_s(m), this);
-        public Task<string> GetProp33Async()
-            => Connection.CallMethodAsync(CreateGetPropertyMessage("Prop33"), (Message m, object? s) => MessageReader.Read_v_s(m), this);
-        public Task<string> GetProp34Async()
-            => Connection.CallMethodAsync(CreateGetPropertyMessage("Prop34"), (Message m, object? s) => MessageReader.Read_v_s(m), this);
-        public Task<string> GetProp35Async()
-            => Connection.CallMethodAsync(CreateGetPropertyMessage("Prop35"), (Message m, object? s) => MessageReader.Read_v_s(m), this);
-        public Task<string> GetProp36Async()
-            => Connection.CallMethodAsync(CreateGetPropertyMessage("Prop36"), (Message m, object? s) => MessageReader.Read_v_s(m), this);
-        public Task<string> GetProp37Async()
-            => Connection.CallMethodAsync(CreateGetPropertyMessage("Prop37"), (Message m, object? s) => MessageReader.Read_v_s(m), this);
-        public Task<string> GetProp38Async()
-            => Connection.CallMethodAsync(CreateGetPropertyMessage("Prop38"), (Message m, object? s) => MessageReader.Read_v_s(m), this);
-        public Task<string> GetProp39Async()
-            => Connection.CallMethodAsync(CreateGetPropertyMessage("Prop39"), (Message m, object? s) => MessageReader.Read_v_s(m), this);
-        public Task<string> GetProp40Async()
-            => Connection.CallMethodAsync(CreateGetPropertyMessage("Prop40"), (Message m, object? s) => MessageReader.Read_v_s(m), this);
-        public Task<string> GetProp41Async()
-            => Connection.CallMethodAsync(CreateGetPropertyMessage("Prop41"), (Message m, object? s) => MessageReader.Read_v_s(m), this);
-        public Task<string> GetProp42Async()
-            => Connection.CallMethodAsync(CreateGetPropertyMessage("Prop42"), (Message m, object? s) => MessageReader.Read_v_s(m), this);
-        public Task<string> GetProp43Async()
-            => Connection.CallMethodAsync(CreateGetPropertyMessage("Prop43"), (Message m, object? s) => MessageReader.Read_v_s(m), this);
-        public Task<string> GetProp44Async()
-            => Connection.CallMethodAsync(CreateGetPropertyMessage("Prop44"), (Message m, object? s) => MessageReader.Read_v_s(m), this);
-        public Task<string> GetProp45Async()
-            => Connection.CallMethodAsync(CreateGetPropertyMessage("Prop45"), (Message m, object? s) => MessageReader.Read_v_s(m), this);
-        public Task<string> GetProp46Async()
-            => Connection.CallMethodAsync(CreateGetPropertyMessage("Prop46"), (Message m, object? s) => MessageReader.Read_v_s(m), this);
-        public Task<string> GetProp47Async()
-            => Connection.CallMethodAsync(CreateGetPropertyMessage("Prop47"), (Message m, object? s) => MessageReader.Read_v_s(m), this);
-        public Task<string> GetProp48Async()
-            => Connection.CallMethodAsync(CreateGetPropertyMessage("Prop48"), (Message m, object? s) => MessageReader.Read_v_s(m), this);
-        public Task<string> GetProp49Async()
-            => Connection.CallMethodAsync(CreateGetPropertyMessage("Prop49"), (Message m, object? s) => MessageReader.Read_v_s(m), this);
-        public Task<string> GetProp50Async()
-            => Connection.CallMethodAsync(CreateGetPropertyMessage("Prop50"), (Message m, object? s) => MessageReader.Read_v_s(m), this);
-        public Task<string> GetProp51Async()
-            => Connection.CallMethodAsync(CreateGetPropertyMessage("Prop51"), (Message m, object? s) => MessageReader.Read_v_s(m), this);
-        public Task<string> GetProp52Async()
-            => Connection.CallMethodAsync(CreateGetPropertyMessage("Prop52"), (Message m, object? s) => MessageReader.Read_v_s(m), this);
-        public Task<string> GetProp53Async()
-            => Connection.CallMethodAsync(CreateGetPropertyMessage("Prop53"), (Message m, object? s) => MessageReader.Read_v_s(m), this);
-        public Task<string> GetProp54Async()
-            => Connection.CallMethodAsync(CreateGetPropertyMessage("Prop54"), (Message m, object? s) => MessageReader.Read_v_s(m), this);
-        public Task<string> GetProp55Async()
-            => Connection.CallMethodAsync(CreateGetPropertyMessage("Prop55"), (Message m, object? s) => MessageReader.Read_v_s(m), this);
-        public Task<string> GetProp56Async()
-            => Connection.CallMethodAsync(CreateGetPropertyMessage("Prop56"), (Message m, object? s) => MessageReader.Read_v_s(m), this);
-        public Task<string> GetProp57Async()
-            => Connection.CallMethodAsync(CreateGetPropertyMessage("Prop57"), (Message m, object? s) => MessageReader.Read_v_s(m), this);
-        public Task<string> GetProp58Async()
-            => Connection.CallMethodAsync(CreateGetPropertyMessage("Prop58"), (Message m, object? s) => MessageReader.Read_v_s(m), this);
-        public Task<string> GetProp59Async()
-            => Connection.CallMethodAsync(CreateGetPropertyMessage("Prop59"), (Message m, object? s) => MessageReader.Read_v_s(m), this);
-        public Task<string> GetProp60Async()
-            => Connection.CallMethodAsync(CreateGetPropertyMessage("Prop60"), (Message m, object? s) => MessageReader.Read_v_s(m), this);
-        public Task<string> GetProp61Async()
-            => Connection.CallMethodAsync(CreateGetPropertyMessage("Prop61"), (Message m, object? s) => MessageReader.Read_v_s(m), this);
-        public Task<string> GetProp62Async()
-            => Connection.CallMethodAsync(CreateGetPropertyMessage("Prop62"), (Message m, object? s) => MessageReader.Read_v_s(m), this);
-        public Task<string> GetProp63Async()
-            => Connection.CallMethodAsync(CreateGetPropertyMessage("Prop63"), (Message m, object? s) => MessageReader.Read_v_s(m), this);
-        public Task<string> GetProp64Async()
-            => Connection.CallMethodAsync(CreateGetPropertyMessage("Prop64"), (Message m, object? s) => MessageReader.Read_v_s(m), this);
-        public Task<string> GetProp65Async()
-            => Connection.CallMethodAsync(CreateGetPropertyMessage("Prop65"), (Message m, object? s) => MessageReader.Read_v_s(m), this);
-        public Task<ManyPropertiesProperties> GetPropertiesAsync()
+        public global::System.Threading.Tasks.Task<string> GetProp1Async()
+            => Connection.CallMethodAsync(CreateGetPropertyMessage("Prop1"), (global::Tmds.DBus.Protocol.Message m, object? s) => MessageReader.Read_v_s(m), this);
+        public global::System.Threading.Tasks.Task<string> GetProp2Async()
+            => Connection.CallMethodAsync(CreateGetPropertyMessage("Prop2"), (global::Tmds.DBus.Protocol.Message m, object? s) => MessageReader.Read_v_s(m), this);
+        public global::System.Threading.Tasks.Task<string> GetProp3Async()
+            => Connection.CallMethodAsync(CreateGetPropertyMessage("Prop3"), (global::Tmds.DBus.Protocol.Message m, object? s) => MessageReader.Read_v_s(m), this);
+        public global::System.Threading.Tasks.Task<string> GetProp4Async()
+            => Connection.CallMethodAsync(CreateGetPropertyMessage("Prop4"), (global::Tmds.DBus.Protocol.Message m, object? s) => MessageReader.Read_v_s(m), this);
+        public global::System.Threading.Tasks.Task<string> GetProp5Async()
+            => Connection.CallMethodAsync(CreateGetPropertyMessage("Prop5"), (global::Tmds.DBus.Protocol.Message m, object? s) => MessageReader.Read_v_s(m), this);
+        public global::System.Threading.Tasks.Task<string> GetProp6Async()
+            => Connection.CallMethodAsync(CreateGetPropertyMessage("Prop6"), (global::Tmds.DBus.Protocol.Message m, object? s) => MessageReader.Read_v_s(m), this);
+        public global::System.Threading.Tasks.Task<string> GetProp7Async()
+            => Connection.CallMethodAsync(CreateGetPropertyMessage("Prop7"), (global::Tmds.DBus.Protocol.Message m, object? s) => MessageReader.Read_v_s(m), this);
+        public global::System.Threading.Tasks.Task<string> GetProp8Async()
+            => Connection.CallMethodAsync(CreateGetPropertyMessage("Prop8"), (global::Tmds.DBus.Protocol.Message m, object? s) => MessageReader.Read_v_s(m), this);
+        public global::System.Threading.Tasks.Task<string> GetProp9Async()
+            => Connection.CallMethodAsync(CreateGetPropertyMessage("Prop9"), (global::Tmds.DBus.Protocol.Message m, object? s) => MessageReader.Read_v_s(m), this);
+        public global::System.Threading.Tasks.Task<string> GetProp10Async()
+            => Connection.CallMethodAsync(CreateGetPropertyMessage("Prop10"), (global::Tmds.DBus.Protocol.Message m, object? s) => MessageReader.Read_v_s(m), this);
+        public global::System.Threading.Tasks.Task<string> GetProp11Async()
+            => Connection.CallMethodAsync(CreateGetPropertyMessage("Prop11"), (global::Tmds.DBus.Protocol.Message m, object? s) => MessageReader.Read_v_s(m), this);
+        public global::System.Threading.Tasks.Task<string> GetProp12Async()
+            => Connection.CallMethodAsync(CreateGetPropertyMessage("Prop12"), (global::Tmds.DBus.Protocol.Message m, object? s) => MessageReader.Read_v_s(m), this);
+        public global::System.Threading.Tasks.Task<string> GetProp13Async()
+            => Connection.CallMethodAsync(CreateGetPropertyMessage("Prop13"), (global::Tmds.DBus.Protocol.Message m, object? s) => MessageReader.Read_v_s(m), this);
+        public global::System.Threading.Tasks.Task<string> GetProp14Async()
+            => Connection.CallMethodAsync(CreateGetPropertyMessage("Prop14"), (global::Tmds.DBus.Protocol.Message m, object? s) => MessageReader.Read_v_s(m), this);
+        public global::System.Threading.Tasks.Task<string> GetProp15Async()
+            => Connection.CallMethodAsync(CreateGetPropertyMessage("Prop15"), (global::Tmds.DBus.Protocol.Message m, object? s) => MessageReader.Read_v_s(m), this);
+        public global::System.Threading.Tasks.Task<string> GetProp16Async()
+            => Connection.CallMethodAsync(CreateGetPropertyMessage("Prop16"), (global::Tmds.DBus.Protocol.Message m, object? s) => MessageReader.Read_v_s(m), this);
+        public global::System.Threading.Tasks.Task<string> GetProp17Async()
+            => Connection.CallMethodAsync(CreateGetPropertyMessage("Prop17"), (global::Tmds.DBus.Protocol.Message m, object? s) => MessageReader.Read_v_s(m), this);
+        public global::System.Threading.Tasks.Task<string> GetProp18Async()
+            => Connection.CallMethodAsync(CreateGetPropertyMessage("Prop18"), (global::Tmds.DBus.Protocol.Message m, object? s) => MessageReader.Read_v_s(m), this);
+        public global::System.Threading.Tasks.Task<string> GetProp19Async()
+            => Connection.CallMethodAsync(CreateGetPropertyMessage("Prop19"), (global::Tmds.DBus.Protocol.Message m, object? s) => MessageReader.Read_v_s(m), this);
+        public global::System.Threading.Tasks.Task<string> GetProp20Async()
+            => Connection.CallMethodAsync(CreateGetPropertyMessage("Prop20"), (global::Tmds.DBus.Protocol.Message m, object? s) => MessageReader.Read_v_s(m), this);
+        public global::System.Threading.Tasks.Task<string> GetProp21Async()
+            => Connection.CallMethodAsync(CreateGetPropertyMessage("Prop21"), (global::Tmds.DBus.Protocol.Message m, object? s) => MessageReader.Read_v_s(m), this);
+        public global::System.Threading.Tasks.Task<string> GetProp22Async()
+            => Connection.CallMethodAsync(CreateGetPropertyMessage("Prop22"), (global::Tmds.DBus.Protocol.Message m, object? s) => MessageReader.Read_v_s(m), this);
+        public global::System.Threading.Tasks.Task<string> GetProp23Async()
+            => Connection.CallMethodAsync(CreateGetPropertyMessage("Prop23"), (global::Tmds.DBus.Protocol.Message m, object? s) => MessageReader.Read_v_s(m), this);
+        public global::System.Threading.Tasks.Task<string> GetProp24Async()
+            => Connection.CallMethodAsync(CreateGetPropertyMessage("Prop24"), (global::Tmds.DBus.Protocol.Message m, object? s) => MessageReader.Read_v_s(m), this);
+        public global::System.Threading.Tasks.Task<string> GetProp25Async()
+            => Connection.CallMethodAsync(CreateGetPropertyMessage("Prop25"), (global::Tmds.DBus.Protocol.Message m, object? s) => MessageReader.Read_v_s(m), this);
+        public global::System.Threading.Tasks.Task<string> GetProp26Async()
+            => Connection.CallMethodAsync(CreateGetPropertyMessage("Prop26"), (global::Tmds.DBus.Protocol.Message m, object? s) => MessageReader.Read_v_s(m), this);
+        public global::System.Threading.Tasks.Task<string> GetProp27Async()
+            => Connection.CallMethodAsync(CreateGetPropertyMessage("Prop27"), (global::Tmds.DBus.Protocol.Message m, object? s) => MessageReader.Read_v_s(m), this);
+        public global::System.Threading.Tasks.Task<string> GetProp28Async()
+            => Connection.CallMethodAsync(CreateGetPropertyMessage("Prop28"), (global::Tmds.DBus.Protocol.Message m, object? s) => MessageReader.Read_v_s(m), this);
+        public global::System.Threading.Tasks.Task<string> GetProp29Async()
+            => Connection.CallMethodAsync(CreateGetPropertyMessage("Prop29"), (global::Tmds.DBus.Protocol.Message m, object? s) => MessageReader.Read_v_s(m), this);
+        public global::System.Threading.Tasks.Task<string> GetProp30Async()
+            => Connection.CallMethodAsync(CreateGetPropertyMessage("Prop30"), (global::Tmds.DBus.Protocol.Message m, object? s) => MessageReader.Read_v_s(m), this);
+        public global::System.Threading.Tasks.Task<string> GetProp31Async()
+            => Connection.CallMethodAsync(CreateGetPropertyMessage("Prop31"), (global::Tmds.DBus.Protocol.Message m, object? s) => MessageReader.Read_v_s(m), this);
+        public global::System.Threading.Tasks.Task<string> GetProp32Async()
+            => Connection.CallMethodAsync(CreateGetPropertyMessage("Prop32"), (global::Tmds.DBus.Protocol.Message m, object? s) => MessageReader.Read_v_s(m), this);
+        public global::System.Threading.Tasks.Task<string> GetProp33Async()
+            => Connection.CallMethodAsync(CreateGetPropertyMessage("Prop33"), (global::Tmds.DBus.Protocol.Message m, object? s) => MessageReader.Read_v_s(m), this);
+        public global::System.Threading.Tasks.Task<string> GetProp34Async()
+            => Connection.CallMethodAsync(CreateGetPropertyMessage("Prop34"), (global::Tmds.DBus.Protocol.Message m, object? s) => MessageReader.Read_v_s(m), this);
+        public global::System.Threading.Tasks.Task<string> GetProp35Async()
+            => Connection.CallMethodAsync(CreateGetPropertyMessage("Prop35"), (global::Tmds.DBus.Protocol.Message m, object? s) => MessageReader.Read_v_s(m), this);
+        public global::System.Threading.Tasks.Task<string> GetProp36Async()
+            => Connection.CallMethodAsync(CreateGetPropertyMessage("Prop36"), (global::Tmds.DBus.Protocol.Message m, object? s) => MessageReader.Read_v_s(m), this);
+        public global::System.Threading.Tasks.Task<string> GetProp37Async()
+            => Connection.CallMethodAsync(CreateGetPropertyMessage("Prop37"), (global::Tmds.DBus.Protocol.Message m, object? s) => MessageReader.Read_v_s(m), this);
+        public global::System.Threading.Tasks.Task<string> GetProp38Async()
+            => Connection.CallMethodAsync(CreateGetPropertyMessage("Prop38"), (global::Tmds.DBus.Protocol.Message m, object? s) => MessageReader.Read_v_s(m), this);
+        public global::System.Threading.Tasks.Task<string> GetProp39Async()
+            => Connection.CallMethodAsync(CreateGetPropertyMessage("Prop39"), (global::Tmds.DBus.Protocol.Message m, object? s) => MessageReader.Read_v_s(m), this);
+        public global::System.Threading.Tasks.Task<string> GetProp40Async()
+            => Connection.CallMethodAsync(CreateGetPropertyMessage("Prop40"), (global::Tmds.DBus.Protocol.Message m, object? s) => MessageReader.Read_v_s(m), this);
+        public global::System.Threading.Tasks.Task<string> GetProp41Async()
+            => Connection.CallMethodAsync(CreateGetPropertyMessage("Prop41"), (global::Tmds.DBus.Protocol.Message m, object? s) => MessageReader.Read_v_s(m), this);
+        public global::System.Threading.Tasks.Task<string> GetProp42Async()
+            => Connection.CallMethodAsync(CreateGetPropertyMessage("Prop42"), (global::Tmds.DBus.Protocol.Message m, object? s) => MessageReader.Read_v_s(m), this);
+        public global::System.Threading.Tasks.Task<string> GetProp43Async()
+            => Connection.CallMethodAsync(CreateGetPropertyMessage("Prop43"), (global::Tmds.DBus.Protocol.Message m, object? s) => MessageReader.Read_v_s(m), this);
+        public global::System.Threading.Tasks.Task<string> GetProp44Async()
+            => Connection.CallMethodAsync(CreateGetPropertyMessage("Prop44"), (global::Tmds.DBus.Protocol.Message m, object? s) => MessageReader.Read_v_s(m), this);
+        public global::System.Threading.Tasks.Task<string> GetProp45Async()
+            => Connection.CallMethodAsync(CreateGetPropertyMessage("Prop45"), (global::Tmds.DBus.Protocol.Message m, object? s) => MessageReader.Read_v_s(m), this);
+        public global::System.Threading.Tasks.Task<string> GetProp46Async()
+            => Connection.CallMethodAsync(CreateGetPropertyMessage("Prop46"), (global::Tmds.DBus.Protocol.Message m, object? s) => MessageReader.Read_v_s(m), this);
+        public global::System.Threading.Tasks.Task<string> GetProp47Async()
+            => Connection.CallMethodAsync(CreateGetPropertyMessage("Prop47"), (global::Tmds.DBus.Protocol.Message m, object? s) => MessageReader.Read_v_s(m), this);
+        public global::System.Threading.Tasks.Task<string> GetProp48Async()
+            => Connection.CallMethodAsync(CreateGetPropertyMessage("Prop48"), (global::Tmds.DBus.Protocol.Message m, object? s) => MessageReader.Read_v_s(m), this);
+        public global::System.Threading.Tasks.Task<string> GetProp49Async()
+            => Connection.CallMethodAsync(CreateGetPropertyMessage("Prop49"), (global::Tmds.DBus.Protocol.Message m, object? s) => MessageReader.Read_v_s(m), this);
+        public global::System.Threading.Tasks.Task<string> GetProp50Async()
+            => Connection.CallMethodAsync(CreateGetPropertyMessage("Prop50"), (global::Tmds.DBus.Protocol.Message m, object? s) => MessageReader.Read_v_s(m), this);
+        public global::System.Threading.Tasks.Task<string> GetProp51Async()
+            => Connection.CallMethodAsync(CreateGetPropertyMessage("Prop51"), (global::Tmds.DBus.Protocol.Message m, object? s) => MessageReader.Read_v_s(m), this);
+        public global::System.Threading.Tasks.Task<string> GetProp52Async()
+            => Connection.CallMethodAsync(CreateGetPropertyMessage("Prop52"), (global::Tmds.DBus.Protocol.Message m, object? s) => MessageReader.Read_v_s(m), this);
+        public global::System.Threading.Tasks.Task<string> GetProp53Async()
+            => Connection.CallMethodAsync(CreateGetPropertyMessage("Prop53"), (global::Tmds.DBus.Protocol.Message m, object? s) => MessageReader.Read_v_s(m), this);
+        public global::System.Threading.Tasks.Task<string> GetProp54Async()
+            => Connection.CallMethodAsync(CreateGetPropertyMessage("Prop54"), (global::Tmds.DBus.Protocol.Message m, object? s) => MessageReader.Read_v_s(m), this);
+        public global::System.Threading.Tasks.Task<string> GetProp55Async()
+            => Connection.CallMethodAsync(CreateGetPropertyMessage("Prop55"), (global::Tmds.DBus.Protocol.Message m, object? s) => MessageReader.Read_v_s(m), this);
+        public global::System.Threading.Tasks.Task<string> GetProp56Async()
+            => Connection.CallMethodAsync(CreateGetPropertyMessage("Prop56"), (global::Tmds.DBus.Protocol.Message m, object? s) => MessageReader.Read_v_s(m), this);
+        public global::System.Threading.Tasks.Task<string> GetProp57Async()
+            => Connection.CallMethodAsync(CreateGetPropertyMessage("Prop57"), (global::Tmds.DBus.Protocol.Message m, object? s) => MessageReader.Read_v_s(m), this);
+        public global::System.Threading.Tasks.Task<string> GetProp58Async()
+            => Connection.CallMethodAsync(CreateGetPropertyMessage("Prop58"), (global::Tmds.DBus.Protocol.Message m, object? s) => MessageReader.Read_v_s(m), this);
+        public global::System.Threading.Tasks.Task<string> GetProp59Async()
+            => Connection.CallMethodAsync(CreateGetPropertyMessage("Prop59"), (global::Tmds.DBus.Protocol.Message m, object? s) => MessageReader.Read_v_s(m), this);
+        public global::System.Threading.Tasks.Task<string> GetProp60Async()
+            => Connection.CallMethodAsync(CreateGetPropertyMessage("Prop60"), (global::Tmds.DBus.Protocol.Message m, object? s) => MessageReader.Read_v_s(m), this);
+        public global::System.Threading.Tasks.Task<string> GetProp61Async()
+            => Connection.CallMethodAsync(CreateGetPropertyMessage("Prop61"), (global::Tmds.DBus.Protocol.Message m, object? s) => MessageReader.Read_v_s(m), this);
+        public global::System.Threading.Tasks.Task<string> GetProp62Async()
+            => Connection.CallMethodAsync(CreateGetPropertyMessage("Prop62"), (global::Tmds.DBus.Protocol.Message m, object? s) => MessageReader.Read_v_s(m), this);
+        public global::System.Threading.Tasks.Task<string> GetProp63Async()
+            => Connection.CallMethodAsync(CreateGetPropertyMessage("Prop63"), (global::Tmds.DBus.Protocol.Message m, object? s) => MessageReader.Read_v_s(m), this);
+        public global::System.Threading.Tasks.Task<string> GetProp64Async()
+            => Connection.CallMethodAsync(CreateGetPropertyMessage("Prop64"), (global::Tmds.DBus.Protocol.Message m, object? s) => MessageReader.Read_v_s(m), this);
+        public global::System.Threading.Tasks.Task<string> GetProp65Async()
+            => Connection.CallMethodAsync(CreateGetPropertyMessage("Prop65"), (global::Tmds.DBus.Protocol.Message m, object? s) => MessageReader.Read_v_s(m), this);
+        public global::System.Threading.Tasks.Task<ManyPropertiesProperties> GetPropertiesAsync()
         {
-            return Connection.CallMethodAsync(CreateGetAllPropertiesMessage(), (Message m, object? s) => ReadMessage(m), this);
-            static ManyPropertiesProperties ReadMessage(Message message)
+            return Connection.CallMethodAsync(CreateGetAllPropertiesMessage(), (global::Tmds.DBus.Protocol.Message m, object? s) => ReadMessage(m), this);
+            static ManyPropertiesProperties ReadMessage(global::Tmds.DBus.Protocol.Message message)
             {
                 var reader = message.GetBodyReader();
                 return ManyPropertiesProperties.ReadFrom(ref reader, withInvalidated: false);
             }
         }
-        public Task<INullableManyPropertiesProperties> GetNullablePropertiesAsync()
+        public global::System.Threading.Tasks.Task<INullableManyPropertiesProperties> GetNullablePropertiesAsync()
         {
-            return Connection.CallMethodAsync(CreateGetAllPropertiesMessage(), (Message m, object? s) => ReadMessage(m), this);
-            static INullableManyPropertiesProperties ReadMessage(Message message)
+            return Connection.CallMethodAsync(CreateGetAllPropertiesMessage(), (global::Tmds.DBus.Protocol.Message m, object? s) => ReadMessage(m), this);
+            static INullableManyPropertiesProperties ReadMessage(global::Tmds.DBus.Protocol.Message message)
             {
                 var reader = message.GetBodyReader();
                 return ManyPropertiesProperties.ReadFrom(ref reader, withInvalidated: false);
             }
         }
-        public ValueTask<IDisposable> WatchPropertiesChangedAsync(Action<IChangedManyPropertiesProperties> handler, bool emitOnCapturedContext = true)
-            => WatchPropertiesChangedAsync(static (Notification<IChangedManyPropertiesProperties> n) => ((Action<IChangedManyPropertiesProperties>)n.State!)(n.Value), ObserverFlags.None, emitOnCapturedContext, handler);
-        public ValueTask<IDisposable> WatchPropertiesChangedAsync(Func<IChangedManyPropertiesProperties, ValueTask> handler, bool emitOnCapturedContext = true)
-            => WatchPropertiesChangedAsync(static (Notification<IChangedManyPropertiesProperties> n) => ((Func<IChangedManyPropertiesProperties, ValueTask>)n.State!)(n.Value), ObserverFlags.None, emitOnCapturedContext, handler);
-        public ValueTask<IDisposable> WatchPropertiesChangedAsync(Action<Notification<IChangedManyPropertiesProperties>> handler, ObserverFlags flags, bool emitOnCapturedContext = true, object? state = null)
+        public global::System.Threading.Tasks.ValueTask<global::System.IDisposable> WatchPropertiesChangedAsync(global::System.Action<IChangedManyPropertiesProperties> handler, bool emitOnCapturedContext = true)
+            => WatchPropertiesChangedAsync(static (global::Tmds.DBus.Protocol.Notification<IChangedManyPropertiesProperties> n) => ((global::System.Action<IChangedManyPropertiesProperties>)n.State!)(n.Value), global::Tmds.DBus.Protocol.ObserverFlags.None, emitOnCapturedContext, handler);
+        public global::System.Threading.Tasks.ValueTask<global::System.IDisposable> WatchPropertiesChangedAsync(global::System.Func<IChangedManyPropertiesProperties, global::System.Threading.Tasks.ValueTask> handler, bool emitOnCapturedContext = true)
+            => WatchPropertiesChangedAsync(static (global::Tmds.DBus.Protocol.Notification<IChangedManyPropertiesProperties> n) => ((global::System.Func<IChangedManyPropertiesProperties, global::System.Threading.Tasks.ValueTask>)n.State!)(n.Value), global::Tmds.DBus.Protocol.ObserverFlags.None, emitOnCapturedContext, handler);
+        public global::System.Threading.Tasks.ValueTask<global::System.IDisposable> WatchPropertiesChangedAsync(global::System.Action<global::Tmds.DBus.Protocol.Notification<IChangedManyPropertiesProperties>> handler, global::Tmds.DBus.Protocol.ObserverFlags flags, bool emitOnCapturedContext = true, object? state = null)
         {
-            return Connection.WatchPropertiesChangedAsync(Destination, Path, DBusInterfaceName, (Message m, object? s) => ReadMessage(m), handler, flags, emitOnCapturedContext, state);
-            static IChangedManyPropertiesProperties ReadMessage(Message message)
+            return Connection.WatchPropertiesChangedAsync(Destination, Path, DBusInterfaceName, (global::Tmds.DBus.Protocol.Message m, object? s) => ReadMessage(m), handler, flags, emitOnCapturedContext, state);
+            static IChangedManyPropertiesProperties ReadMessage(global::Tmds.DBus.Protocol.Message message)
             {
                 var reader = message.GetBodyReader();
                 reader.ReadString(); // interface
                 return ManyPropertiesProperties.ReadFrom(ref reader, withInvalidated: true);
             }
         }
-        public ValueTask<IDisposable> WatchPropertiesChangedAsync(Func<Notification<IChangedManyPropertiesProperties>, ValueTask> handler, ObserverFlags flags, bool emitOnCapturedContext = true, object? state = null)
+        public global::System.Threading.Tasks.ValueTask<global::System.IDisposable> WatchPropertiesChangedAsync(global::System.Func<global::Tmds.DBus.Protocol.Notification<IChangedManyPropertiesProperties>, global::System.Threading.Tasks.ValueTask> handler, global::Tmds.DBus.Protocol.ObserverFlags flags, bool emitOnCapturedContext = true, object? state = null)
         {
-            return Connection.WatchPropertiesChangedAsync(Destination, Path, DBusInterfaceName, (Message m, object? s) => ReadMessage(m), handler, flags, emitOnCapturedContext, state);
-            static IChangedManyPropertiesProperties ReadMessage(Message message)
+            return Connection.WatchPropertiesChangedAsync(Destination, Path, DBusInterfaceName, (global::Tmds.DBus.Protocol.Message m, object? s) => ReadMessage(m), handler, flags, emitOnCapturedContext, state);
+            static IChangedManyPropertiesProperties ReadMessage(global::Tmds.DBus.Protocol.Message message)
             {
                 var reader = message.GetBodyReader();
                 reader.ReadString(); // interface
                 return ManyPropertiesProperties.ReadFrom(ref reader, withInvalidated: true);
             }
         }
-        private MessageBuffer CreateGetPropertyMessage(string property)
+        private global::Tmds.DBus.Protocol.MessageBuffer CreateGetPropertyMessage(string property)
         {
             var writer = Connection.GetMessageWriter();
             writer.WriteMethodCallHeader(
@@ -1651,7 +1646,7 @@ namespace TestNamespace
             writer.WriteString(property);
             return writer.CreateMessage();
         }
-        private MessageBuffer CreateGetAllPropertiesMessage()
+        private global::Tmds.DBus.Protocol.MessageBuffer CreateGetAllPropertiesMessage()
         {
             var writer = Connection.GetMessageWriter();
             writer.WriteMethodCallHeader(
@@ -1666,11 +1661,11 @@ namespace TestNamespace
     }
     static partial class ObjectFactory
     {
-        public static ManyProperties CreateManyProperties(this DBusService service, ObjectPath path) => new ManyProperties(service.Connection, service.Name, path);
+        public static ManyProperties CreateManyProperties(this global::Tmds.DBus.Protocol.DBusService service, global::Tmds.DBus.Protocol.ObjectPath path) => new ManyProperties(service.Connection, service.Name, path);
     }
     file static class MessageReader
     {
-        public static string Read_v_s(Message message)
+        public static string Read_v_s(global::Tmds.DBus.Protocol.Message message)
         {
             var reader = message.GetBodyReader();
             reader.ReadSignature("s"u8);
@@ -1687,31 +1682,27 @@ namespace TestNamespace
 #nullable enable
 namespace Tmds.DBus.Protocol
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Threading;
-    using System.Threading.Tasks;
     abstract class DBusHandler : IPathMethodHandler
     {
         // Identifies the D-Bus interfaces. Used with SupportsInterface to filter interfaces per path.
-        [Flags]
+        [global::System.Flags]
         public enum DBusInterface
         {
             // OrgFreedesktopDBusIntrospectable = 1,
         }
-        private readonly SendOrPostCallback? _postDelegate;
+        private readonly global::System.Threading.SendOrPostCallback? _postDelegate;
         private const DBusInterface OrgFreedesktopDBusIntrospectable = (DBusInterface)1;
         private const DBusInterface InterfacesWithProperties = 0;
         public string Path { get; }
         public bool HandlesChildPaths { get; }
         public DBusConnection Connection { get; }
         // The SynchronizationContext on which method handlers are invoked.
-        protected SynchronizationContext? SynchronizationContext { get; }
+        protected global::System.Threading.SynchronizationContext? SynchronizationContext { get; }
         protected DBusHandler(DBusConnection connection, string path, bool handlesChildPaths, bool handleOnCapturedContext = true)
-            : this(connection, path, handlesChildPaths, handleOnCapturedContext ? SynchronizationContext.Current : null)
+            : this(connection, path, handlesChildPaths, handleOnCapturedContext ? global::System.Threading.SynchronizationContext.Current : null)
         {
         }
-        protected DBusHandler(DBusConnection connection, string path, bool handlesChildPaths, SynchronizationContext? synchronizationContext)
+        protected DBusHandler(DBusConnection connection, string path, bool handlesChildPaths, global::System.Threading.SynchronizationContext? synchronizationContext)
         {
             Connection = connection;
             Path = path;
@@ -1729,19 +1720,19 @@ namespace Tmds.DBus.Protocol
             }
         }
         // Override to add cross-cutting logic (e.g. logging, error handling) around method invocations.
-        protected virtual async ValueTask InvokeAsync(DBusMethod method, MethodContext context)
+        protected virtual async global::System.Threading.Tasks.ValueTask InvokeAsync(DBusMethod method, MethodContext context)
         {
             try
             {
                 await method.Invoke(context).ConfigureAwait(false);
             }
-            catch (Exception ex)
+            catch (global::System.Exception ex)
             {
                 HandleException(context, ex);
             }
         }
         // Override to customize exception handling for method invocations.
-        protected virtual void HandleException(MethodContext context, Exception ex)
+        protected virtual void HandleException(MethodContext context, global::System.Exception ex)
         {
             if (context.HandleException(ex, shouldDisconnect: false))
             {
@@ -1751,7 +1742,7 @@ namespace Tmds.DBus.Protocol
             {
                 context.ReplyError(dbusEx.ErrorName, dbusEx.ErrorMessage);
             }
-            else if (ex is ArgumentException)
+            else if (ex is global::System.ArgumentException)
             {
                 context.ReplyError("org.freedesktop.DBus.Error.InvalidArgs", ex.Message);
             }
@@ -1761,19 +1752,19 @@ namespace Tmds.DBus.Protocol
             }
         }
         // Override to filter interfaces for specific paths when the handler manages multiple paths.
-        protected virtual bool SupportsInterface(DBusInterface dbusInterface, ReadOnlySpan<char> path)
+        protected virtual bool SupportsInterface(DBusInterface dbusInterface, global::System.ReadOnlySpan<char> path)
         {
             return true;
         }
         // Override to customize introspection, e.g. to include child node names.
-        protected virtual ValueTask HandleIntrospectAsync(IntrospectContext context)
+        protected virtual global::System.Threading.Tasks.ValueTask HandleIntrospectAsync(IntrospectContext context)
         {
-            DBusInterface interfaces = GetSupportedInterfaces(context.MethodContext.Request.PathAsString.AsSpan());
+            DBusInterface interfaces = GetSupportedInterfaces(global::System.MemoryExtensions.AsSpan(context.MethodContext.Request.PathAsString));
             context.Reply(interfaces);
             return default;
         }
         // Context for IntrospectAsync. Call Reply to send the introspection XML response.
-        protected readonly struct IntrospectContext : IDisposable
+        protected readonly struct IntrospectContext : global::System.IDisposable
         {
             public MethodContext MethodContext { get; }
             public IntrospectContext(MethodContext methodContext)
@@ -1781,9 +1772,9 @@ namespace Tmds.DBus.Protocol
                 MethodContext = methodContext;
             }
             public void Dispose() => MethodContext.Dispose();
-            public void Reply(DBusInterface interfaces, IList<string>? childNames = null)
+            public void Reply(DBusInterface interfaces, global::System.Collections.Generic.IList<string>? childNames = null)
             {
-                var interfaceXmls = new ReadOnlyMemory<byte>[1];
+                var interfaceXmls = new global::System.ReadOnlyMemory<byte>[1];
                 int count = 0;
                 if ((interfaces & InterfacesWithProperties) != 0)
                 {
@@ -1791,42 +1782,42 @@ namespace Tmds.DBus.Protocol
                 }
                 if (childNames is not null)
                 {
-                    MethodContext.ReplyIntrospectXml(interfaceXmls.AsSpan(0, count), childNames);
+                    MethodContext.ReplyIntrospectXml(global::System.MemoryExtensions.AsSpan(interfaceXmls, 0, count), childNames);
                 }
                 else
                 {
-                    MethodContext.ReplyIntrospectXml(interfaceXmls.AsSpan(0, count));
+                    MethodContext.ReplyIntrospectXml(global::System.MemoryExtensions.AsSpan(interfaceXmls, 0, count));
                 }
             }
         }
         internal readonly struct DBusMethod
         {
-            private readonly Func<object, MethodContext, ValueTask> _method;
+            private readonly global::System.Func<object, MethodContext, global::System.Threading.Tasks.ValueTask> _method;
             private readonly object _target;
-            public DBusMethod(Func<object, MethodContext, ValueTask> method, object target)
+            public DBusMethod(global::System.Func<object, MethodContext, global::System.Threading.Tasks.ValueTask> method, object target)
             {
                 _method = method;
                 _target = target;
             }
             public bool HasValue => _method is not null;
-            public ValueTask Invoke(MethodContext context)
+            public global::System.Threading.Tasks.ValueTask Invoke(MethodContext context)
             {
                 return _method?.Invoke(_target, context) ?? default;
             }
         }
-        ValueTask IPathMethodHandler.HandleMethodAsync(MethodContext context)
+        global::System.Threading.Tasks.ValueTask IPathMethodHandler.HandleMethodAsync(MethodContext context)
         {
             DBusInterface dbusInterface = ParseInterface(context);
-            DBusMethod method = (dbusInterface != OrgFreedesktopDBusIntrospectable && !SupportsInterface(dbusInterface, context.Request.PathAsString.AsSpan())) ? default : FindMethodHandler(context, dbusInterface);
+            DBusMethod method = (dbusInterface != OrgFreedesktopDBusIntrospectable && !SupportsInterface(dbusInterface, global::System.MemoryExtensions.AsSpan(context.Request.PathAsString))) ? default : FindMethodHandler(context, dbusInterface);
             if (!method.HasValue)
             {
                 return default;
             }
             return HandleAsync(method, context);
         }
-        private ValueTask HandleAsync(DBusMethod method, MethodContext context)
+        private global::System.Threading.Tasks.ValueTask HandleAsync(DBusMethod method, MethodContext context)
         {
-            SynchronizationContext? synchronizationContext = SynchronizationContext;
+            global::System.Threading.SynchronizationContext? synchronizationContext = SynchronizationContext;
             if (synchronizationContext is null)
             {
                 return InvokeAsync(method, context);
@@ -1838,7 +1829,7 @@ namespace Tmds.DBus.Protocol
                 return default;
             }
         }
-        private async ValueTask InvokeAndDisposeAsync(DBusMethod method, MethodContext context)
+        private async global::System.Threading.Tasks.ValueTask InvokeAndDisposeAsync(DBusMethod method, MethodContext context)
         {
             try
             {
@@ -1893,7 +1884,7 @@ namespace Tmds.DBus.Protocol
             };
             return result;
         }
-        protected DBusInterface GetSupportedInterfaces(ReadOnlySpan<char> path)
+        protected DBusInterface GetSupportedInterfaces(global::System.ReadOnlySpan<char> path)
         {
             DBusInterface interfaces = default;
             return interfaces;

--- a/test/Tmds.DBus.Generator.Tests/CodeGenerationTests.VerifyGeneratedOutput_ProxyAndHandlerDifferentNameSpace.verified.txt
+++ b/test/Tmds.DBus.Generator.Tests/CodeGenerationTests.VerifyGeneratedOutput_ProxyAndHandlerDifferentNameSpace.verified.txt
@@ -3,11 +3,6 @@
 #nullable enable
 namespace ProxyNamespace
 {
-    using System;
-    using Tmds.DBus.Protocol;
-    using System.Collections.Generic;
-    using System.Threading.Tasks;
-    using System.Runtime.CompilerServices;
     enum CalculatorProperty
     {
         UnknownProperty = 0,
@@ -19,16 +14,16 @@ namespace ProxyNamespace
     interface ICalculatorProperties
     {
         double LastResult { get; }
-        ObjectPath CurrentPath { get; }
+        global::Tmds.DBus.Protocol.ObjectPath CurrentPath { get; }
         (string, double) CurrentEntry { get; }
-        ValueTuple<bool> IsActive { get; set; }
+        global::System.ValueTuple<bool> IsActive { get; set; }
     }
     interface INullableCalculatorProperties
     {
         double? LastResult { get; }
-        ObjectPath? CurrentPath { get; }
+        global::Tmds.DBus.Protocol.ObjectPath? CurrentPath { get; }
         (string, double)? CurrentEntry { get; }
-        ValueTuple<bool>? IsActive { get; }
+        global::System.ValueTuple<bool>? IsActive { get; }
         bool AreAllPropertiesSet();
         CalculatorProperties EnsureAllPropertiesSet();
     }
@@ -47,14 +42,14 @@ namespace ProxyNamespace
         private static uint Flag(CalculatorProperty property) => property == 0 ? 0 : 1U << ((int)property - 1);
         public CalculatorProperties() { }
         #nullable disable
-        [System.Diagnostics.CodeAnalysis.SetsRequiredMembers]
+        [global::System.Diagnostics.CodeAnalysis.SetsRequiredMembers]
         private CalculatorProperties(bool _) { }
         #nullable enable
         private void EnsureSet(CalculatorProperty property)
         {
             if (!HasFlag(__set, property))
             {
-                throw new InvalidOperationException("Property is not set.");
+                throw new global::System.InvalidOperationException("Property is not set.");
             }
         }
         private double _lastResult = default!;
@@ -63,8 +58,8 @@ namespace ProxyNamespace
             get { EnsureSet(CalculatorProperty.LastResult); return _lastResult; }
             set { _lastResult = value; __set |= Flag(CalculatorProperty.LastResult); }
         }
-        private ObjectPath _currentPath = default!;
-        public required ObjectPath CurrentPath
+        private global::Tmds.DBus.Protocol.ObjectPath _currentPath = default!;
+        public required global::Tmds.DBus.Protocol.ObjectPath CurrentPath
         {
             get { EnsureSet(CalculatorProperty.CurrentPath); return _currentPath; }
             set { _currentPath = value; __set |= Flag(CalculatorProperty.CurrentPath); }
@@ -75,20 +70,20 @@ namespace ProxyNamespace
             get { EnsureSet(CalculatorProperty.CurrentEntry); return _currentEntry; }
             set { _currentEntry = value; __set |= Flag(CalculatorProperty.CurrentEntry); }
         }
-        private ValueTuple<bool> _isActive = default!;
-        public required ValueTuple<bool> IsActive
+        private global::System.ValueTuple<bool> _isActive = default!;
+        public required global::System.ValueTuple<bool> IsActive
         {
             get { EnsureSet(CalculatorProperty.IsActive); return _isActive; }
             set { _isActive = value; __set |= Flag(CalculatorProperty.IsActive); }
         }
         double? INullableCalculatorProperties.LastResult
             => IsSet(CalculatorProperty.LastResult) ? _lastResult : default(double?);
-        ObjectPath? INullableCalculatorProperties.CurrentPath
-            => IsSet(CalculatorProperty.CurrentPath) ? _currentPath : default(ObjectPath?);
+        global::Tmds.DBus.Protocol.ObjectPath? INullableCalculatorProperties.CurrentPath
+            => IsSet(CalculatorProperty.CurrentPath) ? _currentPath : default(global::Tmds.DBus.Protocol.ObjectPath?);
         (string, double)? INullableCalculatorProperties.CurrentEntry
             => IsSet(CalculatorProperty.CurrentEntry) ? _currentEntry : default((string, double)?);
-        ValueTuple<bool>? INullableCalculatorProperties.IsActive
-            => IsSet(CalculatorProperty.IsActive) ? _isActive : default(ValueTuple<bool>?);
+        global::System.ValueTuple<bool>? INullableCalculatorProperties.IsActive
+            => IsSet(CalculatorProperty.IsActive) ? _isActive : default(global::System.ValueTuple<bool>?);
         bool IChangedCalculatorProperties.HasLastResultChanged
             => IsSet(CalculatorProperty.LastResult) || IsInvalidated(CalculatorProperty.LastResult);
         bool IChangedCalculatorProperties.HasCurrentPathChanged
@@ -119,13 +114,13 @@ namespace ProxyNamespace
         {
             if (!AreAllPropertiesSet())
             {
-                throw new DBusUnexpectedValueException($"Not all properties have been set (0x{__set:x}).");
+                throw new global::Tmds.DBus.Protocol.DBusUnexpectedValueException($"Not all properties have been set (0x{__set:x}).");
             }
         }
-        public static CalculatorProperties ReadFrom(ref Reader reader, bool withInvalidated)
+        public static CalculatorProperties ReadFrom(ref global::Tmds.DBus.Protocol.Reader reader, bool withInvalidated)
         {
             var props = CreateUninitialized();
-            ArrayEnd arrayEnd = reader.ReadArrayStart(DBusType.Struct);
+            global::Tmds.DBus.Protocol.ArrayEnd arrayEnd = reader.ReadArrayStart(global::Tmds.DBus.Protocol.DBusType.Struct);
             while (reader.HasNext(arrayEnd))
             {
                 var property = reader.ReadString();
@@ -154,7 +149,7 @@ namespace ProxyNamespace
             }
             if (withInvalidated)
             {
-                ArrayEnd invalidatedEnd = reader.ReadArrayStart(DBusType.String);
+                global::Tmds.DBus.Protocol.ArrayEnd invalidatedEnd = reader.ReadArrayStart(global::Tmds.DBus.Protocol.DBusType.String);
                 while (reader.HasNext(invalidatedEnd))
                 {
                     var propertyName = reader.ReadString();
@@ -171,16 +166,16 @@ namespace ProxyNamespace
             return props;
         }
     }
-    sealed partial class Calculator : Tmds.DBus.Protocol.DBusObject
+    sealed partial class Calculator : global::Tmds.DBus.Protocol.DBusObject
     {
         public const string DBusInterfaceName = "org.example.Calculator";
-        public Calculator(Tmds.DBus.Protocol.DBusConnection connection, string destination, ObjectPath path)
+        public Calculator(global::Tmds.DBus.Protocol.DBusConnection connection, string destination, global::Tmds.DBus.Protocol.ObjectPath path)
             : base(connection, destination, path)
         { }
-        public Task ClearAsync()
+        public global::System.Threading.Tasks.Task ClearAsync()
         {
             return Connection.CallMethodAsync(CreateMessage());
-            MessageBuffer CreateMessage()
+            global::Tmds.DBus.Protocol.MessageBuffer CreateMessage()
             {
                 var writer = Connection.GetMessageWriter();
                 writer.WriteMethodCallHeader(
@@ -191,10 +186,10 @@ namespace ProxyNamespace
                 return writer.CreateMessage();
             }
         }
-        public Task<double> GetResultAsync()
+        public global::System.Threading.Tasks.Task<double> GetResultAsync()
         {
-            return Connection.CallMethodAsync(CreateMessage(), (Message m, object? s) => MessageReader.Read_d(m), this);
-            MessageBuffer CreateMessage()
+            return Connection.CallMethodAsync(CreateMessage(), (global::Tmds.DBus.Protocol.Message m, object? s) => MessageReader.Read_d(m), this);
+            global::Tmds.DBus.Protocol.MessageBuffer CreateMessage()
             {
                 var writer = Connection.GetMessageWriter();
                 writer.WriteMethodCallHeader(
@@ -205,10 +200,10 @@ namespace ProxyNamespace
                 return writer.CreateMessage();
             }
         }
-        public Task<(uint Count, double Total)> GetStatsAsync()
+        public global::System.Threading.Tasks.Task<(uint Count, double Total)> GetStatsAsync()
         {
-            return Connection.CallMethodAsync(CreateMessage(), (Message m, object? s) => MessageReader.Read_ud(m), this);
-            MessageBuffer CreateMessage()
+            return Connection.CallMethodAsync(CreateMessage(), (global::Tmds.DBus.Protocol.Message m, object? s) => MessageReader.Read_ud(m), this);
+            global::Tmds.DBus.Protocol.MessageBuffer CreateMessage()
             {
                 var writer = Connection.GetMessageWriter();
                 writer.WriteMethodCallHeader(
@@ -219,10 +214,10 @@ namespace ProxyNamespace
                 return writer.CreateMessage();
             }
         }
-        public Task StoreAsync(double value)
+        public global::System.Threading.Tasks.Task StoreAsync(double value)
         {
             return Connection.CallMethodAsync(CreateMessage());
-            MessageBuffer CreateMessage()
+            global::Tmds.DBus.Protocol.MessageBuffer CreateMessage()
             {
                 var writer = Connection.GetMessageWriter();
                 writer.WriteMethodCallHeader(
@@ -235,10 +230,10 @@ namespace ProxyNamespace
                 return writer.CreateMessage();
             }
         }
-        public Task<double> SquareAsync(double input)
+        public global::System.Threading.Tasks.Task<double> SquareAsync(double input)
         {
-            return Connection.CallMethodAsync(CreateMessage(), (Message m, object? s) => MessageReader.Read_d(m), this);
-            MessageBuffer CreateMessage()
+            return Connection.CallMethodAsync(CreateMessage(), (global::Tmds.DBus.Protocol.Message m, object? s) => MessageReader.Read_d(m), this);
+            global::Tmds.DBus.Protocol.MessageBuffer CreateMessage()
             {
                 var writer = Connection.GetMessageWriter();
                 writer.WriteMethodCallHeader(
@@ -251,10 +246,10 @@ namespace ProxyNamespace
                 return writer.CreateMessage();
             }
         }
-        public Task<(int Quotient, int Remainder)> DivModAsync(int dividend)
+        public global::System.Threading.Tasks.Task<(int Quotient, int Remainder)> DivModAsync(int dividend)
         {
-            return Connection.CallMethodAsync(CreateMessage(), (Message m, object? s) => MessageReader.Read_ii(m), this);
-            MessageBuffer CreateMessage()
+            return Connection.CallMethodAsync(CreateMessage(), (global::Tmds.DBus.Protocol.Message m, object? s) => MessageReader.Read_ii(m), this);
+            global::Tmds.DBus.Protocol.MessageBuffer CreateMessage()
             {
                 var writer = Connection.GetMessageWriter();
                 writer.WriteMethodCallHeader(
@@ -267,10 +262,10 @@ namespace ProxyNamespace
                 return writer.CreateMessage();
             }
         }
-        public Task LogOperationAsync(string operation, double value)
+        public global::System.Threading.Tasks.Task LogOperationAsync(string operation, double value)
         {
             return Connection.CallMethodAsync(CreateMessage());
-            MessageBuffer CreateMessage()
+            global::Tmds.DBus.Protocol.MessageBuffer CreateMessage()
             {
                 var writer = Connection.GetMessageWriter();
                 writer.WriteMethodCallHeader(
@@ -284,10 +279,10 @@ namespace ProxyNamespace
                 return writer.CreateMessage();
             }
         }
-        public Task<double> AddAsync(double a, double b)
+        public global::System.Threading.Tasks.Task<double> AddAsync(double a, double b)
         {
-            return Connection.CallMethodAsync(CreateMessage(), (Message m, object? s) => MessageReader.Read_d(m), this);
-            MessageBuffer CreateMessage()
+            return Connection.CallMethodAsync(CreateMessage(), (global::Tmds.DBus.Protocol.Message m, object? s) => MessageReader.Read_d(m), this);
+            global::Tmds.DBus.Protocol.MessageBuffer CreateMessage()
             {
                 var writer = Connection.GetMessageWriter();
                 writer.WriteMethodCallHeader(
@@ -301,10 +296,10 @@ namespace ProxyNamespace
                 return writer.CreateMessage();
             }
         }
-        public Task<(bool Equal, double Difference)> CompareAsync(double a, double b)
+        public global::System.Threading.Tasks.Task<(bool Equal, double Difference)> CompareAsync(double a, double b)
         {
-            return Connection.CallMethodAsync(CreateMessage(), (Message m, object? s) => MessageReader.Read_bd(m), this);
-            MessageBuffer CreateMessage()
+            return Connection.CallMethodAsync(CreateMessage(), (global::Tmds.DBus.Protocol.Message m, object? s) => MessageReader.Read_bd(m), this);
+            global::Tmds.DBus.Protocol.MessageBuffer CreateMessage()
             {
                 var writer = Connection.GetMessageWriter();
                 writer.WriteMethodCallHeader(
@@ -318,10 +313,10 @@ namespace ProxyNamespace
                 return writer.CreateMessage();
             }
         }
-        public Task<(string, double)> GetEntryAsync(string key)
+        public global::System.Threading.Tasks.Task<(string, double)> GetEntryAsync(string key)
         {
-            return Connection.CallMethodAsync(CreateMessage(), (Message m, object? s) => MessageReader.Read_rsdz(m), this);
-            MessageBuffer CreateMessage()
+            return Connection.CallMethodAsync(CreateMessage(), (global::Tmds.DBus.Protocol.Message m, object? s) => MessageReader.Read_rsdz(m), this);
+            global::Tmds.DBus.Protocol.MessageBuffer CreateMessage()
             {
                 var writer = Connection.GetMessageWriter();
                 writer.WriteMethodCallHeader(
@@ -334,10 +329,10 @@ namespace ProxyNamespace
                 return writer.CreateMessage();
             }
         }
-        public Task SetEntryAsync((string, double) entry)
+        public global::System.Threading.Tasks.Task SetEntryAsync((string, double) entry)
         {
             return Connection.CallMethodAsync(CreateMessage());
-            MessageBuffer CreateMessage()
+            global::Tmds.DBus.Protocol.MessageBuffer CreateMessage()
             {
                 var writer = Connection.GetMessageWriter();
                 writer.WriteMethodCallHeader(
@@ -350,34 +345,34 @@ namespace ProxyNamespace
                 return writer.CreateMessage();
             }
         }
-        public ValueTask<IDisposable> WatchResetAsync(Action handler, bool emitOnCapturedContext = true)
-            => WatchResetAsync(static (Notification n) => ((Action)n.State!)(), ObserverFlags.None, emitOnCapturedContext, handler);
-        public ValueTask<IDisposable> WatchResetAsync(Func<ValueTask> handler, bool emitOnCapturedContext = true)
-            => WatchResetAsync(static (Notification n) => ((Func<ValueTask>)n.State!)(), ObserverFlags.None, emitOnCapturedContext, handler);
-        public ValueTask<IDisposable> WatchResetAsync(Action<Notification> handler, ObserverFlags flags, bool emitOnCapturedContext = true, object? state = null)
+        public global::System.Threading.Tasks.ValueTask<global::System.IDisposable> WatchResetAsync(global::System.Action handler, bool emitOnCapturedContext = true)
+            => WatchResetAsync(static (global::Tmds.DBus.Protocol.Notification n) => ((global::System.Action)n.State!)(), global::Tmds.DBus.Protocol.ObserverFlags.None, emitOnCapturedContext, handler);
+        public global::System.Threading.Tasks.ValueTask<global::System.IDisposable> WatchResetAsync(global::System.Func<global::System.Threading.Tasks.ValueTask> handler, bool emitOnCapturedContext = true)
+            => WatchResetAsync(static (global::Tmds.DBus.Protocol.Notification n) => ((global::System.Func<global::System.Threading.Tasks.ValueTask>)n.State!)(), global::Tmds.DBus.Protocol.ObserverFlags.None, emitOnCapturedContext, handler);
+        public global::System.Threading.Tasks.ValueTask<global::System.IDisposable> WatchResetAsync(global::System.Action<global::Tmds.DBus.Protocol.Notification> handler, global::Tmds.DBus.Protocol.ObserverFlags flags, bool emitOnCapturedContext = true, object? state = null)
             => Connection.WatchSignalAsync(Destination, Path, DBusInterfaceName, "Reset", handler, flags, emitOnCapturedContext, state);
-        public ValueTask<IDisposable> WatchResetAsync(Func<Notification, ValueTask> handler, ObserverFlags flags, bool emitOnCapturedContext = true, object? state = null)
+        public global::System.Threading.Tasks.ValueTask<global::System.IDisposable> WatchResetAsync(global::System.Func<global::Tmds.DBus.Protocol.Notification, global::System.Threading.Tasks.ValueTask> handler, global::Tmds.DBus.Protocol.ObserverFlags flags, bool emitOnCapturedContext = true, object? state = null)
             => Connection.WatchSignalAsync(Destination, Path, DBusInterfaceName, "Reset", handler, flags, emitOnCapturedContext, state);
-        public ValueTask<IDisposable> WatchErrorAsync(Action<string> handler, bool emitOnCapturedContext = true)
-            => WatchErrorAsync(static (Notification<string> n) => ((Action<string>)n.State!)(n.Value), ObserverFlags.None, emitOnCapturedContext, handler);
-        public ValueTask<IDisposable> WatchErrorAsync(Func<string, ValueTask> handler, bool emitOnCapturedContext = true)
-            => WatchErrorAsync(static (Notification<string> n) => ((Func<string, ValueTask>)n.State!)(n.Value), ObserverFlags.None, emitOnCapturedContext, handler);
-        public ValueTask<IDisposable> WatchErrorAsync(Action<Notification<string>> handler, ObserverFlags flags, bool emitOnCapturedContext = true, object? state = null)
-            => Connection.WatchSignalAsync(Destination, Path, DBusInterfaceName, "Error", (Message m, object? s) => MessageReader.Read_s(m), handler, flags, emitOnCapturedContext, state);
-        public ValueTask<IDisposable> WatchErrorAsync(Func<Notification<string>, ValueTask> handler, ObserverFlags flags, bool emitOnCapturedContext = true, object? state = null)
-            => Connection.WatchSignalAsync(Destination, Path, DBusInterfaceName, "Error", (Message m, object? s) => MessageReader.Read_s(m), handler, flags, emitOnCapturedContext, state);
-        public ValueTask<IDisposable> WatchOperationCompleteAsync(Action<(string Operation, double Result)> handler, bool emitOnCapturedContext = true)
-            => WatchOperationCompleteAsync(static (Notification<(string Operation, double Result)> n) => ((Action<(string Operation, double Result)>)n.State!)(n.Value), ObserverFlags.None, emitOnCapturedContext, handler);
-        public ValueTask<IDisposable> WatchOperationCompleteAsync(Func<(string Operation, double Result), ValueTask> handler, bool emitOnCapturedContext = true)
-            => WatchOperationCompleteAsync(static (Notification<(string Operation, double Result)> n) => ((Func<(string Operation, double Result), ValueTask>)n.State!)(n.Value), ObserverFlags.None, emitOnCapturedContext, handler);
-        public ValueTask<IDisposable> WatchOperationCompleteAsync(Action<Notification<(string Operation, double Result)>> handler, ObserverFlags flags, bool emitOnCapturedContext = true, object? state = null)
-            => Connection.WatchSignalAsync(Destination, Path, DBusInterfaceName, "OperationComplete", (Message m, object? s) => MessageReader.Read_sd(m), handler, flags, emitOnCapturedContext, state);
-        public ValueTask<IDisposable> WatchOperationCompleteAsync(Func<Notification<(string Operation, double Result)>, ValueTask> handler, ObserverFlags flags, bool emitOnCapturedContext = true, object? state = null)
-            => Connection.WatchSignalAsync(Destination, Path, DBusInterfaceName, "OperationComplete", (Message m, object? s) => MessageReader.Read_sd(m), handler, flags, emitOnCapturedContext, state);
-        public Task SetIsActiveAsync(ValueTuple<bool> value)
+        public global::System.Threading.Tasks.ValueTask<global::System.IDisposable> WatchErrorAsync(global::System.Action<string> handler, bool emitOnCapturedContext = true)
+            => WatchErrorAsync(static (global::Tmds.DBus.Protocol.Notification<string> n) => ((global::System.Action<string>)n.State!)(n.Value), global::Tmds.DBus.Protocol.ObserverFlags.None, emitOnCapturedContext, handler);
+        public global::System.Threading.Tasks.ValueTask<global::System.IDisposable> WatchErrorAsync(global::System.Func<string, global::System.Threading.Tasks.ValueTask> handler, bool emitOnCapturedContext = true)
+            => WatchErrorAsync(static (global::Tmds.DBus.Protocol.Notification<string> n) => ((global::System.Func<string, global::System.Threading.Tasks.ValueTask>)n.State!)(n.Value), global::Tmds.DBus.Protocol.ObserverFlags.None, emitOnCapturedContext, handler);
+        public global::System.Threading.Tasks.ValueTask<global::System.IDisposable> WatchErrorAsync(global::System.Action<global::Tmds.DBus.Protocol.Notification<string>> handler, global::Tmds.DBus.Protocol.ObserverFlags flags, bool emitOnCapturedContext = true, object? state = null)
+            => Connection.WatchSignalAsync(Destination, Path, DBusInterfaceName, "Error", (global::Tmds.DBus.Protocol.Message m, object? s) => MessageReader.Read_s(m), handler, flags, emitOnCapturedContext, state);
+        public global::System.Threading.Tasks.ValueTask<global::System.IDisposable> WatchErrorAsync(global::System.Func<global::Tmds.DBus.Protocol.Notification<string>, global::System.Threading.Tasks.ValueTask> handler, global::Tmds.DBus.Protocol.ObserverFlags flags, bool emitOnCapturedContext = true, object? state = null)
+            => Connection.WatchSignalAsync(Destination, Path, DBusInterfaceName, "Error", (global::Tmds.DBus.Protocol.Message m, object? s) => MessageReader.Read_s(m), handler, flags, emitOnCapturedContext, state);
+        public global::System.Threading.Tasks.ValueTask<global::System.IDisposable> WatchOperationCompleteAsync(global::System.Action<(string Operation, double Result)> handler, bool emitOnCapturedContext = true)
+            => WatchOperationCompleteAsync(static (global::Tmds.DBus.Protocol.Notification<(string Operation, double Result)> n) => ((global::System.Action<(string Operation, double Result)>)n.State!)(n.Value), global::Tmds.DBus.Protocol.ObserverFlags.None, emitOnCapturedContext, handler);
+        public global::System.Threading.Tasks.ValueTask<global::System.IDisposable> WatchOperationCompleteAsync(global::System.Func<(string Operation, double Result), global::System.Threading.Tasks.ValueTask> handler, bool emitOnCapturedContext = true)
+            => WatchOperationCompleteAsync(static (global::Tmds.DBus.Protocol.Notification<(string Operation, double Result)> n) => ((global::System.Func<(string Operation, double Result), global::System.Threading.Tasks.ValueTask>)n.State!)(n.Value), global::Tmds.DBus.Protocol.ObserverFlags.None, emitOnCapturedContext, handler);
+        public global::System.Threading.Tasks.ValueTask<global::System.IDisposable> WatchOperationCompleteAsync(global::System.Action<global::Tmds.DBus.Protocol.Notification<(string Operation, double Result)>> handler, global::Tmds.DBus.Protocol.ObserverFlags flags, bool emitOnCapturedContext = true, object? state = null)
+            => Connection.WatchSignalAsync(Destination, Path, DBusInterfaceName, "OperationComplete", (global::Tmds.DBus.Protocol.Message m, object? s) => MessageReader.Read_sd(m), handler, flags, emitOnCapturedContext, state);
+        public global::System.Threading.Tasks.ValueTask<global::System.IDisposable> WatchOperationCompleteAsync(global::System.Func<global::Tmds.DBus.Protocol.Notification<(string Operation, double Result)>, global::System.Threading.Tasks.ValueTask> handler, global::Tmds.DBus.Protocol.ObserverFlags flags, bool emitOnCapturedContext = true, object? state = null)
+            => Connection.WatchSignalAsync(Destination, Path, DBusInterfaceName, "OperationComplete", (global::Tmds.DBus.Protocol.Message m, object? s) => MessageReader.Read_sd(m), handler, flags, emitOnCapturedContext, state);
+        public global::System.Threading.Tasks.Task SetIsActiveAsync(global::System.ValueTuple<bool> value)
         {
             return Connection.CallMethodAsync(CreateMessage());
-            MessageBuffer CreateMessage()
+            global::Tmds.DBus.Protocol.MessageBuffer CreateMessage()
             {
                 var writer = Connection.GetMessageWriter();
                 writer.WriteMethodCallHeader(
@@ -393,57 +388,57 @@ namespace ProxyNamespace
                 return writer.CreateMessage();
             }
         }
-        public Task<double> GetLastResultAsync()
-            => Connection.CallMethodAsync(CreateGetPropertyMessage("LastResult"), (Message m, object? s) => MessageReader.Read_v_d(m), this);
-        public Task<ObjectPath> GetCurrentPathAsync()
-            => Connection.CallMethodAsync(CreateGetPropertyMessage("CurrentPath"), (Message m, object? s) => MessageReader.Read_v_o(m), this);
-        public Task<(string, double)> GetCurrentEntryAsync()
-            => Connection.CallMethodAsync(CreateGetPropertyMessage("CurrentEntry"), (Message m, object? s) => MessageReader.Read_v_rsdz(m), this);
-        public Task<ValueTuple<bool>> GetIsActiveAsync()
-            => Connection.CallMethodAsync(CreateGetPropertyMessage("IsActive"), (Message m, object? s) => MessageReader.Read_v_rbz(m), this);
-        public Task<CalculatorProperties> GetPropertiesAsync()
+        public global::System.Threading.Tasks.Task<double> GetLastResultAsync()
+            => Connection.CallMethodAsync(CreateGetPropertyMessage("LastResult"), (global::Tmds.DBus.Protocol.Message m, object? s) => MessageReader.Read_v_d(m), this);
+        public global::System.Threading.Tasks.Task<global::Tmds.DBus.Protocol.ObjectPath> GetCurrentPathAsync()
+            => Connection.CallMethodAsync(CreateGetPropertyMessage("CurrentPath"), (global::Tmds.DBus.Protocol.Message m, object? s) => MessageReader.Read_v_o(m), this);
+        public global::System.Threading.Tasks.Task<(string, double)> GetCurrentEntryAsync()
+            => Connection.CallMethodAsync(CreateGetPropertyMessage("CurrentEntry"), (global::Tmds.DBus.Protocol.Message m, object? s) => MessageReader.Read_v_rsdz(m), this);
+        public global::System.Threading.Tasks.Task<global::System.ValueTuple<bool>> GetIsActiveAsync()
+            => Connection.CallMethodAsync(CreateGetPropertyMessage("IsActive"), (global::Tmds.DBus.Protocol.Message m, object? s) => MessageReader.Read_v_rbz(m), this);
+        public global::System.Threading.Tasks.Task<CalculatorProperties> GetPropertiesAsync()
         {
-            return Connection.CallMethodAsync(CreateGetAllPropertiesMessage(), (Message m, object? s) => ReadMessage(m), this);
-            static CalculatorProperties ReadMessage(Message message)
+            return Connection.CallMethodAsync(CreateGetAllPropertiesMessage(), (global::Tmds.DBus.Protocol.Message m, object? s) => ReadMessage(m), this);
+            static CalculatorProperties ReadMessage(global::Tmds.DBus.Protocol.Message message)
             {
                 var reader = message.GetBodyReader();
                 return CalculatorProperties.ReadFrom(ref reader, withInvalidated: false);
             }
         }
-        public Task<INullableCalculatorProperties> GetNullablePropertiesAsync()
+        public global::System.Threading.Tasks.Task<INullableCalculatorProperties> GetNullablePropertiesAsync()
         {
-            return Connection.CallMethodAsync(CreateGetAllPropertiesMessage(), (Message m, object? s) => ReadMessage(m), this);
-            static INullableCalculatorProperties ReadMessage(Message message)
+            return Connection.CallMethodAsync(CreateGetAllPropertiesMessage(), (global::Tmds.DBus.Protocol.Message m, object? s) => ReadMessage(m), this);
+            static INullableCalculatorProperties ReadMessage(global::Tmds.DBus.Protocol.Message message)
             {
                 var reader = message.GetBodyReader();
                 return CalculatorProperties.ReadFrom(ref reader, withInvalidated: false);
             }
         }
-        public ValueTask<IDisposable> WatchPropertiesChangedAsync(Action<IChangedCalculatorProperties> handler, bool emitOnCapturedContext = true)
-            => WatchPropertiesChangedAsync(static (Notification<IChangedCalculatorProperties> n) => ((Action<IChangedCalculatorProperties>)n.State!)(n.Value), ObserverFlags.None, emitOnCapturedContext, handler);
-        public ValueTask<IDisposable> WatchPropertiesChangedAsync(Func<IChangedCalculatorProperties, ValueTask> handler, bool emitOnCapturedContext = true)
-            => WatchPropertiesChangedAsync(static (Notification<IChangedCalculatorProperties> n) => ((Func<IChangedCalculatorProperties, ValueTask>)n.State!)(n.Value), ObserverFlags.None, emitOnCapturedContext, handler);
-        public ValueTask<IDisposable> WatchPropertiesChangedAsync(Action<Notification<IChangedCalculatorProperties>> handler, ObserverFlags flags, bool emitOnCapturedContext = true, object? state = null)
+        public global::System.Threading.Tasks.ValueTask<global::System.IDisposable> WatchPropertiesChangedAsync(global::System.Action<IChangedCalculatorProperties> handler, bool emitOnCapturedContext = true)
+            => WatchPropertiesChangedAsync(static (global::Tmds.DBus.Protocol.Notification<IChangedCalculatorProperties> n) => ((global::System.Action<IChangedCalculatorProperties>)n.State!)(n.Value), global::Tmds.DBus.Protocol.ObserverFlags.None, emitOnCapturedContext, handler);
+        public global::System.Threading.Tasks.ValueTask<global::System.IDisposable> WatchPropertiesChangedAsync(global::System.Func<IChangedCalculatorProperties, global::System.Threading.Tasks.ValueTask> handler, bool emitOnCapturedContext = true)
+            => WatchPropertiesChangedAsync(static (global::Tmds.DBus.Protocol.Notification<IChangedCalculatorProperties> n) => ((global::System.Func<IChangedCalculatorProperties, global::System.Threading.Tasks.ValueTask>)n.State!)(n.Value), global::Tmds.DBus.Protocol.ObserverFlags.None, emitOnCapturedContext, handler);
+        public global::System.Threading.Tasks.ValueTask<global::System.IDisposable> WatchPropertiesChangedAsync(global::System.Action<global::Tmds.DBus.Protocol.Notification<IChangedCalculatorProperties>> handler, global::Tmds.DBus.Protocol.ObserverFlags flags, bool emitOnCapturedContext = true, object? state = null)
         {
-            return Connection.WatchPropertiesChangedAsync(Destination, Path, DBusInterfaceName, (Message m, object? s) => ReadMessage(m), handler, flags, emitOnCapturedContext, state);
-            static IChangedCalculatorProperties ReadMessage(Message message)
+            return Connection.WatchPropertiesChangedAsync(Destination, Path, DBusInterfaceName, (global::Tmds.DBus.Protocol.Message m, object? s) => ReadMessage(m), handler, flags, emitOnCapturedContext, state);
+            static IChangedCalculatorProperties ReadMessage(global::Tmds.DBus.Protocol.Message message)
             {
                 var reader = message.GetBodyReader();
                 reader.ReadString(); // interface
                 return CalculatorProperties.ReadFrom(ref reader, withInvalidated: true);
             }
         }
-        public ValueTask<IDisposable> WatchPropertiesChangedAsync(Func<Notification<IChangedCalculatorProperties>, ValueTask> handler, ObserverFlags flags, bool emitOnCapturedContext = true, object? state = null)
+        public global::System.Threading.Tasks.ValueTask<global::System.IDisposable> WatchPropertiesChangedAsync(global::System.Func<global::Tmds.DBus.Protocol.Notification<IChangedCalculatorProperties>, global::System.Threading.Tasks.ValueTask> handler, global::Tmds.DBus.Protocol.ObserverFlags flags, bool emitOnCapturedContext = true, object? state = null)
         {
-            return Connection.WatchPropertiesChangedAsync(Destination, Path, DBusInterfaceName, (Message m, object? s) => ReadMessage(m), handler, flags, emitOnCapturedContext, state);
-            static IChangedCalculatorProperties ReadMessage(Message message)
+            return Connection.WatchPropertiesChangedAsync(Destination, Path, DBusInterfaceName, (global::Tmds.DBus.Protocol.Message m, object? s) => ReadMessage(m), handler, flags, emitOnCapturedContext, state);
+            static IChangedCalculatorProperties ReadMessage(global::Tmds.DBus.Protocol.Message message)
             {
                 var reader = message.GetBodyReader();
                 reader.ReadString(); // interface
                 return CalculatorProperties.ReadFrom(ref reader, withInvalidated: true);
             }
         }
-        private MessageBuffer CreateGetPropertyMessage(string property)
+        private global::Tmds.DBus.Protocol.MessageBuffer CreateGetPropertyMessage(string property)
         {
             var writer = Connection.GetMessageWriter();
             writer.WriteMethodCallHeader(
@@ -456,7 +451,7 @@ namespace ProxyNamespace
             writer.WriteString(property);
             return writer.CreateMessage();
         }
-        private MessageBuffer CreateGetAllPropertiesMessage()
+        private global::Tmds.DBus.Protocol.MessageBuffer CreateGetAllPropertiesMessage()
         {
             var writer = Connection.GetMessageWriter();
             writer.WriteMethodCallHeader(
@@ -501,14 +496,14 @@ namespace ProxyNamespace
         private static uint Flag(SettingsProperty property) => property == 0 ? 0 : 1U << ((int)property - 1);
         public SettingsProperties() { }
         #nullable disable
-        [System.Diagnostics.CodeAnalysis.SetsRequiredMembers]
+        [global::System.Diagnostics.CodeAnalysis.SetsRequiredMembers]
         private SettingsProperties(bool _) { }
         #nullable enable
         private void EnsureSet(SettingsProperty property)
         {
             if (!HasFlag(__set, property))
             {
-                throw new InvalidOperationException("Property is not set.");
+                throw new global::System.InvalidOperationException("Property is not set.");
             }
         }
         private string _theme = default!;
@@ -553,13 +548,13 @@ namespace ProxyNamespace
         {
             if (!AreAllPropertiesSet())
             {
-                throw new DBusUnexpectedValueException($"Not all properties have been set (0x{__set:x}).");
+                throw new global::Tmds.DBus.Protocol.DBusUnexpectedValueException($"Not all properties have been set (0x{__set:x}).");
             }
         }
-        public static SettingsProperties ReadFrom(ref Reader reader, bool withInvalidated)
+        public static SettingsProperties ReadFrom(ref global::Tmds.DBus.Protocol.Reader reader, bool withInvalidated)
         {
             var props = CreateUninitialized();
-            ArrayEnd arrayEnd = reader.ReadArrayStart(DBusType.Struct);
+            global::Tmds.DBus.Protocol.ArrayEnd arrayEnd = reader.ReadArrayStart(global::Tmds.DBus.Protocol.DBusType.Struct);
             while (reader.HasNext(arrayEnd))
             {
                 var property = reader.ReadString();
@@ -580,7 +575,7 @@ namespace ProxyNamespace
             }
             if (withInvalidated)
             {
-                ArrayEnd invalidatedEnd = reader.ReadArrayStart(DBusType.String);
+                global::Tmds.DBus.Protocol.ArrayEnd invalidatedEnd = reader.ReadArrayStart(global::Tmds.DBus.Protocol.DBusType.String);
                 while (reader.HasNext(invalidatedEnd))
                 {
                     var propertyName = reader.ReadString();
@@ -596,16 +591,16 @@ namespace ProxyNamespace
         }
         double ISettingsProperties.Volume { set { } }
     }
-    sealed partial class Settings : Tmds.DBus.Protocol.DBusObject
+    sealed partial class Settings : global::Tmds.DBus.Protocol.DBusObject
     {
         public const string DBusInterfaceName = "org.example.Settings";
-        public Settings(Tmds.DBus.Protocol.DBusConnection connection, string destination, ObjectPath path)
+        public Settings(global::Tmds.DBus.Protocol.DBusConnection connection, string destination, global::Tmds.DBus.Protocol.ObjectPath path)
             : base(connection, destination, path)
         { }
-        public Task SaveAsync()
+        public global::System.Threading.Tasks.Task SaveAsync()
         {
             return Connection.CallMethodAsync(CreateMessage());
-            MessageBuffer CreateMessage()
+            global::Tmds.DBus.Protocol.MessageBuffer CreateMessage()
             {
                 var writer = Connection.GetMessageWriter();
                 writer.WriteMethodCallHeader(
@@ -616,18 +611,18 @@ namespace ProxyNamespace
                 return writer.CreateMessage();
             }
         }
-        public ValueTask<IDisposable> WatchChangedAsync(Action handler, bool emitOnCapturedContext = true)
-            => WatchChangedAsync(static (Notification n) => ((Action)n.State!)(), ObserverFlags.None, emitOnCapturedContext, handler);
-        public ValueTask<IDisposable> WatchChangedAsync(Func<ValueTask> handler, bool emitOnCapturedContext = true)
-            => WatchChangedAsync(static (Notification n) => ((Func<ValueTask>)n.State!)(), ObserverFlags.None, emitOnCapturedContext, handler);
-        public ValueTask<IDisposable> WatchChangedAsync(Action<Notification> handler, ObserverFlags flags, bool emitOnCapturedContext = true, object? state = null)
+        public global::System.Threading.Tasks.ValueTask<global::System.IDisposable> WatchChangedAsync(global::System.Action handler, bool emitOnCapturedContext = true)
+            => WatchChangedAsync(static (global::Tmds.DBus.Protocol.Notification n) => ((global::System.Action)n.State!)(), global::Tmds.DBus.Protocol.ObserverFlags.None, emitOnCapturedContext, handler);
+        public global::System.Threading.Tasks.ValueTask<global::System.IDisposable> WatchChangedAsync(global::System.Func<global::System.Threading.Tasks.ValueTask> handler, bool emitOnCapturedContext = true)
+            => WatchChangedAsync(static (global::Tmds.DBus.Protocol.Notification n) => ((global::System.Func<global::System.Threading.Tasks.ValueTask>)n.State!)(), global::Tmds.DBus.Protocol.ObserverFlags.None, emitOnCapturedContext, handler);
+        public global::System.Threading.Tasks.ValueTask<global::System.IDisposable> WatchChangedAsync(global::System.Action<global::Tmds.DBus.Protocol.Notification> handler, global::Tmds.DBus.Protocol.ObserverFlags flags, bool emitOnCapturedContext = true, object? state = null)
             => Connection.WatchSignalAsync(Destination, Path, DBusInterfaceName, "Changed", handler, flags, emitOnCapturedContext, state);
-        public ValueTask<IDisposable> WatchChangedAsync(Func<Notification, ValueTask> handler, ObserverFlags flags, bool emitOnCapturedContext = true, object? state = null)
+        public global::System.Threading.Tasks.ValueTask<global::System.IDisposable> WatchChangedAsync(global::System.Func<global::Tmds.DBus.Protocol.Notification, global::System.Threading.Tasks.ValueTask> handler, global::Tmds.DBus.Protocol.ObserverFlags flags, bool emitOnCapturedContext = true, object? state = null)
             => Connection.WatchSignalAsync(Destination, Path, DBusInterfaceName, "Changed", handler, flags, emitOnCapturedContext, state);
-        public Task SetVolumeAsync(double value)
+        public global::System.Threading.Tasks.Task SetVolumeAsync(double value)
         {
             return Connection.CallMethodAsync(CreateMessage());
-            MessageBuffer CreateMessage()
+            global::Tmds.DBus.Protocol.MessageBuffer CreateMessage()
             {
                 var writer = Connection.GetMessageWriter();
                 writer.WriteMethodCallHeader(
@@ -643,10 +638,10 @@ namespace ProxyNamespace
                 return writer.CreateMessage();
             }
         }
-        public Task SetLanguageAsync(string value)
+        public global::System.Threading.Tasks.Task SetLanguageAsync(string value)
         {
             return Connection.CallMethodAsync(CreateMessage());
-            MessageBuffer CreateMessage()
+            global::Tmds.DBus.Protocol.MessageBuffer CreateMessage()
             {
                 var writer = Connection.GetMessageWriter();
                 writer.WriteMethodCallHeader(
@@ -662,53 +657,53 @@ namespace ProxyNamespace
                 return writer.CreateMessage();
             }
         }
-        public Task<string> GetThemeAsync()
-            => Connection.CallMethodAsync(CreateGetPropertyMessage("Theme"), (Message m, object? s) => MessageReader.Read_v_s(m), this);
-        public Task<string> GetLanguageAsync()
-            => Connection.CallMethodAsync(CreateGetPropertyMessage("Language"), (Message m, object? s) => MessageReader.Read_v_s(m), this);
-        public Task<SettingsProperties> GetPropertiesAsync()
+        public global::System.Threading.Tasks.Task<string> GetThemeAsync()
+            => Connection.CallMethodAsync(CreateGetPropertyMessage("Theme"), (global::Tmds.DBus.Protocol.Message m, object? s) => MessageReader.Read_v_s(m), this);
+        public global::System.Threading.Tasks.Task<string> GetLanguageAsync()
+            => Connection.CallMethodAsync(CreateGetPropertyMessage("Language"), (global::Tmds.DBus.Protocol.Message m, object? s) => MessageReader.Read_v_s(m), this);
+        public global::System.Threading.Tasks.Task<SettingsProperties> GetPropertiesAsync()
         {
-            return Connection.CallMethodAsync(CreateGetAllPropertiesMessage(), (Message m, object? s) => ReadMessage(m), this);
-            static SettingsProperties ReadMessage(Message message)
+            return Connection.CallMethodAsync(CreateGetAllPropertiesMessage(), (global::Tmds.DBus.Protocol.Message m, object? s) => ReadMessage(m), this);
+            static SettingsProperties ReadMessage(global::Tmds.DBus.Protocol.Message message)
             {
                 var reader = message.GetBodyReader();
                 return SettingsProperties.ReadFrom(ref reader, withInvalidated: false);
             }
         }
-        public Task<INullableSettingsProperties> GetNullablePropertiesAsync()
+        public global::System.Threading.Tasks.Task<INullableSettingsProperties> GetNullablePropertiesAsync()
         {
-            return Connection.CallMethodAsync(CreateGetAllPropertiesMessage(), (Message m, object? s) => ReadMessage(m), this);
-            static INullableSettingsProperties ReadMessage(Message message)
+            return Connection.CallMethodAsync(CreateGetAllPropertiesMessage(), (global::Tmds.DBus.Protocol.Message m, object? s) => ReadMessage(m), this);
+            static INullableSettingsProperties ReadMessage(global::Tmds.DBus.Protocol.Message message)
             {
                 var reader = message.GetBodyReader();
                 return SettingsProperties.ReadFrom(ref reader, withInvalidated: false);
             }
         }
-        public ValueTask<IDisposable> WatchPropertiesChangedAsync(Action<IChangedSettingsProperties> handler, bool emitOnCapturedContext = true)
-            => WatchPropertiesChangedAsync(static (Notification<IChangedSettingsProperties> n) => ((Action<IChangedSettingsProperties>)n.State!)(n.Value), ObserverFlags.None, emitOnCapturedContext, handler);
-        public ValueTask<IDisposable> WatchPropertiesChangedAsync(Func<IChangedSettingsProperties, ValueTask> handler, bool emitOnCapturedContext = true)
-            => WatchPropertiesChangedAsync(static (Notification<IChangedSettingsProperties> n) => ((Func<IChangedSettingsProperties, ValueTask>)n.State!)(n.Value), ObserverFlags.None, emitOnCapturedContext, handler);
-        public ValueTask<IDisposable> WatchPropertiesChangedAsync(Action<Notification<IChangedSettingsProperties>> handler, ObserverFlags flags, bool emitOnCapturedContext = true, object? state = null)
+        public global::System.Threading.Tasks.ValueTask<global::System.IDisposable> WatchPropertiesChangedAsync(global::System.Action<IChangedSettingsProperties> handler, bool emitOnCapturedContext = true)
+            => WatchPropertiesChangedAsync(static (global::Tmds.DBus.Protocol.Notification<IChangedSettingsProperties> n) => ((global::System.Action<IChangedSettingsProperties>)n.State!)(n.Value), global::Tmds.DBus.Protocol.ObserverFlags.None, emitOnCapturedContext, handler);
+        public global::System.Threading.Tasks.ValueTask<global::System.IDisposable> WatchPropertiesChangedAsync(global::System.Func<IChangedSettingsProperties, global::System.Threading.Tasks.ValueTask> handler, bool emitOnCapturedContext = true)
+            => WatchPropertiesChangedAsync(static (global::Tmds.DBus.Protocol.Notification<IChangedSettingsProperties> n) => ((global::System.Func<IChangedSettingsProperties, global::System.Threading.Tasks.ValueTask>)n.State!)(n.Value), global::Tmds.DBus.Protocol.ObserverFlags.None, emitOnCapturedContext, handler);
+        public global::System.Threading.Tasks.ValueTask<global::System.IDisposable> WatchPropertiesChangedAsync(global::System.Action<global::Tmds.DBus.Protocol.Notification<IChangedSettingsProperties>> handler, global::Tmds.DBus.Protocol.ObserverFlags flags, bool emitOnCapturedContext = true, object? state = null)
         {
-            return Connection.WatchPropertiesChangedAsync(Destination, Path, DBusInterfaceName, (Message m, object? s) => ReadMessage(m), handler, flags, emitOnCapturedContext, state);
-            static IChangedSettingsProperties ReadMessage(Message message)
+            return Connection.WatchPropertiesChangedAsync(Destination, Path, DBusInterfaceName, (global::Tmds.DBus.Protocol.Message m, object? s) => ReadMessage(m), handler, flags, emitOnCapturedContext, state);
+            static IChangedSettingsProperties ReadMessage(global::Tmds.DBus.Protocol.Message message)
             {
                 var reader = message.GetBodyReader();
                 reader.ReadString(); // interface
                 return SettingsProperties.ReadFrom(ref reader, withInvalidated: true);
             }
         }
-        public ValueTask<IDisposable> WatchPropertiesChangedAsync(Func<Notification<IChangedSettingsProperties>, ValueTask> handler, ObserverFlags flags, bool emitOnCapturedContext = true, object? state = null)
+        public global::System.Threading.Tasks.ValueTask<global::System.IDisposable> WatchPropertiesChangedAsync(global::System.Func<global::Tmds.DBus.Protocol.Notification<IChangedSettingsProperties>, global::System.Threading.Tasks.ValueTask> handler, global::Tmds.DBus.Protocol.ObserverFlags flags, bool emitOnCapturedContext = true, object? state = null)
         {
-            return Connection.WatchPropertiesChangedAsync(Destination, Path, DBusInterfaceName, (Message m, object? s) => ReadMessage(m), handler, flags, emitOnCapturedContext, state);
-            static IChangedSettingsProperties ReadMessage(Message message)
+            return Connection.WatchPropertiesChangedAsync(Destination, Path, DBusInterfaceName, (global::Tmds.DBus.Protocol.Message m, object? s) => ReadMessage(m), handler, flags, emitOnCapturedContext, state);
+            static IChangedSettingsProperties ReadMessage(global::Tmds.DBus.Protocol.Message message)
             {
                 var reader = message.GetBodyReader();
                 reader.ReadString(); // interface
                 return SettingsProperties.ReadFrom(ref reader, withInvalidated: true);
             }
         }
-        private MessageBuffer CreateGetPropertyMessage(string property)
+        private global::Tmds.DBus.Protocol.MessageBuffer CreateGetPropertyMessage(string property)
         {
             var writer = Connection.GetMessageWriter();
             writer.WriteMethodCallHeader(
@@ -721,7 +716,7 @@ namespace ProxyNamespace
             writer.WriteString(property);
             return writer.CreateMessage();
         }
-        private MessageBuffer CreateGetAllPropertiesMessage()
+        private global::Tmds.DBus.Protocol.MessageBuffer CreateGetAllPropertiesMessage()
         {
             var writer = Connection.GetMessageWriter();
             writer.WriteMethodCallHeader(
@@ -734,114 +729,114 @@ namespace ProxyNamespace
             return writer.CreateMessage();
         }
     }
-    sealed partial class Marker : Tmds.DBus.Protocol.DBusObject
+    sealed partial class Marker : global::Tmds.DBus.Protocol.DBusObject
     {
         public const string DBusInterfaceName = "org.example.Marker";
-        public Marker(Tmds.DBus.Protocol.DBusConnection connection, string destination, ObjectPath path)
+        public Marker(global::Tmds.DBus.Protocol.DBusConnection connection, string destination, global::Tmds.DBus.Protocol.ObjectPath path)
             : base(connection, destination, path)
         { }
     }
     static partial class ObjectFactory
     {
-        public static Calculator CreateCalculator(this DBusService service, ObjectPath path) => new Calculator(service.Connection, service.Name, path);
-        public static Settings CreateSettings(this DBusService service, ObjectPath path) => new Settings(service.Connection, service.Name, path);
-        public static Marker CreateMarker(this DBusService service, ObjectPath path) => new Marker(service.Connection, service.Name, path);
+        public static Calculator CreateCalculator(this global::Tmds.DBus.Protocol.DBusService service, global::Tmds.DBus.Protocol.ObjectPath path) => new Calculator(service.Connection, service.Name, path);
+        public static Settings CreateSettings(this global::Tmds.DBus.Protocol.DBusService service, global::Tmds.DBus.Protocol.ObjectPath path) => new Settings(service.Connection, service.Name, path);
+        public static Marker CreateMarker(this global::Tmds.DBus.Protocol.DBusService service, global::Tmds.DBus.Protocol.ObjectPath path) => new Marker(service.Connection, service.Name, path);
     }
     file static class MessageReader
     {
-        public static double Read_d(Message message)
+        public static double Read_d(global::Tmds.DBus.Protocol.Message message)
         {
             var reader = message.GetBodyReader();
             return reader.ReadDouble();
         }
-        public static (uint, double) Read_ud(Message message)
+        public static (uint, double) Read_ud(global::Tmds.DBus.Protocol.Message message)
         {
             var reader = message.GetBodyReader();
             var arg0 = reader.ReadUInt32();
             var arg1 = reader.ReadDouble();
             return (arg0, arg1);
         }
-        public static (int, int) Read_ii(Message message)
+        public static (int, int) Read_ii(global::Tmds.DBus.Protocol.Message message)
         {
             var reader = message.GetBodyReader();
             var arg0 = reader.ReadInt32();
             var arg1 = reader.ReadInt32();
             return (arg0, arg1);
         }
-        public static (bool, double) Read_bd(Message message)
+        public static (bool, double) Read_bd(global::Tmds.DBus.Protocol.Message message)
         {
             var reader = message.GetBodyReader();
             var arg0 = reader.ReadBool();
             var arg1 = reader.ReadDouble();
             return (arg0, arg1);
         }
-        public static (string, double) Read_rsdz(Message message)
+        public static (string, double) Read_rsdz(global::Tmds.DBus.Protocol.Message message)
         {
             var reader = message.GetBodyReader();
             return reader.Read_rsdz();
         }
-        public static string Read_s(Message message)
+        public static string Read_s(global::Tmds.DBus.Protocol.Message message)
         {
             var reader = message.GetBodyReader();
             return reader.ReadString();
         }
-        public static (string, double) Read_sd(Message message)
+        public static (string, double) Read_sd(global::Tmds.DBus.Protocol.Message message)
         {
             var reader = message.GetBodyReader();
             var arg0 = reader.ReadString();
             var arg1 = reader.ReadDouble();
             return (arg0, arg1);
         }
-        public static double Read_v_d(Message message)
+        public static double Read_v_d(global::Tmds.DBus.Protocol.Message message)
         {
             var reader = message.GetBodyReader();
             reader.ReadSignature("d"u8);
             return reader.ReadDouble();
         }
-        public static ObjectPath Read_v_o(Message message)
+        public static global::Tmds.DBus.Protocol.ObjectPath Read_v_o(global::Tmds.DBus.Protocol.Message message)
         {
             var reader = message.GetBodyReader();
             reader.ReadSignature("o"u8);
             return reader.ReadObjectPath();
         }
-        public static (string, double) Read_v_rsdz(Message message)
+        public static (string, double) Read_v_rsdz(global::Tmds.DBus.Protocol.Message message)
         {
             var reader = message.GetBodyReader();
             reader.ReadSignature("(sd)"u8);
             return reader.Read_rsdz();
         }
-        public static ValueTuple<bool> Read_v_rbz(Message message)
+        public static global::System.ValueTuple<bool> Read_v_rbz(global::Tmds.DBus.Protocol.Message message)
         {
             var reader = message.GetBodyReader();
             reader.ReadSignature("(b)"u8);
             return reader.Read_rbz();
         }
-        public static string Read_v_s(Message message)
+        public static string Read_v_s(global::Tmds.DBus.Protocol.Message message)
         {
             var reader = message.GetBodyReader();
             reader.ReadSignature("s"u8);
             return reader.ReadString();
         }
-        public static (string, double) Read_rsdz(this ref Reader reader)
+        public static (string, double) Read_rsdz(this ref global::Tmds.DBus.Protocol.Reader reader)
         {
             reader.AlignStruct();
             return (reader.ReadString(), reader.ReadDouble());
         }
-        public static ValueTuple<bool> Read_rbz(this ref Reader reader)
+        public static global::System.ValueTuple<bool> Read_rbz(this ref global::Tmds.DBus.Protocol.Reader reader)
         {
             reader.AlignStruct();
-            return new ValueTuple<bool>(reader.ReadBool());
+            return new global::System.ValueTuple<bool>(reader.ReadBool());
         }
     }
     file static class MessageWriterExtensions
     {
-        public static void Write_rsdz(this ref MessageWriter writer, (string, double) value)
+        public static void Write_rsdz(this ref global::Tmds.DBus.Protocol.MessageWriter writer, (string, double) value)
         {
             writer.WriteStructureStart();
             writer.WriteString(value.Item1);
             writer.WriteDouble(value.Item2);
         }
-        public static void Write_rbz(this ref MessageWriter writer, ValueTuple<bool> value)
+        public static void Write_rbz(this ref global::Tmds.DBus.Protocol.MessageWriter writer, global::System.ValueTuple<bool> value)
         {
             writer.WriteStructureStart();
             writer.WriteBool(value.Item1);
@@ -854,11 +849,6 @@ namespace ProxyNamespace
 #nullable enable
 namespace HandlerNamespace
 {
-    using System;
-    using Tmds.DBus.Protocol;
-    using System.Collections.Generic;
-    using System.Threading.Tasks;
-    using System.Runtime.CompilerServices;
     enum CalculatorProperty
     {
         UnknownProperty = 0,
@@ -870,9 +860,9 @@ namespace HandlerNamespace
     interface ICalculatorProperties
     {
         double LastResult { get; }
-        ObjectPath CurrentPath { get; }
+        global::Tmds.DBus.Protocol.ObjectPath CurrentPath { get; }
         (string, double) CurrentEntry { get; }
-        ValueTuple<bool> IsActive { get; set; }
+        global::System.ValueTuple<bool> IsActive { get; set; }
     }
     enum WritableCalculatorProperty
     {
@@ -894,56 +884,56 @@ namespace HandlerNamespace
                     _ => 0
                 };
             }
-            public static DBusHandler.DBusMethod FindMethodHandler(object handler, MethodContext context)
+            public static global::Tmds.DBus.Protocol.DBusHandler.DBusMethod FindMethodHandler(object handler, global::Tmds.DBus.Protocol.MethodContext context)
             {
                 var request = context.Request;
                 if (context.IsPropertiesInterfaceRequest)
                 {
                     return (request.MemberAsString, request.SignatureAsString) switch
                     {
-                        ("Get", "ss") => new DBusHandler.DBusMethod(static (o, c) => ((ICalculatorHandler)o).HandleGetPropertyAsync(new GetPropertyContext(c)), handler),
-                        ("GetAll", "s") => new DBusHandler.DBusMethod(static (o, c) => ((ICalculatorHandler)o).HandleGetAllPropertiesAsync(new GetAllPropertiesContext(c)), handler),
-                        ("Set", "ssv") => new DBusHandler.DBusMethod(static (o, c) => ((ICalculatorHandler)o).HandleSetPropertyAsync(new SetPropertyContext(c)), handler),
+                        ("Get", "ss") => new global::Tmds.DBus.Protocol.DBusHandler.DBusMethod(static (o, c) => ((ICalculatorHandler)o).HandleGetPropertyAsync(new GetPropertyContext(c)), handler),
+                        ("GetAll", "s") => new global::Tmds.DBus.Protocol.DBusHandler.DBusMethod(static (o, c) => ((ICalculatorHandler)o).HandleGetAllPropertiesAsync(new GetAllPropertiesContext(c)), handler),
+                        ("Set", "ssv") => new global::Tmds.DBus.Protocol.DBusHandler.DBusMethod(static (o, c) => ((ICalculatorHandler)o).HandleSetPropertyAsync(new SetPropertyContext(c)), handler),
                         _ => default
                     };
                 }
                 return (request.MemberAsString, request.SignatureAsString) switch
                 {
-                    ("Clear", "") => new DBusHandler.DBusMethod(static (o, c) => HandleClearAsync((ICalculatorHandler)o, c), handler),
-                    ("GetResult", "") => new DBusHandler.DBusMethod(static (o, c) => HandleGetResultAsync((ICalculatorHandler)o, c), handler),
-                    ("GetStats", "") => new DBusHandler.DBusMethod(static (o, c) => HandleGetStatsAsync((ICalculatorHandler)o, c), handler),
-                    ("Store", "d") => new DBusHandler.DBusMethod(static (o, c) => HandleStoreAsync((ICalculatorHandler)o, c), handler),
-                    ("Square", "d") => new DBusHandler.DBusMethod(static (o, c) => HandleSquareAsync((ICalculatorHandler)o, c), handler),
-                    ("DivMod", "i") => new DBusHandler.DBusMethod(static (o, c) => HandleDivModAsync((ICalculatorHandler)o, c), handler),
-                    ("LogOperation", "sd") => new DBusHandler.DBusMethod(static (o, c) => HandleLogOperationAsync((ICalculatorHandler)o, c), handler),
-                    ("Add", "dd") => new DBusHandler.DBusMethod(static (o, c) => HandleAddAsync((ICalculatorHandler)o, c), handler),
-                    ("Compare", "dd") => new DBusHandler.DBusMethod(static (o, c) => HandleCompareAsync((ICalculatorHandler)o, c), handler),
-                    ("GetEntry", "s") => new DBusHandler.DBusMethod(static (o, c) => HandleGetEntryAsync((ICalculatorHandler)o, c), handler),
-                    ("SetEntry", "(sd)") => new DBusHandler.DBusMethod(static (o, c) => HandleSetEntryAsync((ICalculatorHandler)o, c), handler),
+                    ("Clear", "") => new global::Tmds.DBus.Protocol.DBusHandler.DBusMethod(static (o, c) => HandleClearAsync((ICalculatorHandler)o, c), handler),
+                    ("GetResult", "") => new global::Tmds.DBus.Protocol.DBusHandler.DBusMethod(static (o, c) => HandleGetResultAsync((ICalculatorHandler)o, c), handler),
+                    ("GetStats", "") => new global::Tmds.DBus.Protocol.DBusHandler.DBusMethod(static (o, c) => HandleGetStatsAsync((ICalculatorHandler)o, c), handler),
+                    ("Store", "d") => new global::Tmds.DBus.Protocol.DBusHandler.DBusMethod(static (o, c) => HandleStoreAsync((ICalculatorHandler)o, c), handler),
+                    ("Square", "d") => new global::Tmds.DBus.Protocol.DBusHandler.DBusMethod(static (o, c) => HandleSquareAsync((ICalculatorHandler)o, c), handler),
+                    ("DivMod", "i") => new global::Tmds.DBus.Protocol.DBusHandler.DBusMethod(static (o, c) => HandleDivModAsync((ICalculatorHandler)o, c), handler),
+                    ("LogOperation", "sd") => new global::Tmds.DBus.Protocol.DBusHandler.DBusMethod(static (o, c) => HandleLogOperationAsync((ICalculatorHandler)o, c), handler),
+                    ("Add", "dd") => new global::Tmds.DBus.Protocol.DBusHandler.DBusMethod(static (o, c) => HandleAddAsync((ICalculatorHandler)o, c), handler),
+                    ("Compare", "dd") => new global::Tmds.DBus.Protocol.DBusHandler.DBusMethod(static (o, c) => HandleCompareAsync((ICalculatorHandler)o, c), handler),
+                    ("GetEntry", "s") => new global::Tmds.DBus.Protocol.DBusHandler.DBusMethod(static (o, c) => HandleGetEntryAsync((ICalculatorHandler)o, c), handler),
+                    ("SetEntry", "(sd)") => new global::Tmds.DBus.Protocol.DBusHandler.DBusMethod(static (o, c) => HandleSetEntryAsync((ICalculatorHandler)o, c), handler),
                     _ => default
                 };
             }
-            static async ValueTask HandleClearAsync(ICalculatorHandler handler, MethodContext context)
+            static async global::System.Threading.Tasks.ValueTask HandleClearAsync(ICalculatorHandler handler, global::Tmds.DBus.Protocol.MethodContext context)
             {
                 await handler.ClearAsync().ConfigureAwait(false);
                 context.Reply(context.CreateReplyWriter(null).CreateMessage());
             }
-            static async ValueTask HandleGetResultAsync(ICalculatorHandler handler, MethodContext context)
+            static async global::System.Threading.Tasks.ValueTask HandleGetResultAsync(ICalculatorHandler handler, global::Tmds.DBus.Protocol.MethodContext context)
             {
                 var result = await handler.GetResultAsync().ConfigureAwait(false);
                 WriteReply(context, result);
-                static void WriteReply(MethodContext context, double result)
+                static void WriteReply(global::Tmds.DBus.Protocol.MethodContext context, double result)
                 {
                     var writer = context.CreateReplyWriter("d");
                     writer.WriteDouble(result);
                     context.Reply(writer.CreateMessage());
                 }
             }
-            static async ValueTask HandleGetStatsAsync(ICalculatorHandler handler, MethodContext context)
+            static async global::System.Threading.Tasks.ValueTask HandleGetStatsAsync(ICalculatorHandler handler, global::Tmds.DBus.Protocol.MethodContext context)
             {
                 var result = await handler.GetStatsAsync().ConfigureAwait(false);
                 WriteReply(context, result);
-                static void WriteReply(MethodContext context, (uint Count, double Total) result)
+                static void WriteReply(global::Tmds.DBus.Protocol.MethodContext context, (uint Count, double Total) result)
                 {
                     var writer = context.CreateReplyWriter("ud");
                     writer.WriteUInt32(result.Count);
@@ -951,30 +941,30 @@ namespace HandlerNamespace
                     context.Reply(writer.CreateMessage());
                 }
             }
-            static async ValueTask HandleStoreAsync(ICalculatorHandler handler, MethodContext context)
+            static async global::System.Threading.Tasks.ValueTask HandleStoreAsync(ICalculatorHandler handler, global::Tmds.DBus.Protocol.MethodContext context)
             {
                 var value = MessageReader.Read_d(context.Request);
                 await handler.StoreAsync(value).ConfigureAwait(false);
                 context.Reply(context.CreateReplyWriter(null).CreateMessage());
             }
-            static async ValueTask HandleSquareAsync(ICalculatorHandler handler, MethodContext context)
+            static async global::System.Threading.Tasks.ValueTask HandleSquareAsync(ICalculatorHandler handler, global::Tmds.DBus.Protocol.MethodContext context)
             {
                 var input = MessageReader.Read_d(context.Request);
                 var result = await handler.SquareAsync(input).ConfigureAwait(false);
                 WriteReply(context, result);
-                static void WriteReply(MethodContext context, double result)
+                static void WriteReply(global::Tmds.DBus.Protocol.MethodContext context, double result)
                 {
                     var writer = context.CreateReplyWriter("d");
                     writer.WriteDouble(result);
                     context.Reply(writer.CreateMessage());
                 }
             }
-            static async ValueTask HandleDivModAsync(ICalculatorHandler handler, MethodContext context)
+            static async global::System.Threading.Tasks.ValueTask HandleDivModAsync(ICalculatorHandler handler, global::Tmds.DBus.Protocol.MethodContext context)
             {
                 var dividend = MessageReader.Read_i(context.Request);
                 var result = await handler.DivModAsync(dividend).ConfigureAwait(false);
                 WriteReply(context, result);
-                static void WriteReply(MethodContext context, (int Quotient, int Remainder) result)
+                static void WriteReply(global::Tmds.DBus.Protocol.MethodContext context, (int Quotient, int Remainder) result)
                 {
                     var writer = context.CreateReplyWriter("ii");
                     writer.WriteInt32(result.Quotient);
@@ -982,30 +972,30 @@ namespace HandlerNamespace
                     context.Reply(writer.CreateMessage());
                 }
             }
-            static async ValueTask HandleLogOperationAsync(ICalculatorHandler handler, MethodContext context)
+            static async global::System.Threading.Tasks.ValueTask HandleLogOperationAsync(ICalculatorHandler handler, global::Tmds.DBus.Protocol.MethodContext context)
             {
                 var (operation, value) = MessageReader.Read_sd(context.Request);
                 await handler.LogOperationAsync(operation, value).ConfigureAwait(false);
                 context.Reply(context.CreateReplyWriter(null).CreateMessage());
             }
-            static async ValueTask HandleAddAsync(ICalculatorHandler handler, MethodContext context)
+            static async global::System.Threading.Tasks.ValueTask HandleAddAsync(ICalculatorHandler handler, global::Tmds.DBus.Protocol.MethodContext context)
             {
                 var (a, b) = MessageReader.Read_dd(context.Request);
                 var result = await handler.AddAsync(a, b).ConfigureAwait(false);
                 WriteReply(context, result);
-                static void WriteReply(MethodContext context, double result)
+                static void WriteReply(global::Tmds.DBus.Protocol.MethodContext context, double result)
                 {
                     var writer = context.CreateReplyWriter("d");
                     writer.WriteDouble(result);
                     context.Reply(writer.CreateMessage());
                 }
             }
-            static async ValueTask HandleCompareAsync(ICalculatorHandler handler, MethodContext context)
+            static async global::System.Threading.Tasks.ValueTask HandleCompareAsync(ICalculatorHandler handler, global::Tmds.DBus.Protocol.MethodContext context)
             {
                 var (a, b) = MessageReader.Read_dd(context.Request);
                 var result = await handler.CompareAsync(a, b).ConfigureAwait(false);
                 WriteReply(context, result);
-                static void WriteReply(MethodContext context, (bool Equal, double Difference) result)
+                static void WriteReply(global::Tmds.DBus.Protocol.MethodContext context, (bool Equal, double Difference) result)
                 {
                     var writer = context.CreateReplyWriter("bd");
                     writer.WriteBool(result.Equal);
@@ -1013,44 +1003,44 @@ namespace HandlerNamespace
                     context.Reply(writer.CreateMessage());
                 }
             }
-            static async ValueTask HandleGetEntryAsync(ICalculatorHandler handler, MethodContext context)
+            static async global::System.Threading.Tasks.ValueTask HandleGetEntryAsync(ICalculatorHandler handler, global::Tmds.DBus.Protocol.MethodContext context)
             {
                 var key = MessageReader.Read_s(context.Request);
                 var result = await handler.GetEntryAsync(key).ConfigureAwait(false);
                 WriteReply(context, result);
-                static void WriteReply(MethodContext context, (string, double) result)
+                static void WriteReply(global::Tmds.DBus.Protocol.MethodContext context, (string, double) result)
                 {
                     var writer = context.CreateReplyWriter("(sd)");
                     writer.Write_rsdz(result);
                     context.Reply(writer.CreateMessage());
                 }
             }
-            static async ValueTask HandleSetEntryAsync(ICalculatorHandler handler, MethodContext context)
+            static async global::System.Threading.Tasks.ValueTask HandleSetEntryAsync(ICalculatorHandler handler, global::Tmds.DBus.Protocol.MethodContext context)
             {
                 var entry = MessageReader.Read_rsdz(context.Request);
                 await handler.SetEntryAsync(entry).ConfigureAwait(false);
                 context.Reply(context.CreateReplyWriter(null).CreateMessage());
             }
         }
-        ValueTask HandleGetPropertyAsync(GetPropertyContext context);
-        ValueTask HandleGetAllPropertiesAsync(GetAllPropertiesContext context);
-        ValueTask HandleSetPropertyAsync(SetPropertyContext context);
-        ValueTask ClearAsync();
-        ValueTask<double> GetResultAsync();
-        ValueTask<(uint Count, double Total)> GetStatsAsync();
-        ValueTask StoreAsync(double value);
-        ValueTask<double> SquareAsync(double input);
-        ValueTask<(int Quotient, int Remainder)> DivModAsync(int dividend);
-        ValueTask LogOperationAsync(string operation, double value);
-        ValueTask<double> AddAsync(double a, double b);
-        ValueTask<(bool Equal, double Difference)> CompareAsync(double a, double b);
-        ValueTask<(string, double)> GetEntryAsync(string key);
-        ValueTask SetEntryAsync((string, double) entry);
-        readonly struct GetPropertyContext : IDisposable
+        global::System.Threading.Tasks.ValueTask HandleGetPropertyAsync(GetPropertyContext context);
+        global::System.Threading.Tasks.ValueTask HandleGetAllPropertiesAsync(GetAllPropertiesContext context);
+        global::System.Threading.Tasks.ValueTask HandleSetPropertyAsync(SetPropertyContext context);
+        global::System.Threading.Tasks.ValueTask ClearAsync();
+        global::System.Threading.Tasks.ValueTask<double> GetResultAsync();
+        global::System.Threading.Tasks.ValueTask<(uint Count, double Total)> GetStatsAsync();
+        global::System.Threading.Tasks.ValueTask StoreAsync(double value);
+        global::System.Threading.Tasks.ValueTask<double> SquareAsync(double input);
+        global::System.Threading.Tasks.ValueTask<(int Quotient, int Remainder)> DivModAsync(int dividend);
+        global::System.Threading.Tasks.ValueTask LogOperationAsync(string operation, double value);
+        global::System.Threading.Tasks.ValueTask<double> AddAsync(double a, double b);
+        global::System.Threading.Tasks.ValueTask<(bool Equal, double Difference)> CompareAsync(double a, double b);
+        global::System.Threading.Tasks.ValueTask<(string, double)> GetEntryAsync(string key);
+        global::System.Threading.Tasks.ValueTask SetEntryAsync((string, double) entry);
+        readonly struct GetPropertyContext : global::System.IDisposable
         {
-            public MethodContext MethodContext { get; }
+            public global::Tmds.DBus.Protocol.MethodContext MethodContext { get; }
             public CalculatorProperty Property { get; }
-            public GetPropertyContext(MethodContext methodContext)
+            public GetPropertyContext(global::Tmds.DBus.Protocol.MethodContext methodContext)
             {
                 MethodContext = methodContext;
                 var reader = methodContext.Request.GetBodyReader();
@@ -1060,28 +1050,28 @@ namespace HandlerNamespace
             public void Dispose() => MethodContext.Dispose();
             public void ReplyLastResult(double value)
             {
-                System.Diagnostics.Debug.Assert(Property == CalculatorProperty.LastResult);
+                global::System.Diagnostics.Debug.Assert(Property == CalculatorProperty.LastResult);
                 var writer = MethodContext.CreateReplyWriter("v");
                 writer.Write_v_d(value);
                 MethodContext.Reply(writer.CreateMessage());
             }
-            public void ReplyCurrentPath(ObjectPath value)
+            public void ReplyCurrentPath(global::Tmds.DBus.Protocol.ObjectPath value)
             {
-                System.Diagnostics.Debug.Assert(Property == CalculatorProperty.CurrentPath);
+                global::System.Diagnostics.Debug.Assert(Property == CalculatorProperty.CurrentPath);
                 var writer = MethodContext.CreateReplyWriter("v");
                 writer.Write_v_o(value);
                 MethodContext.Reply(writer.CreateMessage());
             }
             public void ReplyCurrentEntry((string, double) value)
             {
-                System.Diagnostics.Debug.Assert(Property == CalculatorProperty.CurrentEntry);
+                global::System.Diagnostics.Debug.Assert(Property == CalculatorProperty.CurrentEntry);
                 var writer = MethodContext.CreateReplyWriter("v");
                 writer.Write_v_rsdz(value);
                 MethodContext.Reply(writer.CreateMessage());
             }
-            public void ReplyIsActive(ValueTuple<bool> value)
+            public void ReplyIsActive(global::System.ValueTuple<bool> value)
             {
-                System.Diagnostics.Debug.Assert(Property == CalculatorProperty.IsActive);
+                global::System.Diagnostics.Debug.Assert(Property == CalculatorProperty.IsActive);
                 var writer = MethodContext.CreateReplyWriter("v");
                 writer.Write_v_rbz(value);
                 MethodContext.Reply(writer.CreateMessage());
@@ -1090,7 +1080,7 @@ namespace HandlerNamespace
             {
                 MethodContext.ReplyError("org.freedesktop.DBus.Error.UnknownProperty", $"Unknown property: {Property}");
             }
-            public ValueTask Handle(ICalculatorProperties properties)
+            public global::System.Threading.Tasks.ValueTask Handle(ICalculatorProperties properties)
             {
                 switch (Property)
                 {
@@ -1113,15 +1103,15 @@ namespace HandlerNamespace
                 return default;
             }
         }
-        readonly struct GetAllPropertiesContext : IDisposable
+        readonly struct GetAllPropertiesContext : global::System.IDisposable
         {
-            public MethodContext MethodContext { get; }
-            public GetAllPropertiesContext(MethodContext methodContext)
+            public global::Tmds.DBus.Protocol.MethodContext MethodContext { get; }
+            public GetAllPropertiesContext(global::Tmds.DBus.Protocol.MethodContext methodContext)
             {
                 MethodContext = methodContext;
             }
             public void Dispose() => MethodContext.Dispose();
-            public ValueTask Handle(ICalculatorProperties properties)
+            public global::System.Threading.Tasks.ValueTask Handle(ICalculatorProperties properties)
             {
                 var writer = MethodContext.CreateReplyWriter("a{sv}");
                 var dictStart = writer.WriteDictionaryStart();
@@ -1141,7 +1131,7 @@ namespace HandlerNamespace
                 MethodContext.Reply(writer.CreateMessage());
                 return default;
             }
-            public ValueTask Handle((string, double)? currentEntry = default, ObjectPath? currentPath = default, ValueTuple<bool>? isActive = default, double? lastResult = default)
+            public global::System.Threading.Tasks.ValueTask Handle((string, double)? currentEntry = default, global::Tmds.DBus.Protocol.ObjectPath? currentPath = default, global::System.ValueTuple<bool>? isActive = default, double? lastResult = default)
             {
                 var writer = MethodContext.CreateReplyWriter("a{sv}");
                 var dictStart = writer.WriteDictionaryStart();
@@ -1155,7 +1145,7 @@ namespace HandlerNamespace
                 {
                     writer.WriteDictionaryEntryStart();
                     writer.WriteString("CurrentPath");
-                    writer.Write_v_o((ObjectPath)currentPath);
+                    writer.Write_v_o((global::Tmds.DBus.Protocol.ObjectPath)currentPath);
                 }
                 if (currentEntry is not null)
                 {
@@ -1167,18 +1157,18 @@ namespace HandlerNamespace
                 {
                     writer.WriteDictionaryEntryStart();
                     writer.WriteString("IsActive");
-                    writer.Write_v_rbz((ValueTuple<bool>)isActive);
+                    writer.Write_v_rbz((global::System.ValueTuple<bool>)isActive);
                 }
                 writer.WriteDictionaryEnd(dictStart);
                 MethodContext.Reply(writer.CreateMessage());
                 return default;
             }
         }
-        readonly struct SetPropertyContext : IDisposable
+        readonly struct SetPropertyContext : global::System.IDisposable
         {
-            public MethodContext MethodContext { get; }
+            public global::Tmds.DBus.Protocol.MethodContext MethodContext { get; }
             public WritableCalculatorProperty Property { get; }
-            public SetPropertyContext(MethodContext methodContext)
+            public SetPropertyContext(global::Tmds.DBus.Protocol.MethodContext methodContext)
             {
                 MethodContext = methodContext;
                 var reader = methodContext.Request.GetBodyReader();
@@ -1186,7 +1176,7 @@ namespace HandlerNamespace
                 Property = (WritableCalculatorProperty)Helper.GetPropertyValue(reader.ReadString());
             }
             public void Dispose() => MethodContext.Dispose();
-            public ValueTuple<bool> ReadIsActive()
+            public global::System.ValueTuple<bool> ReadIsActive()
             {
                 var reader = MethodContext.Request.GetBodyReader();
                 reader.ReadStringAsSpan(); // Skip interface name
@@ -1206,7 +1196,7 @@ namespace HandlerNamespace
             {
                 MethodContext.ReplyError("org.freedesktop.DBus.Error.PropertyReadOnly", $"Property is read-only: {Property}");
             }
-            public ValueTask Handle(ICalculatorProperties properties)
+            public global::System.Threading.Tasks.ValueTask Handle(ICalculatorProperties properties)
             {
                 switch (Property)
                 {
@@ -1227,7 +1217,7 @@ namespace HandlerNamespace
     }
     static class CalculatorSignal
     {
-        public static void EmitReset(this DBusConnection c, ObjectPath p)
+        public static void EmitReset(this global::Tmds.DBus.Protocol.DBusConnection c, global::Tmds.DBus.Protocol.ObjectPath p)
         {
             var writer = c.GetMessageWriter();
             writer.WriteSignalHeader(
@@ -1236,7 +1226,7 @@ namespace HandlerNamespace
                 member: "Reset");
             c.TrySendMessage(writer.CreateMessage());
         }
-        public static void EmitError(this DBusConnection c, ObjectPath p, string message)
+        public static void EmitError(this global::Tmds.DBus.Protocol.DBusConnection c, global::Tmds.DBus.Protocol.ObjectPath p, string message)
         {
             var writer = c.GetMessageWriter();
             writer.WriteSignalHeader(
@@ -1247,7 +1237,7 @@ namespace HandlerNamespace
             writer.WriteString(message);
             c.TrySendMessage(writer.CreateMessage());
         }
-        public static void EmitOperationComplete(this DBusConnection c, ObjectPath p, string operation, double result)
+        public static void EmitOperationComplete(this global::Tmds.DBus.Protocol.DBusConnection c, global::Tmds.DBus.Protocol.ObjectPath p, string operation, double result)
         {
             var writer = c.GetMessageWriter();
             writer.WriteSignalHeader(
@@ -1259,7 +1249,7 @@ namespace HandlerNamespace
             writer.WriteDouble(result);
             c.TrySendMessage(writer.CreateMessage());
         }
-        public static void EmitPropertiesChanged(this DBusConnection c, ObjectPath p, ICalculatorProperties properties, ReadOnlySpan<CalculatorProperty> changed, ReadOnlySpan<CalculatorProperty> invalidated = default)
+        public static void EmitPropertiesChanged(this global::Tmds.DBus.Protocol.DBusConnection c, global::Tmds.DBus.Protocol.ObjectPath p, ICalculatorProperties properties, global::System.ReadOnlySpan<CalculatorProperty> changed, global::System.ReadOnlySpan<CalculatorProperty> invalidated = default)
         {
             var writer = c.GetMessageWriter();
             writer.WriteSignalHeader(
@@ -1296,7 +1286,7 @@ namespace HandlerNamespace
                 }
             }
             writer.WriteDictionaryEnd(dictStart);
-            var arrayStart = writer.WriteArrayStart(DBusType.String);
+            var arrayStart = writer.WriteArrayStart(global::Tmds.DBus.Protocol.DBusType.String);
             foreach (var property in invalidated)
             {
                 switch (property)
@@ -1318,11 +1308,11 @@ namespace HandlerNamespace
             writer.WriteArrayEnd(arrayStart);
             c.TrySendMessage(writer.CreateMessage());
         }
-        public static void EmitPropertyChanged(this DBusConnection c, ObjectPath p, ICalculatorProperties properties, CalculatorProperty changed)
+        public static void EmitPropertyChanged(this global::Tmds.DBus.Protocol.DBusConnection c, global::Tmds.DBus.Protocol.ObjectPath p, ICalculatorProperties properties, CalculatorProperty changed)
         {
             EmitPropertiesChanged(c, p, properties, stackalloc[] { changed }, default);
         }
-        public static void EmitCalculatorPropertiesChanged(this DBusConnection c, ObjectPath p, (string, double)? currentEntry = default, ObjectPath? currentPath = default, ValueTuple<bool>? isActive = default, double? lastResult = default, ReadOnlySpan<CalculatorProperty> invalidated = default)
+        public static void EmitCalculatorPropertiesChanged(this global::Tmds.DBus.Protocol.DBusConnection c, global::Tmds.DBus.Protocol.ObjectPath p, (string, double)? currentEntry = default, global::Tmds.DBus.Protocol.ObjectPath? currentPath = default, global::System.ValueTuple<bool>? isActive = default, double? lastResult = default, global::System.ReadOnlySpan<CalculatorProperty> invalidated = default)
         {
             var writer = c.GetMessageWriter();
             writer.WriteSignalHeader(
@@ -1342,7 +1332,7 @@ namespace HandlerNamespace
             {
                 writer.WriteDictionaryEntryStart();
                 writer.WriteString("CurrentPath");
-                writer.Write_v_o((ObjectPath)currentPath);
+                writer.Write_v_o((global::Tmds.DBus.Protocol.ObjectPath)currentPath);
             }
             if (currentEntry is not null)
             {
@@ -1354,10 +1344,10 @@ namespace HandlerNamespace
             {
                 writer.WriteDictionaryEntryStart();
                 writer.WriteString("IsActive");
-                writer.Write_v_rbz((ValueTuple<bool>)isActive);
+                writer.Write_v_rbz((global::System.ValueTuple<bool>)isActive);
             }
             writer.WriteDictionaryEnd(dictStart);
-            var arrayStart = writer.WriteArrayStart(DBusType.String);
+            var arrayStart = writer.WriteArrayStart(global::Tmds.DBus.Protocol.DBusType.String);
             foreach (var property in invalidated)
             {
                 switch (property)
@@ -1412,40 +1402,40 @@ namespace HandlerNamespace
                     _ => 0
                 };
             }
-            public static DBusHandler.DBusMethod FindMethodHandler(object handler, MethodContext context)
+            public static global::Tmds.DBus.Protocol.DBusHandler.DBusMethod FindMethodHandler(object handler, global::Tmds.DBus.Protocol.MethodContext context)
             {
                 var request = context.Request;
                 if (context.IsPropertiesInterfaceRequest)
                 {
                     return (request.MemberAsString, request.SignatureAsString) switch
                     {
-                        ("Get", "ss") => new DBusHandler.DBusMethod(static (o, c) => ((ISettingsHandler)o).HandleGetPropertyAsync(new GetPropertyContext(c)), handler),
-                        ("GetAll", "s") => new DBusHandler.DBusMethod(static (o, c) => ((ISettingsHandler)o).HandleGetAllPropertiesAsync(new GetAllPropertiesContext(c)), handler),
-                        ("Set", "ssv") => new DBusHandler.DBusMethod(static (o, c) => ((ISettingsHandler)o).HandleSetPropertyAsync(new SetPropertyContext(c)), handler),
+                        ("Get", "ss") => new global::Tmds.DBus.Protocol.DBusHandler.DBusMethod(static (o, c) => ((ISettingsHandler)o).HandleGetPropertyAsync(new GetPropertyContext(c)), handler),
+                        ("GetAll", "s") => new global::Tmds.DBus.Protocol.DBusHandler.DBusMethod(static (o, c) => ((ISettingsHandler)o).HandleGetAllPropertiesAsync(new GetAllPropertiesContext(c)), handler),
+                        ("Set", "ssv") => new global::Tmds.DBus.Protocol.DBusHandler.DBusMethod(static (o, c) => ((ISettingsHandler)o).HandleSetPropertyAsync(new SetPropertyContext(c)), handler),
                         _ => default
                     };
                 }
                 return (request.MemberAsString, request.SignatureAsString) switch
                 {
-                    ("Save", "") => new DBusHandler.DBusMethod(static (o, c) => HandleSaveAsync((ISettingsHandler)o, c), handler),
+                    ("Save", "") => new global::Tmds.DBus.Protocol.DBusHandler.DBusMethod(static (o, c) => HandleSaveAsync((ISettingsHandler)o, c), handler),
                     _ => default
                 };
             }
-            static async ValueTask HandleSaveAsync(ISettingsHandler handler, MethodContext context)
+            static async global::System.Threading.Tasks.ValueTask HandleSaveAsync(ISettingsHandler handler, global::Tmds.DBus.Protocol.MethodContext context)
             {
                 await handler.SaveAsync().ConfigureAwait(false);
                 context.Reply(context.CreateReplyWriter(null).CreateMessage());
             }
         }
-        ValueTask HandleGetPropertyAsync(GetPropertyContext context);
-        ValueTask HandleGetAllPropertiesAsync(GetAllPropertiesContext context);
-        ValueTask HandleSetPropertyAsync(SetPropertyContext context);
-        ValueTask SaveAsync();
-        readonly struct GetPropertyContext : IDisposable
+        global::System.Threading.Tasks.ValueTask HandleGetPropertyAsync(GetPropertyContext context);
+        global::System.Threading.Tasks.ValueTask HandleGetAllPropertiesAsync(GetAllPropertiesContext context);
+        global::System.Threading.Tasks.ValueTask HandleSetPropertyAsync(SetPropertyContext context);
+        global::System.Threading.Tasks.ValueTask SaveAsync();
+        readonly struct GetPropertyContext : global::System.IDisposable
         {
-            public MethodContext MethodContext { get; }
+            public global::Tmds.DBus.Protocol.MethodContext MethodContext { get; }
             public SettingsProperty Property { get; }
-            public GetPropertyContext(MethodContext methodContext)
+            public GetPropertyContext(global::Tmds.DBus.Protocol.MethodContext methodContext)
             {
                 MethodContext = methodContext;
                 var reader = methodContext.Request.GetBodyReader();
@@ -1455,14 +1445,14 @@ namespace HandlerNamespace
             public void Dispose() => MethodContext.Dispose();
             public void ReplyTheme(string value)
             {
-                System.Diagnostics.Debug.Assert(Property == SettingsProperty.Theme);
+                global::System.Diagnostics.Debug.Assert(Property == SettingsProperty.Theme);
                 var writer = MethodContext.CreateReplyWriter("v");
                 writer.Write_v_s(value);
                 MethodContext.Reply(writer.CreateMessage());
             }
             public void ReplyLanguage(string value)
             {
-                System.Diagnostics.Debug.Assert(Property == SettingsProperty.Language);
+                global::System.Diagnostics.Debug.Assert(Property == SettingsProperty.Language);
                 var writer = MethodContext.CreateReplyWriter("v");
                 writer.Write_v_s(value);
                 MethodContext.Reply(writer.CreateMessage());
@@ -1471,7 +1461,7 @@ namespace HandlerNamespace
             {
                 MethodContext.ReplyError("org.freedesktop.DBus.Error.UnknownProperty", $"Unknown property: {Property}");
             }
-            public ValueTask Handle(ISettingsProperties properties)
+            public global::System.Threading.Tasks.ValueTask Handle(ISettingsProperties properties)
             {
                 switch (Property)
                 {
@@ -1488,15 +1478,15 @@ namespace HandlerNamespace
                 return default;
             }
         }
-        readonly struct GetAllPropertiesContext : IDisposable
+        readonly struct GetAllPropertiesContext : global::System.IDisposable
         {
-            public MethodContext MethodContext { get; }
-            public GetAllPropertiesContext(MethodContext methodContext)
+            public global::Tmds.DBus.Protocol.MethodContext MethodContext { get; }
+            public GetAllPropertiesContext(global::Tmds.DBus.Protocol.MethodContext methodContext)
             {
                 MethodContext = methodContext;
             }
             public void Dispose() => MethodContext.Dispose();
-            public ValueTask Handle(ISettingsProperties properties)
+            public global::System.Threading.Tasks.ValueTask Handle(ISettingsProperties properties)
             {
                 var writer = MethodContext.CreateReplyWriter("a{sv}");
                 var dictStart = writer.WriteDictionaryStart();
@@ -1510,7 +1500,7 @@ namespace HandlerNamespace
                 MethodContext.Reply(writer.CreateMessage());
                 return default;
             }
-            public ValueTask Handle(string? language = default, string? theme = default)
+            public global::System.Threading.Tasks.ValueTask Handle(string? language = default, string? theme = default)
             {
                 var writer = MethodContext.CreateReplyWriter("a{sv}");
                 var dictStart = writer.WriteDictionaryStart();
@@ -1531,11 +1521,11 @@ namespace HandlerNamespace
                 return default;
             }
         }
-        readonly struct SetPropertyContext : IDisposable
+        readonly struct SetPropertyContext : global::System.IDisposable
         {
-            public MethodContext MethodContext { get; }
+            public global::Tmds.DBus.Protocol.MethodContext MethodContext { get; }
             public WritableSettingsProperty Property { get; }
-            public SetPropertyContext(MethodContext methodContext)
+            public SetPropertyContext(global::Tmds.DBus.Protocol.MethodContext methodContext)
             {
                 MethodContext = methodContext;
                 var reader = methodContext.Request.GetBodyReader();
@@ -1571,7 +1561,7 @@ namespace HandlerNamespace
             {
                 MethodContext.ReplyError("org.freedesktop.DBus.Error.PropertyReadOnly", $"Property is read-only: {Property}");
             }
-            public ValueTask Handle(ISettingsProperties properties)
+            public global::System.Threading.Tasks.ValueTask Handle(ISettingsProperties properties)
             {
                 switch (Property)
                 {
@@ -1596,7 +1586,7 @@ namespace HandlerNamespace
     }
     static class SettingsSignal
     {
-        public static void EmitChanged(this DBusConnection c, ObjectPath p)
+        public static void EmitChanged(this global::Tmds.DBus.Protocol.DBusConnection c, global::Tmds.DBus.Protocol.ObjectPath p)
         {
             var writer = c.GetMessageWriter();
             writer.WriteSignalHeader(
@@ -1605,7 +1595,7 @@ namespace HandlerNamespace
                 member: "Changed");
             c.TrySendMessage(writer.CreateMessage());
         }
-        public static void EmitPropertiesChanged(this DBusConnection c, ObjectPath p, ISettingsProperties properties, ReadOnlySpan<SettingsProperty> changed, ReadOnlySpan<SettingsProperty> invalidated = default)
+        public static void EmitPropertiesChanged(this global::Tmds.DBus.Protocol.DBusConnection c, global::Tmds.DBus.Protocol.ObjectPath p, ISettingsProperties properties, global::System.ReadOnlySpan<SettingsProperty> changed, global::System.ReadOnlySpan<SettingsProperty> invalidated = default)
         {
             var writer = c.GetMessageWriter();
             writer.WriteSignalHeader(
@@ -1632,7 +1622,7 @@ namespace HandlerNamespace
                 }
             }
             writer.WriteDictionaryEnd(dictStart);
-            var arrayStart = writer.WriteArrayStart(DBusType.String);
+            var arrayStart = writer.WriteArrayStart(global::Tmds.DBus.Protocol.DBusType.String);
             foreach (var property in invalidated)
             {
                 switch (property)
@@ -1648,11 +1638,11 @@ namespace HandlerNamespace
             writer.WriteArrayEnd(arrayStart);
             c.TrySendMessage(writer.CreateMessage());
         }
-        public static void EmitPropertyChanged(this DBusConnection c, ObjectPath p, ISettingsProperties properties, SettingsProperty changed)
+        public static void EmitPropertyChanged(this global::Tmds.DBus.Protocol.DBusConnection c, global::Tmds.DBus.Protocol.ObjectPath p, ISettingsProperties properties, SettingsProperty changed)
         {
             EmitPropertiesChanged(c, p, properties, stackalloc[] { changed }, default);
         }
-        public static void EmitSettingsPropertiesChanged(this DBusConnection c, ObjectPath p, string? language = default, string? theme = default, ReadOnlySpan<SettingsProperty> invalidated = default)
+        public static void EmitSettingsPropertiesChanged(this global::Tmds.DBus.Protocol.DBusConnection c, global::Tmds.DBus.Protocol.ObjectPath p, string? language = default, string? theme = default, global::System.ReadOnlySpan<SettingsProperty> invalidated = default)
         {
             var writer = c.GetMessageWriter();
             writer.WriteSignalHeader(
@@ -1675,7 +1665,7 @@ namespace HandlerNamespace
                 writer.Write_v_s((string)language);
             }
             writer.WriteDictionaryEnd(dictStart);
-            var arrayStart = writer.WriteArrayStart(DBusType.String);
+            var arrayStart = writer.WriteArrayStart(global::Tmds.DBus.Protocol.DBusType.String);
             foreach (var property in invalidated)
             {
                 switch (property)
@@ -1696,7 +1686,7 @@ namespace HandlerNamespace
     {
         internal static class Helper
         {
-            public static DBusHandler.DBusMethod FindMethodHandler(object handler, MethodContext context)
+            public static global::Tmds.DBus.Protocol.DBusHandler.DBusMethod FindMethodHandler(object handler, global::Tmds.DBus.Protocol.MethodContext context)
             {
                 var request = context.Request;
                 return default;
@@ -1705,136 +1695,136 @@ namespace HandlerNamespace
     }
     file static class MessageReader
     {
-        public static double Read_d(Message message)
+        public static double Read_d(global::Tmds.DBus.Protocol.Message message)
         {
             var reader = message.GetBodyReader();
             return reader.ReadDouble();
         }
-        public static (uint, double) Read_ud(Message message)
+        public static (uint, double) Read_ud(global::Tmds.DBus.Protocol.Message message)
         {
             var reader = message.GetBodyReader();
             var arg0 = reader.ReadUInt32();
             var arg1 = reader.ReadDouble();
             return (arg0, arg1);
         }
-        public static (int, int) Read_ii(Message message)
+        public static (int, int) Read_ii(global::Tmds.DBus.Protocol.Message message)
         {
             var reader = message.GetBodyReader();
             var arg0 = reader.ReadInt32();
             var arg1 = reader.ReadInt32();
             return (arg0, arg1);
         }
-        public static (bool, double) Read_bd(Message message)
+        public static (bool, double) Read_bd(global::Tmds.DBus.Protocol.Message message)
         {
             var reader = message.GetBodyReader();
             var arg0 = reader.ReadBool();
             var arg1 = reader.ReadDouble();
             return (arg0, arg1);
         }
-        public static (string, double) Read_rsdz(Message message)
+        public static (string, double) Read_rsdz(global::Tmds.DBus.Protocol.Message message)
         {
             var reader = message.GetBodyReader();
             return reader.Read_rsdz();
         }
-        public static string Read_s(Message message)
+        public static string Read_s(global::Tmds.DBus.Protocol.Message message)
         {
             var reader = message.GetBodyReader();
             return reader.ReadString();
         }
-        public static (string, double) Read_sd(Message message)
+        public static (string, double) Read_sd(global::Tmds.DBus.Protocol.Message message)
         {
             var reader = message.GetBodyReader();
             var arg0 = reader.ReadString();
             var arg1 = reader.ReadDouble();
             return (arg0, arg1);
         }
-        public static double Read_v_d(Message message)
+        public static double Read_v_d(global::Tmds.DBus.Protocol.Message message)
         {
             var reader = message.GetBodyReader();
             reader.ReadSignature("d"u8);
             return reader.ReadDouble();
         }
-        public static ObjectPath Read_v_o(Message message)
+        public static global::Tmds.DBus.Protocol.ObjectPath Read_v_o(global::Tmds.DBus.Protocol.Message message)
         {
             var reader = message.GetBodyReader();
             reader.ReadSignature("o"u8);
             return reader.ReadObjectPath();
         }
-        public static (string, double) Read_v_rsdz(Message message)
+        public static (string, double) Read_v_rsdz(global::Tmds.DBus.Protocol.Message message)
         {
             var reader = message.GetBodyReader();
             reader.ReadSignature("(sd)"u8);
             return reader.Read_rsdz();
         }
-        public static ValueTuple<bool> Read_v_rbz(Message message)
+        public static global::System.ValueTuple<bool> Read_v_rbz(global::Tmds.DBus.Protocol.Message message)
         {
             var reader = message.GetBodyReader();
             reader.ReadSignature("(b)"u8);
             return reader.Read_rbz();
         }
-        public static string Read_v_s(Message message)
+        public static string Read_v_s(global::Tmds.DBus.Protocol.Message message)
         {
             var reader = message.GetBodyReader();
             reader.ReadSignature("s"u8);
             return reader.ReadString();
         }
-        public static int Read_i(Message message)
+        public static int Read_i(global::Tmds.DBus.Protocol.Message message)
         {
             var reader = message.GetBodyReader();
             return reader.ReadInt32();
         }
-        public static (double, double) Read_dd(Message message)
+        public static (double, double) Read_dd(global::Tmds.DBus.Protocol.Message message)
         {
             var reader = message.GetBodyReader();
             var arg0 = reader.ReadDouble();
             var arg1 = reader.ReadDouble();
             return (arg0, arg1);
         }
-        public static (string, double) Read_rsdz(this ref Reader reader)
+        public static (string, double) Read_rsdz(this ref global::Tmds.DBus.Protocol.Reader reader)
         {
             reader.AlignStruct();
             return (reader.ReadString(), reader.ReadDouble());
         }
-        public static ValueTuple<bool> Read_rbz(this ref Reader reader)
+        public static global::System.ValueTuple<bool> Read_rbz(this ref global::Tmds.DBus.Protocol.Reader reader)
         {
             reader.AlignStruct();
-            return new ValueTuple<bool>(reader.ReadBool());
+            return new global::System.ValueTuple<bool>(reader.ReadBool());
         }
     }
     file static class MessageWriterExtensions
     {
-        public static void Write_rsdz(this ref MessageWriter writer, (string, double) value)
+        public static void Write_rsdz(this ref global::Tmds.DBus.Protocol.MessageWriter writer, (string, double) value)
         {
             writer.WriteStructureStart();
             writer.WriteString(value.Item1);
             writer.WriteDouble(value.Item2);
         }
-        public static void Write_rbz(this ref MessageWriter writer, ValueTuple<bool> value)
+        public static void Write_rbz(this ref global::Tmds.DBus.Protocol.MessageWriter writer, global::System.ValueTuple<bool> value)
         {
             writer.WriteStructureStart();
             writer.WriteBool(value.Item1);
         }
-        public static void Write_v_d(this ref MessageWriter writer, double value)
+        public static void Write_v_d(this ref global::Tmds.DBus.Protocol.MessageWriter writer, double value)
         {
             writer.WriteSignature("d");
             writer.WriteDouble(value);
         }
-        public static void Write_v_o(this ref MessageWriter writer, ObjectPath value)
+        public static void Write_v_o(this ref global::Tmds.DBus.Protocol.MessageWriter writer, global::Tmds.DBus.Protocol.ObjectPath value)
         {
             writer.WriteSignature("o");
             writer.WriteObjectPath(value);
         }
-        public static void Write_v_rsdz(this ref MessageWriter writer, (string, double) value)
+        public static void Write_v_rsdz(this ref global::Tmds.DBus.Protocol.MessageWriter writer, (string, double) value)
         {
             writer.WriteSignature("(sd)");
             writer.Write_rsdz(value);
         }
-        public static void Write_v_rbz(this ref MessageWriter writer, ValueTuple<bool> value)
+        public static void Write_v_rbz(this ref global::Tmds.DBus.Protocol.MessageWriter writer, global::System.ValueTuple<bool> value)
         {
             writer.WriteSignature("(b)");
             writer.Write_rbz(value);
         }
-        public static void Write_v_s(this ref MessageWriter writer, string value)
+        public static void Write_v_s(this ref global::Tmds.DBus.Protocol.MessageWriter writer, string value)
         {
             writer.WriteSignature("s");
             writer.WriteString(value);
@@ -1847,14 +1837,10 @@ namespace HandlerNamespace
 #nullable enable
 namespace Tmds.DBus.Protocol
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Threading;
-    using System.Threading.Tasks;
     abstract class DBusHandler : IPathMethodHandler
     {
         // Identifies the D-Bus interfaces. Used with SupportsInterface to filter interfaces per path.
-        [Flags]
+        [global::System.Flags]
         public enum DBusInterface
         {
             // OrgFreedesktopDBusIntrospectable = 1,
@@ -1862,7 +1848,7 @@ namespace Tmds.DBus.Protocol
             OrgExampleMarker = 4,
             OrgExampleSettings = 8,
         }
-        private static ReadOnlyMemory<byte> OrgExampleCalculatorXml { get; } =
+        private static global::System.ReadOnlyMemory<byte> OrgExampleCalculatorXml { get; } =
             """
             <interface name="org.example.Calculator">
               <method name="Clear" />
@@ -1922,12 +1908,12 @@ namespace Tmds.DBus.Protocol
             </interface>
 
             """u8.ToArray();
-        private static ReadOnlyMemory<byte> OrgExampleMarkerXml { get; } =
+        private static global::System.ReadOnlyMemory<byte> OrgExampleMarkerXml { get; } =
             """
             <interface name="org.example.Marker" />
 
             """u8.ToArray();
-        private static ReadOnlyMemory<byte> OrgExampleSettingsXml { get; } =
+        private static global::System.ReadOnlyMemory<byte> OrgExampleSettingsXml { get; } =
             """
             <interface name="org.example.Settings">
               <method name="Save" />
@@ -1938,19 +1924,19 @@ namespace Tmds.DBus.Protocol
             </interface>
 
             """u8.ToArray();
-        private readonly SendOrPostCallback? _postDelegate;
+        private readonly global::System.Threading.SendOrPostCallback? _postDelegate;
         private const DBusInterface OrgFreedesktopDBusIntrospectable = (DBusInterface)1;
         private const DBusInterface InterfacesWithProperties = DBusInterface.OrgExampleCalculator | DBusInterface.OrgExampleSettings;
         public string Path { get; }
         public bool HandlesChildPaths { get; }
         public DBusConnection Connection { get; }
         // The SynchronizationContext on which method handlers are invoked.
-        protected SynchronizationContext? SynchronizationContext { get; }
+        protected global::System.Threading.SynchronizationContext? SynchronizationContext { get; }
         protected DBusHandler(DBusConnection connection, string path, bool handlesChildPaths, bool handleOnCapturedContext = true)
-            : this(connection, path, handlesChildPaths, handleOnCapturedContext ? SynchronizationContext.Current : null)
+            : this(connection, path, handlesChildPaths, handleOnCapturedContext ? global::System.Threading.SynchronizationContext.Current : null)
         {
         }
-        protected DBusHandler(DBusConnection connection, string path, bool handlesChildPaths, SynchronizationContext? synchronizationContext)
+        protected DBusHandler(DBusConnection connection, string path, bool handlesChildPaths, global::System.Threading.SynchronizationContext? synchronizationContext)
         {
             Connection = connection;
             Path = path;
@@ -1968,19 +1954,19 @@ namespace Tmds.DBus.Protocol
             }
         }
         // Override to add cross-cutting logic (e.g. logging, error handling) around method invocations.
-        protected virtual async ValueTask InvokeAsync(DBusMethod method, MethodContext context)
+        protected virtual async global::System.Threading.Tasks.ValueTask InvokeAsync(DBusMethod method, MethodContext context)
         {
             try
             {
                 await method.Invoke(context).ConfigureAwait(false);
             }
-            catch (Exception ex)
+            catch (global::System.Exception ex)
             {
                 HandleException(context, ex);
             }
         }
         // Override to customize exception handling for method invocations.
-        protected virtual void HandleException(MethodContext context, Exception ex)
+        protected virtual void HandleException(MethodContext context, global::System.Exception ex)
         {
             if (context.HandleException(ex, shouldDisconnect: false))
             {
@@ -1990,7 +1976,7 @@ namespace Tmds.DBus.Protocol
             {
                 context.ReplyError(dbusEx.ErrorName, dbusEx.ErrorMessage);
             }
-            else if (ex is ArgumentException)
+            else if (ex is global::System.ArgumentException)
             {
                 context.ReplyError("org.freedesktop.DBus.Error.InvalidArgs", ex.Message);
             }
@@ -2000,19 +1986,19 @@ namespace Tmds.DBus.Protocol
             }
         }
         // Override to filter interfaces for specific paths when the handler manages multiple paths.
-        protected virtual bool SupportsInterface(DBusInterface dbusInterface, ReadOnlySpan<char> path)
+        protected virtual bool SupportsInterface(DBusInterface dbusInterface, global::System.ReadOnlySpan<char> path)
         {
             return true;
         }
         // Override to customize introspection, e.g. to include child node names.
-        protected virtual ValueTask HandleIntrospectAsync(IntrospectContext context)
+        protected virtual global::System.Threading.Tasks.ValueTask HandleIntrospectAsync(IntrospectContext context)
         {
-            DBusInterface interfaces = GetSupportedInterfaces(context.MethodContext.Request.PathAsString.AsSpan());
+            DBusInterface interfaces = GetSupportedInterfaces(global::System.MemoryExtensions.AsSpan(context.MethodContext.Request.PathAsString));
             context.Reply(interfaces);
             return default;
         }
         // Context for IntrospectAsync. Call Reply to send the introspection XML response.
-        protected readonly struct IntrospectContext : IDisposable
+        protected readonly struct IntrospectContext : global::System.IDisposable
         {
             public MethodContext MethodContext { get; }
             public IntrospectContext(MethodContext methodContext)
@@ -2020,9 +2006,9 @@ namespace Tmds.DBus.Protocol
                 MethodContext = methodContext;
             }
             public void Dispose() => MethodContext.Dispose();
-            public void Reply(DBusInterface interfaces, IList<string>? childNames = null)
+            public void Reply(DBusInterface interfaces, global::System.Collections.Generic.IList<string>? childNames = null)
             {
-                var interfaceXmls = new ReadOnlyMemory<byte>[4];
+                var interfaceXmls = new global::System.ReadOnlyMemory<byte>[4];
                 int count = 0;
                 if ((interfaces & DBusInterface.OrgExampleCalculator) != 0)
                 {
@@ -2042,42 +2028,42 @@ namespace Tmds.DBus.Protocol
                 }
                 if (childNames is not null)
                 {
-                    MethodContext.ReplyIntrospectXml(interfaceXmls.AsSpan(0, count), childNames);
+                    MethodContext.ReplyIntrospectXml(global::System.MemoryExtensions.AsSpan(interfaceXmls, 0, count), childNames);
                 }
                 else
                 {
-                    MethodContext.ReplyIntrospectXml(interfaceXmls.AsSpan(0, count));
+                    MethodContext.ReplyIntrospectXml(global::System.MemoryExtensions.AsSpan(interfaceXmls, 0, count));
                 }
             }
         }
         internal readonly struct DBusMethod
         {
-            private readonly Func<object, MethodContext, ValueTask> _method;
+            private readonly global::System.Func<object, MethodContext, global::System.Threading.Tasks.ValueTask> _method;
             private readonly object _target;
-            public DBusMethod(Func<object, MethodContext, ValueTask> method, object target)
+            public DBusMethod(global::System.Func<object, MethodContext, global::System.Threading.Tasks.ValueTask> method, object target)
             {
                 _method = method;
                 _target = target;
             }
             public bool HasValue => _method is not null;
-            public ValueTask Invoke(MethodContext context)
+            public global::System.Threading.Tasks.ValueTask Invoke(MethodContext context)
             {
                 return _method?.Invoke(_target, context) ?? default;
             }
         }
-        ValueTask IPathMethodHandler.HandleMethodAsync(MethodContext context)
+        global::System.Threading.Tasks.ValueTask IPathMethodHandler.HandleMethodAsync(MethodContext context)
         {
             DBusInterface dbusInterface = ParseInterface(context);
-            DBusMethod method = (dbusInterface != OrgFreedesktopDBusIntrospectable && !SupportsInterface(dbusInterface, context.Request.PathAsString.AsSpan())) ? default : FindMethodHandler(context, dbusInterface);
+            DBusMethod method = (dbusInterface != OrgFreedesktopDBusIntrospectable && !SupportsInterface(dbusInterface, global::System.MemoryExtensions.AsSpan(context.Request.PathAsString))) ? default : FindMethodHandler(context, dbusInterface);
             if (!method.HasValue)
             {
                 return default;
             }
             return HandleAsync(method, context);
         }
-        private ValueTask HandleAsync(DBusMethod method, MethodContext context)
+        private global::System.Threading.Tasks.ValueTask HandleAsync(DBusMethod method, MethodContext context)
         {
-            SynchronizationContext? synchronizationContext = SynchronizationContext;
+            global::System.Threading.SynchronizationContext? synchronizationContext = SynchronizationContext;
             if (synchronizationContext is null)
             {
                 return InvokeAsync(method, context);
@@ -2089,7 +2075,7 @@ namespace Tmds.DBus.Protocol
                 return default;
             }
         }
-        private async ValueTask InvokeAndDisposeAsync(DBusMethod method, MethodContext context)
+        private async global::System.Threading.Tasks.ValueTask InvokeAndDisposeAsync(DBusMethod method, MethodContext context)
         {
             try
             {
@@ -2150,7 +2136,7 @@ namespace Tmds.DBus.Protocol
             };
             return result;
         }
-        protected DBusInterface GetSupportedInterfaces(ReadOnlySpan<char> path)
+        protected DBusInterface GetSupportedInterfaces(global::System.ReadOnlySpan<char> path)
         {
             DBusInterface interfaces = default;
             if (SupportsInterface(DBusInterface.OrgExampleCalculator, path) && this is HandlerNamespace.ICalculatorHandler)

--- a/test/Tmds.DBus.Generator.Tests/CodeGenerationTests.VerifyGeneratedOutput_ProxyAndHandlerSameNamespace.verified.txt
+++ b/test/Tmds.DBus.Generator.Tests/CodeGenerationTests.VerifyGeneratedOutput_ProxyAndHandlerSameNamespace.verified.txt
@@ -3,11 +3,6 @@
 #nullable enable
 namespace TestNamespace
 {
-    using System;
-    using Tmds.DBus.Protocol;
-    using System.Collections.Generic;
-    using System.Threading.Tasks;
-    using System.Runtime.CompilerServices;
     enum CalculatorProperty
     {
         UnknownProperty = 0,
@@ -19,9 +14,9 @@ namespace TestNamespace
     interface ICalculatorProperties
     {
         double LastResult { get; }
-        ObjectPath CurrentPath { get; }
+        global::Tmds.DBus.Protocol.ObjectPath CurrentPath { get; }
         (string, double) CurrentEntry { get; }
-        ValueTuple<bool> IsActive { get; set; }
+        global::System.ValueTuple<bool> IsActive { get; set; }
     }
     enum WritableCalculatorProperty
     {
@@ -31,9 +26,9 @@ namespace TestNamespace
     interface INullableCalculatorProperties
     {
         double? LastResult { get; }
-        ObjectPath? CurrentPath { get; }
+        global::Tmds.DBus.Protocol.ObjectPath? CurrentPath { get; }
         (string, double)? CurrentEntry { get; }
-        ValueTuple<bool>? IsActive { get; }
+        global::System.ValueTuple<bool>? IsActive { get; }
         bool AreAllPropertiesSet();
         CalculatorProperties EnsureAllPropertiesSet();
     }
@@ -52,14 +47,14 @@ namespace TestNamespace
         private static uint Flag(CalculatorProperty property) => property == 0 ? 0 : 1U << ((int)property - 1);
         public CalculatorProperties() { }
         #nullable disable
-        [System.Diagnostics.CodeAnalysis.SetsRequiredMembers]
+        [global::System.Diagnostics.CodeAnalysis.SetsRequiredMembers]
         private CalculatorProperties(bool _) { }
         #nullable enable
         private void EnsureSet(CalculatorProperty property)
         {
             if (!HasFlag(__set, property))
             {
-                throw new InvalidOperationException("Property is not set.");
+                throw new global::System.InvalidOperationException("Property is not set.");
             }
         }
         private double _lastResult = default!;
@@ -68,8 +63,8 @@ namespace TestNamespace
             get { EnsureSet(CalculatorProperty.LastResult); return _lastResult; }
             set { _lastResult = value; __set |= Flag(CalculatorProperty.LastResult); }
         }
-        private ObjectPath _currentPath = default!;
-        public required ObjectPath CurrentPath
+        private global::Tmds.DBus.Protocol.ObjectPath _currentPath = default!;
+        public required global::Tmds.DBus.Protocol.ObjectPath CurrentPath
         {
             get { EnsureSet(CalculatorProperty.CurrentPath); return _currentPath; }
             set { _currentPath = value; __set |= Flag(CalculatorProperty.CurrentPath); }
@@ -80,20 +75,20 @@ namespace TestNamespace
             get { EnsureSet(CalculatorProperty.CurrentEntry); return _currentEntry; }
             set { _currentEntry = value; __set |= Flag(CalculatorProperty.CurrentEntry); }
         }
-        private ValueTuple<bool> _isActive = default!;
-        public required ValueTuple<bool> IsActive
+        private global::System.ValueTuple<bool> _isActive = default!;
+        public required global::System.ValueTuple<bool> IsActive
         {
             get { EnsureSet(CalculatorProperty.IsActive); return _isActive; }
             set { _isActive = value; __set |= Flag(CalculatorProperty.IsActive); }
         }
         double? INullableCalculatorProperties.LastResult
             => IsSet(CalculatorProperty.LastResult) ? _lastResult : default(double?);
-        ObjectPath? INullableCalculatorProperties.CurrentPath
-            => IsSet(CalculatorProperty.CurrentPath) ? _currentPath : default(ObjectPath?);
+        global::Tmds.DBus.Protocol.ObjectPath? INullableCalculatorProperties.CurrentPath
+            => IsSet(CalculatorProperty.CurrentPath) ? _currentPath : default(global::Tmds.DBus.Protocol.ObjectPath?);
         (string, double)? INullableCalculatorProperties.CurrentEntry
             => IsSet(CalculatorProperty.CurrentEntry) ? _currentEntry : default((string, double)?);
-        ValueTuple<bool>? INullableCalculatorProperties.IsActive
-            => IsSet(CalculatorProperty.IsActive) ? _isActive : default(ValueTuple<bool>?);
+        global::System.ValueTuple<bool>? INullableCalculatorProperties.IsActive
+            => IsSet(CalculatorProperty.IsActive) ? _isActive : default(global::System.ValueTuple<bool>?);
         bool IChangedCalculatorProperties.HasLastResultChanged
             => IsSet(CalculatorProperty.LastResult) || IsInvalidated(CalculatorProperty.LastResult);
         bool IChangedCalculatorProperties.HasCurrentPathChanged
@@ -124,13 +119,13 @@ namespace TestNamespace
         {
             if (!AreAllPropertiesSet())
             {
-                throw new DBusUnexpectedValueException($"Not all properties have been set (0x{__set:x}).");
+                throw new global::Tmds.DBus.Protocol.DBusUnexpectedValueException($"Not all properties have been set (0x{__set:x}).");
             }
         }
-        public static CalculatorProperties ReadFrom(ref Reader reader, bool withInvalidated)
+        public static CalculatorProperties ReadFrom(ref global::Tmds.DBus.Protocol.Reader reader, bool withInvalidated)
         {
             var props = CreateUninitialized();
-            ArrayEnd arrayEnd = reader.ReadArrayStart(DBusType.Struct);
+            global::Tmds.DBus.Protocol.ArrayEnd arrayEnd = reader.ReadArrayStart(global::Tmds.DBus.Protocol.DBusType.Struct);
             while (reader.HasNext(arrayEnd))
             {
                 var property = reader.ReadString();
@@ -159,7 +154,7 @@ namespace TestNamespace
             }
             if (withInvalidated)
             {
-                ArrayEnd invalidatedEnd = reader.ReadArrayStart(DBusType.String);
+                global::Tmds.DBus.Protocol.ArrayEnd invalidatedEnd = reader.ReadArrayStart(global::Tmds.DBus.Protocol.DBusType.String);
                 while (reader.HasNext(invalidatedEnd))
                 {
                     var propertyName = reader.ReadString();
@@ -176,16 +171,16 @@ namespace TestNamespace
             return props;
         }
     }
-    sealed partial class Calculator : Tmds.DBus.Protocol.DBusObject
+    sealed partial class Calculator : global::Tmds.DBus.Protocol.DBusObject
     {
         public const string DBusInterfaceName = "org.example.Calculator";
-        public Calculator(Tmds.DBus.Protocol.DBusConnection connection, string destination, ObjectPath path)
+        public Calculator(global::Tmds.DBus.Protocol.DBusConnection connection, string destination, global::Tmds.DBus.Protocol.ObjectPath path)
             : base(connection, destination, path)
         { }
-        public Task ClearAsync()
+        public global::System.Threading.Tasks.Task ClearAsync()
         {
             return Connection.CallMethodAsync(CreateMessage());
-            MessageBuffer CreateMessage()
+            global::Tmds.DBus.Protocol.MessageBuffer CreateMessage()
             {
                 var writer = Connection.GetMessageWriter();
                 writer.WriteMethodCallHeader(
@@ -196,10 +191,10 @@ namespace TestNamespace
                 return writer.CreateMessage();
             }
         }
-        public Task<double> GetResultAsync()
+        public global::System.Threading.Tasks.Task<double> GetResultAsync()
         {
-            return Connection.CallMethodAsync(CreateMessage(), (Message m, object? s) => MessageReader.Read_d(m), this);
-            MessageBuffer CreateMessage()
+            return Connection.CallMethodAsync(CreateMessage(), (global::Tmds.DBus.Protocol.Message m, object? s) => MessageReader.Read_d(m), this);
+            global::Tmds.DBus.Protocol.MessageBuffer CreateMessage()
             {
                 var writer = Connection.GetMessageWriter();
                 writer.WriteMethodCallHeader(
@@ -210,10 +205,10 @@ namespace TestNamespace
                 return writer.CreateMessage();
             }
         }
-        public Task<(uint Count, double Total)> GetStatsAsync()
+        public global::System.Threading.Tasks.Task<(uint Count, double Total)> GetStatsAsync()
         {
-            return Connection.CallMethodAsync(CreateMessage(), (Message m, object? s) => MessageReader.Read_ud(m), this);
-            MessageBuffer CreateMessage()
+            return Connection.CallMethodAsync(CreateMessage(), (global::Tmds.DBus.Protocol.Message m, object? s) => MessageReader.Read_ud(m), this);
+            global::Tmds.DBus.Protocol.MessageBuffer CreateMessage()
             {
                 var writer = Connection.GetMessageWriter();
                 writer.WriteMethodCallHeader(
@@ -224,10 +219,10 @@ namespace TestNamespace
                 return writer.CreateMessage();
             }
         }
-        public Task StoreAsync(double value)
+        public global::System.Threading.Tasks.Task StoreAsync(double value)
         {
             return Connection.CallMethodAsync(CreateMessage());
-            MessageBuffer CreateMessage()
+            global::Tmds.DBus.Protocol.MessageBuffer CreateMessage()
             {
                 var writer = Connection.GetMessageWriter();
                 writer.WriteMethodCallHeader(
@@ -240,10 +235,10 @@ namespace TestNamespace
                 return writer.CreateMessage();
             }
         }
-        public Task<double> SquareAsync(double input)
+        public global::System.Threading.Tasks.Task<double> SquareAsync(double input)
         {
-            return Connection.CallMethodAsync(CreateMessage(), (Message m, object? s) => MessageReader.Read_d(m), this);
-            MessageBuffer CreateMessage()
+            return Connection.CallMethodAsync(CreateMessage(), (global::Tmds.DBus.Protocol.Message m, object? s) => MessageReader.Read_d(m), this);
+            global::Tmds.DBus.Protocol.MessageBuffer CreateMessage()
             {
                 var writer = Connection.GetMessageWriter();
                 writer.WriteMethodCallHeader(
@@ -256,10 +251,10 @@ namespace TestNamespace
                 return writer.CreateMessage();
             }
         }
-        public Task<(int Quotient, int Remainder)> DivModAsync(int dividend)
+        public global::System.Threading.Tasks.Task<(int Quotient, int Remainder)> DivModAsync(int dividend)
         {
-            return Connection.CallMethodAsync(CreateMessage(), (Message m, object? s) => MessageReader.Read_ii(m), this);
-            MessageBuffer CreateMessage()
+            return Connection.CallMethodAsync(CreateMessage(), (global::Tmds.DBus.Protocol.Message m, object? s) => MessageReader.Read_ii(m), this);
+            global::Tmds.DBus.Protocol.MessageBuffer CreateMessage()
             {
                 var writer = Connection.GetMessageWriter();
                 writer.WriteMethodCallHeader(
@@ -272,10 +267,10 @@ namespace TestNamespace
                 return writer.CreateMessage();
             }
         }
-        public Task LogOperationAsync(string operation, double value)
+        public global::System.Threading.Tasks.Task LogOperationAsync(string operation, double value)
         {
             return Connection.CallMethodAsync(CreateMessage());
-            MessageBuffer CreateMessage()
+            global::Tmds.DBus.Protocol.MessageBuffer CreateMessage()
             {
                 var writer = Connection.GetMessageWriter();
                 writer.WriteMethodCallHeader(
@@ -289,10 +284,10 @@ namespace TestNamespace
                 return writer.CreateMessage();
             }
         }
-        public Task<double> AddAsync(double a, double b)
+        public global::System.Threading.Tasks.Task<double> AddAsync(double a, double b)
         {
-            return Connection.CallMethodAsync(CreateMessage(), (Message m, object? s) => MessageReader.Read_d(m), this);
-            MessageBuffer CreateMessage()
+            return Connection.CallMethodAsync(CreateMessage(), (global::Tmds.DBus.Protocol.Message m, object? s) => MessageReader.Read_d(m), this);
+            global::Tmds.DBus.Protocol.MessageBuffer CreateMessage()
             {
                 var writer = Connection.GetMessageWriter();
                 writer.WriteMethodCallHeader(
@@ -306,10 +301,10 @@ namespace TestNamespace
                 return writer.CreateMessage();
             }
         }
-        public Task<(bool Equal, double Difference)> CompareAsync(double a, double b)
+        public global::System.Threading.Tasks.Task<(bool Equal, double Difference)> CompareAsync(double a, double b)
         {
-            return Connection.CallMethodAsync(CreateMessage(), (Message m, object? s) => MessageReader.Read_bd(m), this);
-            MessageBuffer CreateMessage()
+            return Connection.CallMethodAsync(CreateMessage(), (global::Tmds.DBus.Protocol.Message m, object? s) => MessageReader.Read_bd(m), this);
+            global::Tmds.DBus.Protocol.MessageBuffer CreateMessage()
             {
                 var writer = Connection.GetMessageWriter();
                 writer.WriteMethodCallHeader(
@@ -323,10 +318,10 @@ namespace TestNamespace
                 return writer.CreateMessage();
             }
         }
-        public Task<(string, double)> GetEntryAsync(string key)
+        public global::System.Threading.Tasks.Task<(string, double)> GetEntryAsync(string key)
         {
-            return Connection.CallMethodAsync(CreateMessage(), (Message m, object? s) => MessageReader.Read_rsdz(m), this);
-            MessageBuffer CreateMessage()
+            return Connection.CallMethodAsync(CreateMessage(), (global::Tmds.DBus.Protocol.Message m, object? s) => MessageReader.Read_rsdz(m), this);
+            global::Tmds.DBus.Protocol.MessageBuffer CreateMessage()
             {
                 var writer = Connection.GetMessageWriter();
                 writer.WriteMethodCallHeader(
@@ -339,10 +334,10 @@ namespace TestNamespace
                 return writer.CreateMessage();
             }
         }
-        public Task SetEntryAsync((string, double) entry)
+        public global::System.Threading.Tasks.Task SetEntryAsync((string, double) entry)
         {
             return Connection.CallMethodAsync(CreateMessage());
-            MessageBuffer CreateMessage()
+            global::Tmds.DBus.Protocol.MessageBuffer CreateMessage()
             {
                 var writer = Connection.GetMessageWriter();
                 writer.WriteMethodCallHeader(
@@ -355,34 +350,34 @@ namespace TestNamespace
                 return writer.CreateMessage();
             }
         }
-        public ValueTask<IDisposable> WatchResetAsync(Action handler, bool emitOnCapturedContext = true)
-            => WatchResetAsync(static (Notification n) => ((Action)n.State!)(), ObserverFlags.None, emitOnCapturedContext, handler);
-        public ValueTask<IDisposable> WatchResetAsync(Func<ValueTask> handler, bool emitOnCapturedContext = true)
-            => WatchResetAsync(static (Notification n) => ((Func<ValueTask>)n.State!)(), ObserverFlags.None, emitOnCapturedContext, handler);
-        public ValueTask<IDisposable> WatchResetAsync(Action<Notification> handler, ObserverFlags flags, bool emitOnCapturedContext = true, object? state = null)
+        public global::System.Threading.Tasks.ValueTask<global::System.IDisposable> WatchResetAsync(global::System.Action handler, bool emitOnCapturedContext = true)
+            => WatchResetAsync(static (global::Tmds.DBus.Protocol.Notification n) => ((global::System.Action)n.State!)(), global::Tmds.DBus.Protocol.ObserverFlags.None, emitOnCapturedContext, handler);
+        public global::System.Threading.Tasks.ValueTask<global::System.IDisposable> WatchResetAsync(global::System.Func<global::System.Threading.Tasks.ValueTask> handler, bool emitOnCapturedContext = true)
+            => WatchResetAsync(static (global::Tmds.DBus.Protocol.Notification n) => ((global::System.Func<global::System.Threading.Tasks.ValueTask>)n.State!)(), global::Tmds.DBus.Protocol.ObserverFlags.None, emitOnCapturedContext, handler);
+        public global::System.Threading.Tasks.ValueTask<global::System.IDisposable> WatchResetAsync(global::System.Action<global::Tmds.DBus.Protocol.Notification> handler, global::Tmds.DBus.Protocol.ObserverFlags flags, bool emitOnCapturedContext = true, object? state = null)
             => Connection.WatchSignalAsync(Destination, Path, DBusInterfaceName, "Reset", handler, flags, emitOnCapturedContext, state);
-        public ValueTask<IDisposable> WatchResetAsync(Func<Notification, ValueTask> handler, ObserverFlags flags, bool emitOnCapturedContext = true, object? state = null)
+        public global::System.Threading.Tasks.ValueTask<global::System.IDisposable> WatchResetAsync(global::System.Func<global::Tmds.DBus.Protocol.Notification, global::System.Threading.Tasks.ValueTask> handler, global::Tmds.DBus.Protocol.ObserverFlags flags, bool emitOnCapturedContext = true, object? state = null)
             => Connection.WatchSignalAsync(Destination, Path, DBusInterfaceName, "Reset", handler, flags, emitOnCapturedContext, state);
-        public ValueTask<IDisposable> WatchErrorAsync(Action<string> handler, bool emitOnCapturedContext = true)
-            => WatchErrorAsync(static (Notification<string> n) => ((Action<string>)n.State!)(n.Value), ObserverFlags.None, emitOnCapturedContext, handler);
-        public ValueTask<IDisposable> WatchErrorAsync(Func<string, ValueTask> handler, bool emitOnCapturedContext = true)
-            => WatchErrorAsync(static (Notification<string> n) => ((Func<string, ValueTask>)n.State!)(n.Value), ObserverFlags.None, emitOnCapturedContext, handler);
-        public ValueTask<IDisposable> WatchErrorAsync(Action<Notification<string>> handler, ObserverFlags flags, bool emitOnCapturedContext = true, object? state = null)
-            => Connection.WatchSignalAsync(Destination, Path, DBusInterfaceName, "Error", (Message m, object? s) => MessageReader.Read_s(m), handler, flags, emitOnCapturedContext, state);
-        public ValueTask<IDisposable> WatchErrorAsync(Func<Notification<string>, ValueTask> handler, ObserverFlags flags, bool emitOnCapturedContext = true, object? state = null)
-            => Connection.WatchSignalAsync(Destination, Path, DBusInterfaceName, "Error", (Message m, object? s) => MessageReader.Read_s(m), handler, flags, emitOnCapturedContext, state);
-        public ValueTask<IDisposable> WatchOperationCompleteAsync(Action<(string Operation, double Result)> handler, bool emitOnCapturedContext = true)
-            => WatchOperationCompleteAsync(static (Notification<(string Operation, double Result)> n) => ((Action<(string Operation, double Result)>)n.State!)(n.Value), ObserverFlags.None, emitOnCapturedContext, handler);
-        public ValueTask<IDisposable> WatchOperationCompleteAsync(Func<(string Operation, double Result), ValueTask> handler, bool emitOnCapturedContext = true)
-            => WatchOperationCompleteAsync(static (Notification<(string Operation, double Result)> n) => ((Func<(string Operation, double Result), ValueTask>)n.State!)(n.Value), ObserverFlags.None, emitOnCapturedContext, handler);
-        public ValueTask<IDisposable> WatchOperationCompleteAsync(Action<Notification<(string Operation, double Result)>> handler, ObserverFlags flags, bool emitOnCapturedContext = true, object? state = null)
-            => Connection.WatchSignalAsync(Destination, Path, DBusInterfaceName, "OperationComplete", (Message m, object? s) => MessageReader.Read_sd(m), handler, flags, emitOnCapturedContext, state);
-        public ValueTask<IDisposable> WatchOperationCompleteAsync(Func<Notification<(string Operation, double Result)>, ValueTask> handler, ObserverFlags flags, bool emitOnCapturedContext = true, object? state = null)
-            => Connection.WatchSignalAsync(Destination, Path, DBusInterfaceName, "OperationComplete", (Message m, object? s) => MessageReader.Read_sd(m), handler, flags, emitOnCapturedContext, state);
-        public Task SetIsActiveAsync(ValueTuple<bool> value)
+        public global::System.Threading.Tasks.ValueTask<global::System.IDisposable> WatchErrorAsync(global::System.Action<string> handler, bool emitOnCapturedContext = true)
+            => WatchErrorAsync(static (global::Tmds.DBus.Protocol.Notification<string> n) => ((global::System.Action<string>)n.State!)(n.Value), global::Tmds.DBus.Protocol.ObserverFlags.None, emitOnCapturedContext, handler);
+        public global::System.Threading.Tasks.ValueTask<global::System.IDisposable> WatchErrorAsync(global::System.Func<string, global::System.Threading.Tasks.ValueTask> handler, bool emitOnCapturedContext = true)
+            => WatchErrorAsync(static (global::Tmds.DBus.Protocol.Notification<string> n) => ((global::System.Func<string, global::System.Threading.Tasks.ValueTask>)n.State!)(n.Value), global::Tmds.DBus.Protocol.ObserverFlags.None, emitOnCapturedContext, handler);
+        public global::System.Threading.Tasks.ValueTask<global::System.IDisposable> WatchErrorAsync(global::System.Action<global::Tmds.DBus.Protocol.Notification<string>> handler, global::Tmds.DBus.Protocol.ObserverFlags flags, bool emitOnCapturedContext = true, object? state = null)
+            => Connection.WatchSignalAsync(Destination, Path, DBusInterfaceName, "Error", (global::Tmds.DBus.Protocol.Message m, object? s) => MessageReader.Read_s(m), handler, flags, emitOnCapturedContext, state);
+        public global::System.Threading.Tasks.ValueTask<global::System.IDisposable> WatchErrorAsync(global::System.Func<global::Tmds.DBus.Protocol.Notification<string>, global::System.Threading.Tasks.ValueTask> handler, global::Tmds.DBus.Protocol.ObserverFlags flags, bool emitOnCapturedContext = true, object? state = null)
+            => Connection.WatchSignalAsync(Destination, Path, DBusInterfaceName, "Error", (global::Tmds.DBus.Protocol.Message m, object? s) => MessageReader.Read_s(m), handler, flags, emitOnCapturedContext, state);
+        public global::System.Threading.Tasks.ValueTask<global::System.IDisposable> WatchOperationCompleteAsync(global::System.Action<(string Operation, double Result)> handler, bool emitOnCapturedContext = true)
+            => WatchOperationCompleteAsync(static (global::Tmds.DBus.Protocol.Notification<(string Operation, double Result)> n) => ((global::System.Action<(string Operation, double Result)>)n.State!)(n.Value), global::Tmds.DBus.Protocol.ObserverFlags.None, emitOnCapturedContext, handler);
+        public global::System.Threading.Tasks.ValueTask<global::System.IDisposable> WatchOperationCompleteAsync(global::System.Func<(string Operation, double Result), global::System.Threading.Tasks.ValueTask> handler, bool emitOnCapturedContext = true)
+            => WatchOperationCompleteAsync(static (global::Tmds.DBus.Protocol.Notification<(string Operation, double Result)> n) => ((global::System.Func<(string Operation, double Result), global::System.Threading.Tasks.ValueTask>)n.State!)(n.Value), global::Tmds.DBus.Protocol.ObserverFlags.None, emitOnCapturedContext, handler);
+        public global::System.Threading.Tasks.ValueTask<global::System.IDisposable> WatchOperationCompleteAsync(global::System.Action<global::Tmds.DBus.Protocol.Notification<(string Operation, double Result)>> handler, global::Tmds.DBus.Protocol.ObserverFlags flags, bool emitOnCapturedContext = true, object? state = null)
+            => Connection.WatchSignalAsync(Destination, Path, DBusInterfaceName, "OperationComplete", (global::Tmds.DBus.Protocol.Message m, object? s) => MessageReader.Read_sd(m), handler, flags, emitOnCapturedContext, state);
+        public global::System.Threading.Tasks.ValueTask<global::System.IDisposable> WatchOperationCompleteAsync(global::System.Func<global::Tmds.DBus.Protocol.Notification<(string Operation, double Result)>, global::System.Threading.Tasks.ValueTask> handler, global::Tmds.DBus.Protocol.ObserverFlags flags, bool emitOnCapturedContext = true, object? state = null)
+            => Connection.WatchSignalAsync(Destination, Path, DBusInterfaceName, "OperationComplete", (global::Tmds.DBus.Protocol.Message m, object? s) => MessageReader.Read_sd(m), handler, flags, emitOnCapturedContext, state);
+        public global::System.Threading.Tasks.Task SetIsActiveAsync(global::System.ValueTuple<bool> value)
         {
             return Connection.CallMethodAsync(CreateMessage());
-            MessageBuffer CreateMessage()
+            global::Tmds.DBus.Protocol.MessageBuffer CreateMessage()
             {
                 var writer = Connection.GetMessageWriter();
                 writer.WriteMethodCallHeader(
@@ -398,57 +393,57 @@ namespace TestNamespace
                 return writer.CreateMessage();
             }
         }
-        public Task<double> GetLastResultAsync()
-            => Connection.CallMethodAsync(CreateGetPropertyMessage("LastResult"), (Message m, object? s) => MessageReader.Read_v_d(m), this);
-        public Task<ObjectPath> GetCurrentPathAsync()
-            => Connection.CallMethodAsync(CreateGetPropertyMessage("CurrentPath"), (Message m, object? s) => MessageReader.Read_v_o(m), this);
-        public Task<(string, double)> GetCurrentEntryAsync()
-            => Connection.CallMethodAsync(CreateGetPropertyMessage("CurrentEntry"), (Message m, object? s) => MessageReader.Read_v_rsdz(m), this);
-        public Task<ValueTuple<bool>> GetIsActiveAsync()
-            => Connection.CallMethodAsync(CreateGetPropertyMessage("IsActive"), (Message m, object? s) => MessageReader.Read_v_rbz(m), this);
-        public Task<CalculatorProperties> GetPropertiesAsync()
+        public global::System.Threading.Tasks.Task<double> GetLastResultAsync()
+            => Connection.CallMethodAsync(CreateGetPropertyMessage("LastResult"), (global::Tmds.DBus.Protocol.Message m, object? s) => MessageReader.Read_v_d(m), this);
+        public global::System.Threading.Tasks.Task<global::Tmds.DBus.Protocol.ObjectPath> GetCurrentPathAsync()
+            => Connection.CallMethodAsync(CreateGetPropertyMessage("CurrentPath"), (global::Tmds.DBus.Protocol.Message m, object? s) => MessageReader.Read_v_o(m), this);
+        public global::System.Threading.Tasks.Task<(string, double)> GetCurrentEntryAsync()
+            => Connection.CallMethodAsync(CreateGetPropertyMessage("CurrentEntry"), (global::Tmds.DBus.Protocol.Message m, object? s) => MessageReader.Read_v_rsdz(m), this);
+        public global::System.Threading.Tasks.Task<global::System.ValueTuple<bool>> GetIsActiveAsync()
+            => Connection.CallMethodAsync(CreateGetPropertyMessage("IsActive"), (global::Tmds.DBus.Protocol.Message m, object? s) => MessageReader.Read_v_rbz(m), this);
+        public global::System.Threading.Tasks.Task<CalculatorProperties> GetPropertiesAsync()
         {
-            return Connection.CallMethodAsync(CreateGetAllPropertiesMessage(), (Message m, object? s) => ReadMessage(m), this);
-            static CalculatorProperties ReadMessage(Message message)
+            return Connection.CallMethodAsync(CreateGetAllPropertiesMessage(), (global::Tmds.DBus.Protocol.Message m, object? s) => ReadMessage(m), this);
+            static CalculatorProperties ReadMessage(global::Tmds.DBus.Protocol.Message message)
             {
                 var reader = message.GetBodyReader();
                 return CalculatorProperties.ReadFrom(ref reader, withInvalidated: false);
             }
         }
-        public Task<INullableCalculatorProperties> GetNullablePropertiesAsync()
+        public global::System.Threading.Tasks.Task<INullableCalculatorProperties> GetNullablePropertiesAsync()
         {
-            return Connection.CallMethodAsync(CreateGetAllPropertiesMessage(), (Message m, object? s) => ReadMessage(m), this);
-            static INullableCalculatorProperties ReadMessage(Message message)
+            return Connection.CallMethodAsync(CreateGetAllPropertiesMessage(), (global::Tmds.DBus.Protocol.Message m, object? s) => ReadMessage(m), this);
+            static INullableCalculatorProperties ReadMessage(global::Tmds.DBus.Protocol.Message message)
             {
                 var reader = message.GetBodyReader();
                 return CalculatorProperties.ReadFrom(ref reader, withInvalidated: false);
             }
         }
-        public ValueTask<IDisposable> WatchPropertiesChangedAsync(Action<IChangedCalculatorProperties> handler, bool emitOnCapturedContext = true)
-            => WatchPropertiesChangedAsync(static (Notification<IChangedCalculatorProperties> n) => ((Action<IChangedCalculatorProperties>)n.State!)(n.Value), ObserverFlags.None, emitOnCapturedContext, handler);
-        public ValueTask<IDisposable> WatchPropertiesChangedAsync(Func<IChangedCalculatorProperties, ValueTask> handler, bool emitOnCapturedContext = true)
-            => WatchPropertiesChangedAsync(static (Notification<IChangedCalculatorProperties> n) => ((Func<IChangedCalculatorProperties, ValueTask>)n.State!)(n.Value), ObserverFlags.None, emitOnCapturedContext, handler);
-        public ValueTask<IDisposable> WatchPropertiesChangedAsync(Action<Notification<IChangedCalculatorProperties>> handler, ObserverFlags flags, bool emitOnCapturedContext = true, object? state = null)
+        public global::System.Threading.Tasks.ValueTask<global::System.IDisposable> WatchPropertiesChangedAsync(global::System.Action<IChangedCalculatorProperties> handler, bool emitOnCapturedContext = true)
+            => WatchPropertiesChangedAsync(static (global::Tmds.DBus.Protocol.Notification<IChangedCalculatorProperties> n) => ((global::System.Action<IChangedCalculatorProperties>)n.State!)(n.Value), global::Tmds.DBus.Protocol.ObserverFlags.None, emitOnCapturedContext, handler);
+        public global::System.Threading.Tasks.ValueTask<global::System.IDisposable> WatchPropertiesChangedAsync(global::System.Func<IChangedCalculatorProperties, global::System.Threading.Tasks.ValueTask> handler, bool emitOnCapturedContext = true)
+            => WatchPropertiesChangedAsync(static (global::Tmds.DBus.Protocol.Notification<IChangedCalculatorProperties> n) => ((global::System.Func<IChangedCalculatorProperties, global::System.Threading.Tasks.ValueTask>)n.State!)(n.Value), global::Tmds.DBus.Protocol.ObserverFlags.None, emitOnCapturedContext, handler);
+        public global::System.Threading.Tasks.ValueTask<global::System.IDisposable> WatchPropertiesChangedAsync(global::System.Action<global::Tmds.DBus.Protocol.Notification<IChangedCalculatorProperties>> handler, global::Tmds.DBus.Protocol.ObserverFlags flags, bool emitOnCapturedContext = true, object? state = null)
         {
-            return Connection.WatchPropertiesChangedAsync(Destination, Path, DBusInterfaceName, (Message m, object? s) => ReadMessage(m), handler, flags, emitOnCapturedContext, state);
-            static IChangedCalculatorProperties ReadMessage(Message message)
+            return Connection.WatchPropertiesChangedAsync(Destination, Path, DBusInterfaceName, (global::Tmds.DBus.Protocol.Message m, object? s) => ReadMessage(m), handler, flags, emitOnCapturedContext, state);
+            static IChangedCalculatorProperties ReadMessage(global::Tmds.DBus.Protocol.Message message)
             {
                 var reader = message.GetBodyReader();
                 reader.ReadString(); // interface
                 return CalculatorProperties.ReadFrom(ref reader, withInvalidated: true);
             }
         }
-        public ValueTask<IDisposable> WatchPropertiesChangedAsync(Func<Notification<IChangedCalculatorProperties>, ValueTask> handler, ObserverFlags flags, bool emitOnCapturedContext = true, object? state = null)
+        public global::System.Threading.Tasks.ValueTask<global::System.IDisposable> WatchPropertiesChangedAsync(global::System.Func<global::Tmds.DBus.Protocol.Notification<IChangedCalculatorProperties>, global::System.Threading.Tasks.ValueTask> handler, global::Tmds.DBus.Protocol.ObserverFlags flags, bool emitOnCapturedContext = true, object? state = null)
         {
-            return Connection.WatchPropertiesChangedAsync(Destination, Path, DBusInterfaceName, (Message m, object? s) => ReadMessage(m), handler, flags, emitOnCapturedContext, state);
-            static IChangedCalculatorProperties ReadMessage(Message message)
+            return Connection.WatchPropertiesChangedAsync(Destination, Path, DBusInterfaceName, (global::Tmds.DBus.Protocol.Message m, object? s) => ReadMessage(m), handler, flags, emitOnCapturedContext, state);
+            static IChangedCalculatorProperties ReadMessage(global::Tmds.DBus.Protocol.Message message)
             {
                 var reader = message.GetBodyReader();
                 reader.ReadString(); // interface
                 return CalculatorProperties.ReadFrom(ref reader, withInvalidated: true);
             }
         }
-        private MessageBuffer CreateGetPropertyMessage(string property)
+        private global::Tmds.DBus.Protocol.MessageBuffer CreateGetPropertyMessage(string property)
         {
             var writer = Connection.GetMessageWriter();
             writer.WriteMethodCallHeader(
@@ -461,7 +456,7 @@ namespace TestNamespace
             writer.WriteString(property);
             return writer.CreateMessage();
         }
-        private MessageBuffer CreateGetAllPropertiesMessage()
+        private global::Tmds.DBus.Protocol.MessageBuffer CreateGetAllPropertiesMessage()
         {
             var writer = Connection.GetMessageWriter();
             writer.WriteMethodCallHeader(
@@ -489,56 +484,56 @@ namespace TestNamespace
                     _ => 0
                 };
             }
-            public static DBusHandler.DBusMethod FindMethodHandler(object handler, MethodContext context)
+            public static global::Tmds.DBus.Protocol.DBusHandler.DBusMethod FindMethodHandler(object handler, global::Tmds.DBus.Protocol.MethodContext context)
             {
                 var request = context.Request;
                 if (context.IsPropertiesInterfaceRequest)
                 {
                     return (request.MemberAsString, request.SignatureAsString) switch
                     {
-                        ("Get", "ss") => new DBusHandler.DBusMethod(static (o, c) => ((ICalculatorHandler)o).HandleGetPropertyAsync(new GetPropertyContext(c)), handler),
-                        ("GetAll", "s") => new DBusHandler.DBusMethod(static (o, c) => ((ICalculatorHandler)o).HandleGetAllPropertiesAsync(new GetAllPropertiesContext(c)), handler),
-                        ("Set", "ssv") => new DBusHandler.DBusMethod(static (o, c) => ((ICalculatorHandler)o).HandleSetPropertyAsync(new SetPropertyContext(c)), handler),
+                        ("Get", "ss") => new global::Tmds.DBus.Protocol.DBusHandler.DBusMethod(static (o, c) => ((ICalculatorHandler)o).HandleGetPropertyAsync(new GetPropertyContext(c)), handler),
+                        ("GetAll", "s") => new global::Tmds.DBus.Protocol.DBusHandler.DBusMethod(static (o, c) => ((ICalculatorHandler)o).HandleGetAllPropertiesAsync(new GetAllPropertiesContext(c)), handler),
+                        ("Set", "ssv") => new global::Tmds.DBus.Protocol.DBusHandler.DBusMethod(static (o, c) => ((ICalculatorHandler)o).HandleSetPropertyAsync(new SetPropertyContext(c)), handler),
                         _ => default
                     };
                 }
                 return (request.MemberAsString, request.SignatureAsString) switch
                 {
-                    ("Clear", "") => new DBusHandler.DBusMethod(static (o, c) => HandleClearAsync((ICalculatorHandler)o, c), handler),
-                    ("GetResult", "") => new DBusHandler.DBusMethod(static (o, c) => HandleGetResultAsync((ICalculatorHandler)o, c), handler),
-                    ("GetStats", "") => new DBusHandler.DBusMethod(static (o, c) => HandleGetStatsAsync((ICalculatorHandler)o, c), handler),
-                    ("Store", "d") => new DBusHandler.DBusMethod(static (o, c) => HandleStoreAsync((ICalculatorHandler)o, c), handler),
-                    ("Square", "d") => new DBusHandler.DBusMethod(static (o, c) => HandleSquareAsync((ICalculatorHandler)o, c), handler),
-                    ("DivMod", "i") => new DBusHandler.DBusMethod(static (o, c) => HandleDivModAsync((ICalculatorHandler)o, c), handler),
-                    ("LogOperation", "sd") => new DBusHandler.DBusMethod(static (o, c) => HandleLogOperationAsync((ICalculatorHandler)o, c), handler),
-                    ("Add", "dd") => new DBusHandler.DBusMethod(static (o, c) => HandleAddAsync((ICalculatorHandler)o, c), handler),
-                    ("Compare", "dd") => new DBusHandler.DBusMethod(static (o, c) => HandleCompareAsync((ICalculatorHandler)o, c), handler),
-                    ("GetEntry", "s") => new DBusHandler.DBusMethod(static (o, c) => HandleGetEntryAsync((ICalculatorHandler)o, c), handler),
-                    ("SetEntry", "(sd)") => new DBusHandler.DBusMethod(static (o, c) => HandleSetEntryAsync((ICalculatorHandler)o, c), handler),
+                    ("Clear", "") => new global::Tmds.DBus.Protocol.DBusHandler.DBusMethod(static (o, c) => HandleClearAsync((ICalculatorHandler)o, c), handler),
+                    ("GetResult", "") => new global::Tmds.DBus.Protocol.DBusHandler.DBusMethod(static (o, c) => HandleGetResultAsync((ICalculatorHandler)o, c), handler),
+                    ("GetStats", "") => new global::Tmds.DBus.Protocol.DBusHandler.DBusMethod(static (o, c) => HandleGetStatsAsync((ICalculatorHandler)o, c), handler),
+                    ("Store", "d") => new global::Tmds.DBus.Protocol.DBusHandler.DBusMethod(static (o, c) => HandleStoreAsync((ICalculatorHandler)o, c), handler),
+                    ("Square", "d") => new global::Tmds.DBus.Protocol.DBusHandler.DBusMethod(static (o, c) => HandleSquareAsync((ICalculatorHandler)o, c), handler),
+                    ("DivMod", "i") => new global::Tmds.DBus.Protocol.DBusHandler.DBusMethod(static (o, c) => HandleDivModAsync((ICalculatorHandler)o, c), handler),
+                    ("LogOperation", "sd") => new global::Tmds.DBus.Protocol.DBusHandler.DBusMethod(static (o, c) => HandleLogOperationAsync((ICalculatorHandler)o, c), handler),
+                    ("Add", "dd") => new global::Tmds.DBus.Protocol.DBusHandler.DBusMethod(static (o, c) => HandleAddAsync((ICalculatorHandler)o, c), handler),
+                    ("Compare", "dd") => new global::Tmds.DBus.Protocol.DBusHandler.DBusMethod(static (o, c) => HandleCompareAsync((ICalculatorHandler)o, c), handler),
+                    ("GetEntry", "s") => new global::Tmds.DBus.Protocol.DBusHandler.DBusMethod(static (o, c) => HandleGetEntryAsync((ICalculatorHandler)o, c), handler),
+                    ("SetEntry", "(sd)") => new global::Tmds.DBus.Protocol.DBusHandler.DBusMethod(static (o, c) => HandleSetEntryAsync((ICalculatorHandler)o, c), handler),
                     _ => default
                 };
             }
-            static async ValueTask HandleClearAsync(ICalculatorHandler handler, MethodContext context)
+            static async global::System.Threading.Tasks.ValueTask HandleClearAsync(ICalculatorHandler handler, global::Tmds.DBus.Protocol.MethodContext context)
             {
                 await handler.ClearAsync().ConfigureAwait(false);
                 context.Reply(context.CreateReplyWriter(null).CreateMessage());
             }
-            static async ValueTask HandleGetResultAsync(ICalculatorHandler handler, MethodContext context)
+            static async global::System.Threading.Tasks.ValueTask HandleGetResultAsync(ICalculatorHandler handler, global::Tmds.DBus.Protocol.MethodContext context)
             {
                 var result = await handler.GetResultAsync().ConfigureAwait(false);
                 WriteReply(context, result);
-                static void WriteReply(MethodContext context, double result)
+                static void WriteReply(global::Tmds.DBus.Protocol.MethodContext context, double result)
                 {
                     var writer = context.CreateReplyWriter("d");
                     writer.WriteDouble(result);
                     context.Reply(writer.CreateMessage());
                 }
             }
-            static async ValueTask HandleGetStatsAsync(ICalculatorHandler handler, MethodContext context)
+            static async global::System.Threading.Tasks.ValueTask HandleGetStatsAsync(ICalculatorHandler handler, global::Tmds.DBus.Protocol.MethodContext context)
             {
                 var result = await handler.GetStatsAsync().ConfigureAwait(false);
                 WriteReply(context, result);
-                static void WriteReply(MethodContext context, (uint Count, double Total) result)
+                static void WriteReply(global::Tmds.DBus.Protocol.MethodContext context, (uint Count, double Total) result)
                 {
                     var writer = context.CreateReplyWriter("ud");
                     writer.WriteUInt32(result.Count);
@@ -546,30 +541,30 @@ namespace TestNamespace
                     context.Reply(writer.CreateMessage());
                 }
             }
-            static async ValueTask HandleStoreAsync(ICalculatorHandler handler, MethodContext context)
+            static async global::System.Threading.Tasks.ValueTask HandleStoreAsync(ICalculatorHandler handler, global::Tmds.DBus.Protocol.MethodContext context)
             {
                 var value = MessageReader.Read_d(context.Request);
                 await handler.StoreAsync(value).ConfigureAwait(false);
                 context.Reply(context.CreateReplyWriter(null).CreateMessage());
             }
-            static async ValueTask HandleSquareAsync(ICalculatorHandler handler, MethodContext context)
+            static async global::System.Threading.Tasks.ValueTask HandleSquareAsync(ICalculatorHandler handler, global::Tmds.DBus.Protocol.MethodContext context)
             {
                 var input = MessageReader.Read_d(context.Request);
                 var result = await handler.SquareAsync(input).ConfigureAwait(false);
                 WriteReply(context, result);
-                static void WriteReply(MethodContext context, double result)
+                static void WriteReply(global::Tmds.DBus.Protocol.MethodContext context, double result)
                 {
                     var writer = context.CreateReplyWriter("d");
                     writer.WriteDouble(result);
                     context.Reply(writer.CreateMessage());
                 }
             }
-            static async ValueTask HandleDivModAsync(ICalculatorHandler handler, MethodContext context)
+            static async global::System.Threading.Tasks.ValueTask HandleDivModAsync(ICalculatorHandler handler, global::Tmds.DBus.Protocol.MethodContext context)
             {
                 var dividend = MessageReader.Read_i(context.Request);
                 var result = await handler.DivModAsync(dividend).ConfigureAwait(false);
                 WriteReply(context, result);
-                static void WriteReply(MethodContext context, (int Quotient, int Remainder) result)
+                static void WriteReply(global::Tmds.DBus.Protocol.MethodContext context, (int Quotient, int Remainder) result)
                 {
                     var writer = context.CreateReplyWriter("ii");
                     writer.WriteInt32(result.Quotient);
@@ -577,30 +572,30 @@ namespace TestNamespace
                     context.Reply(writer.CreateMessage());
                 }
             }
-            static async ValueTask HandleLogOperationAsync(ICalculatorHandler handler, MethodContext context)
+            static async global::System.Threading.Tasks.ValueTask HandleLogOperationAsync(ICalculatorHandler handler, global::Tmds.DBus.Protocol.MethodContext context)
             {
                 var (operation, value) = MessageReader.Read_sd(context.Request);
                 await handler.LogOperationAsync(operation, value).ConfigureAwait(false);
                 context.Reply(context.CreateReplyWriter(null).CreateMessage());
             }
-            static async ValueTask HandleAddAsync(ICalculatorHandler handler, MethodContext context)
+            static async global::System.Threading.Tasks.ValueTask HandleAddAsync(ICalculatorHandler handler, global::Tmds.DBus.Protocol.MethodContext context)
             {
                 var (a, b) = MessageReader.Read_dd(context.Request);
                 var result = await handler.AddAsync(a, b).ConfigureAwait(false);
                 WriteReply(context, result);
-                static void WriteReply(MethodContext context, double result)
+                static void WriteReply(global::Tmds.DBus.Protocol.MethodContext context, double result)
                 {
                     var writer = context.CreateReplyWriter("d");
                     writer.WriteDouble(result);
                     context.Reply(writer.CreateMessage());
                 }
             }
-            static async ValueTask HandleCompareAsync(ICalculatorHandler handler, MethodContext context)
+            static async global::System.Threading.Tasks.ValueTask HandleCompareAsync(ICalculatorHandler handler, global::Tmds.DBus.Protocol.MethodContext context)
             {
                 var (a, b) = MessageReader.Read_dd(context.Request);
                 var result = await handler.CompareAsync(a, b).ConfigureAwait(false);
                 WriteReply(context, result);
-                static void WriteReply(MethodContext context, (bool Equal, double Difference) result)
+                static void WriteReply(global::Tmds.DBus.Protocol.MethodContext context, (bool Equal, double Difference) result)
                 {
                     var writer = context.CreateReplyWriter("bd");
                     writer.WriteBool(result.Equal);
@@ -608,44 +603,44 @@ namespace TestNamespace
                     context.Reply(writer.CreateMessage());
                 }
             }
-            static async ValueTask HandleGetEntryAsync(ICalculatorHandler handler, MethodContext context)
+            static async global::System.Threading.Tasks.ValueTask HandleGetEntryAsync(ICalculatorHandler handler, global::Tmds.DBus.Protocol.MethodContext context)
             {
                 var key = MessageReader.Read_s(context.Request);
                 var result = await handler.GetEntryAsync(key).ConfigureAwait(false);
                 WriteReply(context, result);
-                static void WriteReply(MethodContext context, (string, double) result)
+                static void WriteReply(global::Tmds.DBus.Protocol.MethodContext context, (string, double) result)
                 {
                     var writer = context.CreateReplyWriter("(sd)");
                     writer.Write_rsdz(result);
                     context.Reply(writer.CreateMessage());
                 }
             }
-            static async ValueTask HandleSetEntryAsync(ICalculatorHandler handler, MethodContext context)
+            static async global::System.Threading.Tasks.ValueTask HandleSetEntryAsync(ICalculatorHandler handler, global::Tmds.DBus.Protocol.MethodContext context)
             {
                 var entry = MessageReader.Read_rsdz(context.Request);
                 await handler.SetEntryAsync(entry).ConfigureAwait(false);
                 context.Reply(context.CreateReplyWriter(null).CreateMessage());
             }
         }
-        ValueTask HandleGetPropertyAsync(GetPropertyContext context);
-        ValueTask HandleGetAllPropertiesAsync(GetAllPropertiesContext context);
-        ValueTask HandleSetPropertyAsync(SetPropertyContext context);
-        ValueTask ClearAsync();
-        ValueTask<double> GetResultAsync();
-        ValueTask<(uint Count, double Total)> GetStatsAsync();
-        ValueTask StoreAsync(double value);
-        ValueTask<double> SquareAsync(double input);
-        ValueTask<(int Quotient, int Remainder)> DivModAsync(int dividend);
-        ValueTask LogOperationAsync(string operation, double value);
-        ValueTask<double> AddAsync(double a, double b);
-        ValueTask<(bool Equal, double Difference)> CompareAsync(double a, double b);
-        ValueTask<(string, double)> GetEntryAsync(string key);
-        ValueTask SetEntryAsync((string, double) entry);
-        readonly struct GetPropertyContext : IDisposable
+        global::System.Threading.Tasks.ValueTask HandleGetPropertyAsync(GetPropertyContext context);
+        global::System.Threading.Tasks.ValueTask HandleGetAllPropertiesAsync(GetAllPropertiesContext context);
+        global::System.Threading.Tasks.ValueTask HandleSetPropertyAsync(SetPropertyContext context);
+        global::System.Threading.Tasks.ValueTask ClearAsync();
+        global::System.Threading.Tasks.ValueTask<double> GetResultAsync();
+        global::System.Threading.Tasks.ValueTask<(uint Count, double Total)> GetStatsAsync();
+        global::System.Threading.Tasks.ValueTask StoreAsync(double value);
+        global::System.Threading.Tasks.ValueTask<double> SquareAsync(double input);
+        global::System.Threading.Tasks.ValueTask<(int Quotient, int Remainder)> DivModAsync(int dividend);
+        global::System.Threading.Tasks.ValueTask LogOperationAsync(string operation, double value);
+        global::System.Threading.Tasks.ValueTask<double> AddAsync(double a, double b);
+        global::System.Threading.Tasks.ValueTask<(bool Equal, double Difference)> CompareAsync(double a, double b);
+        global::System.Threading.Tasks.ValueTask<(string, double)> GetEntryAsync(string key);
+        global::System.Threading.Tasks.ValueTask SetEntryAsync((string, double) entry);
+        readonly struct GetPropertyContext : global::System.IDisposable
         {
-            public MethodContext MethodContext { get; }
+            public global::Tmds.DBus.Protocol.MethodContext MethodContext { get; }
             public CalculatorProperty Property { get; }
-            public GetPropertyContext(MethodContext methodContext)
+            public GetPropertyContext(global::Tmds.DBus.Protocol.MethodContext methodContext)
             {
                 MethodContext = methodContext;
                 var reader = methodContext.Request.GetBodyReader();
@@ -655,28 +650,28 @@ namespace TestNamespace
             public void Dispose() => MethodContext.Dispose();
             public void ReplyLastResult(double value)
             {
-                System.Diagnostics.Debug.Assert(Property == CalculatorProperty.LastResult);
+                global::System.Diagnostics.Debug.Assert(Property == CalculatorProperty.LastResult);
                 var writer = MethodContext.CreateReplyWriter("v");
                 writer.Write_v_d(value);
                 MethodContext.Reply(writer.CreateMessage());
             }
-            public void ReplyCurrentPath(ObjectPath value)
+            public void ReplyCurrentPath(global::Tmds.DBus.Protocol.ObjectPath value)
             {
-                System.Diagnostics.Debug.Assert(Property == CalculatorProperty.CurrentPath);
+                global::System.Diagnostics.Debug.Assert(Property == CalculatorProperty.CurrentPath);
                 var writer = MethodContext.CreateReplyWriter("v");
                 writer.Write_v_o(value);
                 MethodContext.Reply(writer.CreateMessage());
             }
             public void ReplyCurrentEntry((string, double) value)
             {
-                System.Diagnostics.Debug.Assert(Property == CalculatorProperty.CurrentEntry);
+                global::System.Diagnostics.Debug.Assert(Property == CalculatorProperty.CurrentEntry);
                 var writer = MethodContext.CreateReplyWriter("v");
                 writer.Write_v_rsdz(value);
                 MethodContext.Reply(writer.CreateMessage());
             }
-            public void ReplyIsActive(ValueTuple<bool> value)
+            public void ReplyIsActive(global::System.ValueTuple<bool> value)
             {
-                System.Diagnostics.Debug.Assert(Property == CalculatorProperty.IsActive);
+                global::System.Diagnostics.Debug.Assert(Property == CalculatorProperty.IsActive);
                 var writer = MethodContext.CreateReplyWriter("v");
                 writer.Write_v_rbz(value);
                 MethodContext.Reply(writer.CreateMessage());
@@ -685,7 +680,7 @@ namespace TestNamespace
             {
                 MethodContext.ReplyError("org.freedesktop.DBus.Error.UnknownProperty", $"Unknown property: {Property}");
             }
-            public ValueTask Handle(ICalculatorProperties properties)
+            public global::System.Threading.Tasks.ValueTask Handle(ICalculatorProperties properties)
             {
                 switch (Property)
                 {
@@ -708,15 +703,15 @@ namespace TestNamespace
                 return default;
             }
         }
-        readonly struct GetAllPropertiesContext : IDisposable
+        readonly struct GetAllPropertiesContext : global::System.IDisposable
         {
-            public MethodContext MethodContext { get; }
-            public GetAllPropertiesContext(MethodContext methodContext)
+            public global::Tmds.DBus.Protocol.MethodContext MethodContext { get; }
+            public GetAllPropertiesContext(global::Tmds.DBus.Protocol.MethodContext methodContext)
             {
                 MethodContext = methodContext;
             }
             public void Dispose() => MethodContext.Dispose();
-            public ValueTask Handle(ICalculatorProperties properties)
+            public global::System.Threading.Tasks.ValueTask Handle(ICalculatorProperties properties)
             {
                 var writer = MethodContext.CreateReplyWriter("a{sv}");
                 var dictStart = writer.WriteDictionaryStart();
@@ -736,7 +731,7 @@ namespace TestNamespace
                 MethodContext.Reply(writer.CreateMessage());
                 return default;
             }
-            public ValueTask Handle((string, double)? currentEntry = default, ObjectPath? currentPath = default, ValueTuple<bool>? isActive = default, double? lastResult = default)
+            public global::System.Threading.Tasks.ValueTask Handle((string, double)? currentEntry = default, global::Tmds.DBus.Protocol.ObjectPath? currentPath = default, global::System.ValueTuple<bool>? isActive = default, double? lastResult = default)
             {
                 var writer = MethodContext.CreateReplyWriter("a{sv}");
                 var dictStart = writer.WriteDictionaryStart();
@@ -750,7 +745,7 @@ namespace TestNamespace
                 {
                     writer.WriteDictionaryEntryStart();
                     writer.WriteString("CurrentPath");
-                    writer.Write_v_o((ObjectPath)currentPath);
+                    writer.Write_v_o((global::Tmds.DBus.Protocol.ObjectPath)currentPath);
                 }
                 if (currentEntry is not null)
                 {
@@ -762,18 +757,18 @@ namespace TestNamespace
                 {
                     writer.WriteDictionaryEntryStart();
                     writer.WriteString("IsActive");
-                    writer.Write_v_rbz((ValueTuple<bool>)isActive);
+                    writer.Write_v_rbz((global::System.ValueTuple<bool>)isActive);
                 }
                 writer.WriteDictionaryEnd(dictStart);
                 MethodContext.Reply(writer.CreateMessage());
                 return default;
             }
         }
-        readonly struct SetPropertyContext : IDisposable
+        readonly struct SetPropertyContext : global::System.IDisposable
         {
-            public MethodContext MethodContext { get; }
+            public global::Tmds.DBus.Protocol.MethodContext MethodContext { get; }
             public WritableCalculatorProperty Property { get; }
-            public SetPropertyContext(MethodContext methodContext)
+            public SetPropertyContext(global::Tmds.DBus.Protocol.MethodContext methodContext)
             {
                 MethodContext = methodContext;
                 var reader = methodContext.Request.GetBodyReader();
@@ -781,7 +776,7 @@ namespace TestNamespace
                 Property = (WritableCalculatorProperty)Helper.GetPropertyValue(reader.ReadString());
             }
             public void Dispose() => MethodContext.Dispose();
-            public ValueTuple<bool> ReadIsActive()
+            public global::System.ValueTuple<bool> ReadIsActive()
             {
                 var reader = MethodContext.Request.GetBodyReader();
                 reader.ReadStringAsSpan(); // Skip interface name
@@ -801,7 +796,7 @@ namespace TestNamespace
             {
                 MethodContext.ReplyError("org.freedesktop.DBus.Error.PropertyReadOnly", $"Property is read-only: {Property}");
             }
-            public ValueTask Handle(ICalculatorProperties properties)
+            public global::System.Threading.Tasks.ValueTask Handle(ICalculatorProperties properties)
             {
                 switch (Property)
                 {
@@ -822,7 +817,7 @@ namespace TestNamespace
     }
     static class CalculatorSignal
     {
-        public static void EmitReset(this DBusConnection c, ObjectPath p)
+        public static void EmitReset(this global::Tmds.DBus.Protocol.DBusConnection c, global::Tmds.DBus.Protocol.ObjectPath p)
         {
             var writer = c.GetMessageWriter();
             writer.WriteSignalHeader(
@@ -831,7 +826,7 @@ namespace TestNamespace
                 member: "Reset");
             c.TrySendMessage(writer.CreateMessage());
         }
-        public static void EmitError(this DBusConnection c, ObjectPath p, string message)
+        public static void EmitError(this global::Tmds.DBus.Protocol.DBusConnection c, global::Tmds.DBus.Protocol.ObjectPath p, string message)
         {
             var writer = c.GetMessageWriter();
             writer.WriteSignalHeader(
@@ -842,7 +837,7 @@ namespace TestNamespace
             writer.WriteString(message);
             c.TrySendMessage(writer.CreateMessage());
         }
-        public static void EmitOperationComplete(this DBusConnection c, ObjectPath p, string operation, double result)
+        public static void EmitOperationComplete(this global::Tmds.DBus.Protocol.DBusConnection c, global::Tmds.DBus.Protocol.ObjectPath p, string operation, double result)
         {
             var writer = c.GetMessageWriter();
             writer.WriteSignalHeader(
@@ -854,7 +849,7 @@ namespace TestNamespace
             writer.WriteDouble(result);
             c.TrySendMessage(writer.CreateMessage());
         }
-        public static void EmitPropertiesChanged(this DBusConnection c, ObjectPath p, ICalculatorProperties properties, ReadOnlySpan<CalculatorProperty> changed, ReadOnlySpan<CalculatorProperty> invalidated = default)
+        public static void EmitPropertiesChanged(this global::Tmds.DBus.Protocol.DBusConnection c, global::Tmds.DBus.Protocol.ObjectPath p, ICalculatorProperties properties, global::System.ReadOnlySpan<CalculatorProperty> changed, global::System.ReadOnlySpan<CalculatorProperty> invalidated = default)
         {
             var writer = c.GetMessageWriter();
             writer.WriteSignalHeader(
@@ -891,7 +886,7 @@ namespace TestNamespace
                 }
             }
             writer.WriteDictionaryEnd(dictStart);
-            var arrayStart = writer.WriteArrayStart(DBusType.String);
+            var arrayStart = writer.WriteArrayStart(global::Tmds.DBus.Protocol.DBusType.String);
             foreach (var property in invalidated)
             {
                 switch (property)
@@ -913,11 +908,11 @@ namespace TestNamespace
             writer.WriteArrayEnd(arrayStart);
             c.TrySendMessage(writer.CreateMessage());
         }
-        public static void EmitPropertyChanged(this DBusConnection c, ObjectPath p, ICalculatorProperties properties, CalculatorProperty changed)
+        public static void EmitPropertyChanged(this global::Tmds.DBus.Protocol.DBusConnection c, global::Tmds.DBus.Protocol.ObjectPath p, ICalculatorProperties properties, CalculatorProperty changed)
         {
             EmitPropertiesChanged(c, p, properties, stackalloc[] { changed }, default);
         }
-        public static void EmitCalculatorPropertiesChanged(this DBusConnection c, ObjectPath p, (string, double)? currentEntry = default, ObjectPath? currentPath = default, ValueTuple<bool>? isActive = default, double? lastResult = default, ReadOnlySpan<CalculatorProperty> invalidated = default)
+        public static void EmitCalculatorPropertiesChanged(this global::Tmds.DBus.Protocol.DBusConnection c, global::Tmds.DBus.Protocol.ObjectPath p, (string, double)? currentEntry = default, global::Tmds.DBus.Protocol.ObjectPath? currentPath = default, global::System.ValueTuple<bool>? isActive = default, double? lastResult = default, global::System.ReadOnlySpan<CalculatorProperty> invalidated = default)
         {
             var writer = c.GetMessageWriter();
             writer.WriteSignalHeader(
@@ -937,7 +932,7 @@ namespace TestNamespace
             {
                 writer.WriteDictionaryEntryStart();
                 writer.WriteString("CurrentPath");
-                writer.Write_v_o((ObjectPath)currentPath);
+                writer.Write_v_o((global::Tmds.DBus.Protocol.ObjectPath)currentPath);
             }
             if (currentEntry is not null)
             {
@@ -949,10 +944,10 @@ namespace TestNamespace
             {
                 writer.WriteDictionaryEntryStart();
                 writer.WriteString("IsActive");
-                writer.Write_v_rbz((ValueTuple<bool>)isActive);
+                writer.Write_v_rbz((global::System.ValueTuple<bool>)isActive);
             }
             writer.WriteDictionaryEnd(dictStart);
-            var arrayStart = writer.WriteArrayStart(DBusType.String);
+            var arrayStart = writer.WriteArrayStart(global::Tmds.DBus.Protocol.DBusType.String);
             foreach (var property in invalidated)
             {
                 switch (property)
@@ -1013,14 +1008,14 @@ namespace TestNamespace
         private static uint Flag(SettingsProperty property) => property == 0 ? 0 : 1U << ((int)property - 1);
         public SettingsProperties() { }
         #nullable disable
-        [System.Diagnostics.CodeAnalysis.SetsRequiredMembers]
+        [global::System.Diagnostics.CodeAnalysis.SetsRequiredMembers]
         private SettingsProperties(bool _) { }
         #nullable enable
         private void EnsureSet(SettingsProperty property)
         {
             if (!HasFlag(__set, property))
             {
-                throw new InvalidOperationException("Property is not set.");
+                throw new global::System.InvalidOperationException("Property is not set.");
             }
         }
         private string _theme = default!;
@@ -1065,13 +1060,13 @@ namespace TestNamespace
         {
             if (!AreAllPropertiesSet())
             {
-                throw new DBusUnexpectedValueException($"Not all properties have been set (0x{__set:x}).");
+                throw new global::Tmds.DBus.Protocol.DBusUnexpectedValueException($"Not all properties have been set (0x{__set:x}).");
             }
         }
-        public static SettingsProperties ReadFrom(ref Reader reader, bool withInvalidated)
+        public static SettingsProperties ReadFrom(ref global::Tmds.DBus.Protocol.Reader reader, bool withInvalidated)
         {
             var props = CreateUninitialized();
-            ArrayEnd arrayEnd = reader.ReadArrayStart(DBusType.Struct);
+            global::Tmds.DBus.Protocol.ArrayEnd arrayEnd = reader.ReadArrayStart(global::Tmds.DBus.Protocol.DBusType.Struct);
             while (reader.HasNext(arrayEnd))
             {
                 var property = reader.ReadString();
@@ -1092,7 +1087,7 @@ namespace TestNamespace
             }
             if (withInvalidated)
             {
-                ArrayEnd invalidatedEnd = reader.ReadArrayStart(DBusType.String);
+                global::Tmds.DBus.Protocol.ArrayEnd invalidatedEnd = reader.ReadArrayStart(global::Tmds.DBus.Protocol.DBusType.String);
                 while (reader.HasNext(invalidatedEnd))
                 {
                     var propertyName = reader.ReadString();
@@ -1108,16 +1103,16 @@ namespace TestNamespace
         }
         double ISettingsProperties.Volume { set { } }
     }
-    sealed partial class Settings : Tmds.DBus.Protocol.DBusObject
+    sealed partial class Settings : global::Tmds.DBus.Protocol.DBusObject
     {
         public const string DBusInterfaceName = "org.example.Settings";
-        public Settings(Tmds.DBus.Protocol.DBusConnection connection, string destination, ObjectPath path)
+        public Settings(global::Tmds.DBus.Protocol.DBusConnection connection, string destination, global::Tmds.DBus.Protocol.ObjectPath path)
             : base(connection, destination, path)
         { }
-        public Task SaveAsync()
+        public global::System.Threading.Tasks.Task SaveAsync()
         {
             return Connection.CallMethodAsync(CreateMessage());
-            MessageBuffer CreateMessage()
+            global::Tmds.DBus.Protocol.MessageBuffer CreateMessage()
             {
                 var writer = Connection.GetMessageWriter();
                 writer.WriteMethodCallHeader(
@@ -1128,18 +1123,18 @@ namespace TestNamespace
                 return writer.CreateMessage();
             }
         }
-        public ValueTask<IDisposable> WatchChangedAsync(Action handler, bool emitOnCapturedContext = true)
-            => WatchChangedAsync(static (Notification n) => ((Action)n.State!)(), ObserverFlags.None, emitOnCapturedContext, handler);
-        public ValueTask<IDisposable> WatchChangedAsync(Func<ValueTask> handler, bool emitOnCapturedContext = true)
-            => WatchChangedAsync(static (Notification n) => ((Func<ValueTask>)n.State!)(), ObserverFlags.None, emitOnCapturedContext, handler);
-        public ValueTask<IDisposable> WatchChangedAsync(Action<Notification> handler, ObserverFlags flags, bool emitOnCapturedContext = true, object? state = null)
+        public global::System.Threading.Tasks.ValueTask<global::System.IDisposable> WatchChangedAsync(global::System.Action handler, bool emitOnCapturedContext = true)
+            => WatchChangedAsync(static (global::Tmds.DBus.Protocol.Notification n) => ((global::System.Action)n.State!)(), global::Tmds.DBus.Protocol.ObserverFlags.None, emitOnCapturedContext, handler);
+        public global::System.Threading.Tasks.ValueTask<global::System.IDisposable> WatchChangedAsync(global::System.Func<global::System.Threading.Tasks.ValueTask> handler, bool emitOnCapturedContext = true)
+            => WatchChangedAsync(static (global::Tmds.DBus.Protocol.Notification n) => ((global::System.Func<global::System.Threading.Tasks.ValueTask>)n.State!)(), global::Tmds.DBus.Protocol.ObserverFlags.None, emitOnCapturedContext, handler);
+        public global::System.Threading.Tasks.ValueTask<global::System.IDisposable> WatchChangedAsync(global::System.Action<global::Tmds.DBus.Protocol.Notification> handler, global::Tmds.DBus.Protocol.ObserverFlags flags, bool emitOnCapturedContext = true, object? state = null)
             => Connection.WatchSignalAsync(Destination, Path, DBusInterfaceName, "Changed", handler, flags, emitOnCapturedContext, state);
-        public ValueTask<IDisposable> WatchChangedAsync(Func<Notification, ValueTask> handler, ObserverFlags flags, bool emitOnCapturedContext = true, object? state = null)
+        public global::System.Threading.Tasks.ValueTask<global::System.IDisposable> WatchChangedAsync(global::System.Func<global::Tmds.DBus.Protocol.Notification, global::System.Threading.Tasks.ValueTask> handler, global::Tmds.DBus.Protocol.ObserverFlags flags, bool emitOnCapturedContext = true, object? state = null)
             => Connection.WatchSignalAsync(Destination, Path, DBusInterfaceName, "Changed", handler, flags, emitOnCapturedContext, state);
-        public Task SetVolumeAsync(double value)
+        public global::System.Threading.Tasks.Task SetVolumeAsync(double value)
         {
             return Connection.CallMethodAsync(CreateMessage());
-            MessageBuffer CreateMessage()
+            global::Tmds.DBus.Protocol.MessageBuffer CreateMessage()
             {
                 var writer = Connection.GetMessageWriter();
                 writer.WriteMethodCallHeader(
@@ -1155,10 +1150,10 @@ namespace TestNamespace
                 return writer.CreateMessage();
             }
         }
-        public Task SetLanguageAsync(string value)
+        public global::System.Threading.Tasks.Task SetLanguageAsync(string value)
         {
             return Connection.CallMethodAsync(CreateMessage());
-            MessageBuffer CreateMessage()
+            global::Tmds.DBus.Protocol.MessageBuffer CreateMessage()
             {
                 var writer = Connection.GetMessageWriter();
                 writer.WriteMethodCallHeader(
@@ -1174,53 +1169,53 @@ namespace TestNamespace
                 return writer.CreateMessage();
             }
         }
-        public Task<string> GetThemeAsync()
-            => Connection.CallMethodAsync(CreateGetPropertyMessage("Theme"), (Message m, object? s) => MessageReader.Read_v_s(m), this);
-        public Task<string> GetLanguageAsync()
-            => Connection.CallMethodAsync(CreateGetPropertyMessage("Language"), (Message m, object? s) => MessageReader.Read_v_s(m), this);
-        public Task<SettingsProperties> GetPropertiesAsync()
+        public global::System.Threading.Tasks.Task<string> GetThemeAsync()
+            => Connection.CallMethodAsync(CreateGetPropertyMessage("Theme"), (global::Tmds.DBus.Protocol.Message m, object? s) => MessageReader.Read_v_s(m), this);
+        public global::System.Threading.Tasks.Task<string> GetLanguageAsync()
+            => Connection.CallMethodAsync(CreateGetPropertyMessage("Language"), (global::Tmds.DBus.Protocol.Message m, object? s) => MessageReader.Read_v_s(m), this);
+        public global::System.Threading.Tasks.Task<SettingsProperties> GetPropertiesAsync()
         {
-            return Connection.CallMethodAsync(CreateGetAllPropertiesMessage(), (Message m, object? s) => ReadMessage(m), this);
-            static SettingsProperties ReadMessage(Message message)
+            return Connection.CallMethodAsync(CreateGetAllPropertiesMessage(), (global::Tmds.DBus.Protocol.Message m, object? s) => ReadMessage(m), this);
+            static SettingsProperties ReadMessage(global::Tmds.DBus.Protocol.Message message)
             {
                 var reader = message.GetBodyReader();
                 return SettingsProperties.ReadFrom(ref reader, withInvalidated: false);
             }
         }
-        public Task<INullableSettingsProperties> GetNullablePropertiesAsync()
+        public global::System.Threading.Tasks.Task<INullableSettingsProperties> GetNullablePropertiesAsync()
         {
-            return Connection.CallMethodAsync(CreateGetAllPropertiesMessage(), (Message m, object? s) => ReadMessage(m), this);
-            static INullableSettingsProperties ReadMessage(Message message)
+            return Connection.CallMethodAsync(CreateGetAllPropertiesMessage(), (global::Tmds.DBus.Protocol.Message m, object? s) => ReadMessage(m), this);
+            static INullableSettingsProperties ReadMessage(global::Tmds.DBus.Protocol.Message message)
             {
                 var reader = message.GetBodyReader();
                 return SettingsProperties.ReadFrom(ref reader, withInvalidated: false);
             }
         }
-        public ValueTask<IDisposable> WatchPropertiesChangedAsync(Action<IChangedSettingsProperties> handler, bool emitOnCapturedContext = true)
-            => WatchPropertiesChangedAsync(static (Notification<IChangedSettingsProperties> n) => ((Action<IChangedSettingsProperties>)n.State!)(n.Value), ObserverFlags.None, emitOnCapturedContext, handler);
-        public ValueTask<IDisposable> WatchPropertiesChangedAsync(Func<IChangedSettingsProperties, ValueTask> handler, bool emitOnCapturedContext = true)
-            => WatchPropertiesChangedAsync(static (Notification<IChangedSettingsProperties> n) => ((Func<IChangedSettingsProperties, ValueTask>)n.State!)(n.Value), ObserverFlags.None, emitOnCapturedContext, handler);
-        public ValueTask<IDisposable> WatchPropertiesChangedAsync(Action<Notification<IChangedSettingsProperties>> handler, ObserverFlags flags, bool emitOnCapturedContext = true, object? state = null)
+        public global::System.Threading.Tasks.ValueTask<global::System.IDisposable> WatchPropertiesChangedAsync(global::System.Action<IChangedSettingsProperties> handler, bool emitOnCapturedContext = true)
+            => WatchPropertiesChangedAsync(static (global::Tmds.DBus.Protocol.Notification<IChangedSettingsProperties> n) => ((global::System.Action<IChangedSettingsProperties>)n.State!)(n.Value), global::Tmds.DBus.Protocol.ObserverFlags.None, emitOnCapturedContext, handler);
+        public global::System.Threading.Tasks.ValueTask<global::System.IDisposable> WatchPropertiesChangedAsync(global::System.Func<IChangedSettingsProperties, global::System.Threading.Tasks.ValueTask> handler, bool emitOnCapturedContext = true)
+            => WatchPropertiesChangedAsync(static (global::Tmds.DBus.Protocol.Notification<IChangedSettingsProperties> n) => ((global::System.Func<IChangedSettingsProperties, global::System.Threading.Tasks.ValueTask>)n.State!)(n.Value), global::Tmds.DBus.Protocol.ObserverFlags.None, emitOnCapturedContext, handler);
+        public global::System.Threading.Tasks.ValueTask<global::System.IDisposable> WatchPropertiesChangedAsync(global::System.Action<global::Tmds.DBus.Protocol.Notification<IChangedSettingsProperties>> handler, global::Tmds.DBus.Protocol.ObserverFlags flags, bool emitOnCapturedContext = true, object? state = null)
         {
-            return Connection.WatchPropertiesChangedAsync(Destination, Path, DBusInterfaceName, (Message m, object? s) => ReadMessage(m), handler, flags, emitOnCapturedContext, state);
-            static IChangedSettingsProperties ReadMessage(Message message)
+            return Connection.WatchPropertiesChangedAsync(Destination, Path, DBusInterfaceName, (global::Tmds.DBus.Protocol.Message m, object? s) => ReadMessage(m), handler, flags, emitOnCapturedContext, state);
+            static IChangedSettingsProperties ReadMessage(global::Tmds.DBus.Protocol.Message message)
             {
                 var reader = message.GetBodyReader();
                 reader.ReadString(); // interface
                 return SettingsProperties.ReadFrom(ref reader, withInvalidated: true);
             }
         }
-        public ValueTask<IDisposable> WatchPropertiesChangedAsync(Func<Notification<IChangedSettingsProperties>, ValueTask> handler, ObserverFlags flags, bool emitOnCapturedContext = true, object? state = null)
+        public global::System.Threading.Tasks.ValueTask<global::System.IDisposable> WatchPropertiesChangedAsync(global::System.Func<global::Tmds.DBus.Protocol.Notification<IChangedSettingsProperties>, global::System.Threading.Tasks.ValueTask> handler, global::Tmds.DBus.Protocol.ObserverFlags flags, bool emitOnCapturedContext = true, object? state = null)
         {
-            return Connection.WatchPropertiesChangedAsync(Destination, Path, DBusInterfaceName, (Message m, object? s) => ReadMessage(m), handler, flags, emitOnCapturedContext, state);
-            static IChangedSettingsProperties ReadMessage(Message message)
+            return Connection.WatchPropertiesChangedAsync(Destination, Path, DBusInterfaceName, (global::Tmds.DBus.Protocol.Message m, object? s) => ReadMessage(m), handler, flags, emitOnCapturedContext, state);
+            static IChangedSettingsProperties ReadMessage(global::Tmds.DBus.Protocol.Message message)
             {
                 var reader = message.GetBodyReader();
                 reader.ReadString(); // interface
                 return SettingsProperties.ReadFrom(ref reader, withInvalidated: true);
             }
         }
-        private MessageBuffer CreateGetPropertyMessage(string property)
+        private global::Tmds.DBus.Protocol.MessageBuffer CreateGetPropertyMessage(string property)
         {
             var writer = Connection.GetMessageWriter();
             writer.WriteMethodCallHeader(
@@ -1233,7 +1228,7 @@ namespace TestNamespace
             writer.WriteString(property);
             return writer.CreateMessage();
         }
-        private MessageBuffer CreateGetAllPropertiesMessage()
+        private global::Tmds.DBus.Protocol.MessageBuffer CreateGetAllPropertiesMessage()
         {
             var writer = Connection.GetMessageWriter();
             writer.WriteMethodCallHeader(
@@ -1260,40 +1255,40 @@ namespace TestNamespace
                     _ => 0
                 };
             }
-            public static DBusHandler.DBusMethod FindMethodHandler(object handler, MethodContext context)
+            public static global::Tmds.DBus.Protocol.DBusHandler.DBusMethod FindMethodHandler(object handler, global::Tmds.DBus.Protocol.MethodContext context)
             {
                 var request = context.Request;
                 if (context.IsPropertiesInterfaceRequest)
                 {
                     return (request.MemberAsString, request.SignatureAsString) switch
                     {
-                        ("Get", "ss") => new DBusHandler.DBusMethod(static (o, c) => ((ISettingsHandler)o).HandleGetPropertyAsync(new GetPropertyContext(c)), handler),
-                        ("GetAll", "s") => new DBusHandler.DBusMethod(static (o, c) => ((ISettingsHandler)o).HandleGetAllPropertiesAsync(new GetAllPropertiesContext(c)), handler),
-                        ("Set", "ssv") => new DBusHandler.DBusMethod(static (o, c) => ((ISettingsHandler)o).HandleSetPropertyAsync(new SetPropertyContext(c)), handler),
+                        ("Get", "ss") => new global::Tmds.DBus.Protocol.DBusHandler.DBusMethod(static (o, c) => ((ISettingsHandler)o).HandleGetPropertyAsync(new GetPropertyContext(c)), handler),
+                        ("GetAll", "s") => new global::Tmds.DBus.Protocol.DBusHandler.DBusMethod(static (o, c) => ((ISettingsHandler)o).HandleGetAllPropertiesAsync(new GetAllPropertiesContext(c)), handler),
+                        ("Set", "ssv") => new global::Tmds.DBus.Protocol.DBusHandler.DBusMethod(static (o, c) => ((ISettingsHandler)o).HandleSetPropertyAsync(new SetPropertyContext(c)), handler),
                         _ => default
                     };
                 }
                 return (request.MemberAsString, request.SignatureAsString) switch
                 {
-                    ("Save", "") => new DBusHandler.DBusMethod(static (o, c) => HandleSaveAsync((ISettingsHandler)o, c), handler),
+                    ("Save", "") => new global::Tmds.DBus.Protocol.DBusHandler.DBusMethod(static (o, c) => HandleSaveAsync((ISettingsHandler)o, c), handler),
                     _ => default
                 };
             }
-            static async ValueTask HandleSaveAsync(ISettingsHandler handler, MethodContext context)
+            static async global::System.Threading.Tasks.ValueTask HandleSaveAsync(ISettingsHandler handler, global::Tmds.DBus.Protocol.MethodContext context)
             {
                 await handler.SaveAsync().ConfigureAwait(false);
                 context.Reply(context.CreateReplyWriter(null).CreateMessage());
             }
         }
-        ValueTask HandleGetPropertyAsync(GetPropertyContext context);
-        ValueTask HandleGetAllPropertiesAsync(GetAllPropertiesContext context);
-        ValueTask HandleSetPropertyAsync(SetPropertyContext context);
-        ValueTask SaveAsync();
-        readonly struct GetPropertyContext : IDisposable
+        global::System.Threading.Tasks.ValueTask HandleGetPropertyAsync(GetPropertyContext context);
+        global::System.Threading.Tasks.ValueTask HandleGetAllPropertiesAsync(GetAllPropertiesContext context);
+        global::System.Threading.Tasks.ValueTask HandleSetPropertyAsync(SetPropertyContext context);
+        global::System.Threading.Tasks.ValueTask SaveAsync();
+        readonly struct GetPropertyContext : global::System.IDisposable
         {
-            public MethodContext MethodContext { get; }
+            public global::Tmds.DBus.Protocol.MethodContext MethodContext { get; }
             public SettingsProperty Property { get; }
-            public GetPropertyContext(MethodContext methodContext)
+            public GetPropertyContext(global::Tmds.DBus.Protocol.MethodContext methodContext)
             {
                 MethodContext = methodContext;
                 var reader = methodContext.Request.GetBodyReader();
@@ -1303,14 +1298,14 @@ namespace TestNamespace
             public void Dispose() => MethodContext.Dispose();
             public void ReplyTheme(string value)
             {
-                System.Diagnostics.Debug.Assert(Property == SettingsProperty.Theme);
+                global::System.Diagnostics.Debug.Assert(Property == SettingsProperty.Theme);
                 var writer = MethodContext.CreateReplyWriter("v");
                 writer.Write_v_s(value);
                 MethodContext.Reply(writer.CreateMessage());
             }
             public void ReplyLanguage(string value)
             {
-                System.Diagnostics.Debug.Assert(Property == SettingsProperty.Language);
+                global::System.Diagnostics.Debug.Assert(Property == SettingsProperty.Language);
                 var writer = MethodContext.CreateReplyWriter("v");
                 writer.Write_v_s(value);
                 MethodContext.Reply(writer.CreateMessage());
@@ -1319,7 +1314,7 @@ namespace TestNamespace
             {
                 MethodContext.ReplyError("org.freedesktop.DBus.Error.UnknownProperty", $"Unknown property: {Property}");
             }
-            public ValueTask Handle(ISettingsProperties properties)
+            public global::System.Threading.Tasks.ValueTask Handle(ISettingsProperties properties)
             {
                 switch (Property)
                 {
@@ -1336,15 +1331,15 @@ namespace TestNamespace
                 return default;
             }
         }
-        readonly struct GetAllPropertiesContext : IDisposable
+        readonly struct GetAllPropertiesContext : global::System.IDisposable
         {
-            public MethodContext MethodContext { get; }
-            public GetAllPropertiesContext(MethodContext methodContext)
+            public global::Tmds.DBus.Protocol.MethodContext MethodContext { get; }
+            public GetAllPropertiesContext(global::Tmds.DBus.Protocol.MethodContext methodContext)
             {
                 MethodContext = methodContext;
             }
             public void Dispose() => MethodContext.Dispose();
-            public ValueTask Handle(ISettingsProperties properties)
+            public global::System.Threading.Tasks.ValueTask Handle(ISettingsProperties properties)
             {
                 var writer = MethodContext.CreateReplyWriter("a{sv}");
                 var dictStart = writer.WriteDictionaryStart();
@@ -1358,7 +1353,7 @@ namespace TestNamespace
                 MethodContext.Reply(writer.CreateMessage());
                 return default;
             }
-            public ValueTask Handle(string? language = default, string? theme = default)
+            public global::System.Threading.Tasks.ValueTask Handle(string? language = default, string? theme = default)
             {
                 var writer = MethodContext.CreateReplyWriter("a{sv}");
                 var dictStart = writer.WriteDictionaryStart();
@@ -1379,11 +1374,11 @@ namespace TestNamespace
                 return default;
             }
         }
-        readonly struct SetPropertyContext : IDisposable
+        readonly struct SetPropertyContext : global::System.IDisposable
         {
-            public MethodContext MethodContext { get; }
+            public global::Tmds.DBus.Protocol.MethodContext MethodContext { get; }
             public WritableSettingsProperty Property { get; }
-            public SetPropertyContext(MethodContext methodContext)
+            public SetPropertyContext(global::Tmds.DBus.Protocol.MethodContext methodContext)
             {
                 MethodContext = methodContext;
                 var reader = methodContext.Request.GetBodyReader();
@@ -1419,7 +1414,7 @@ namespace TestNamespace
             {
                 MethodContext.ReplyError("org.freedesktop.DBus.Error.PropertyReadOnly", $"Property is read-only: {Property}");
             }
-            public ValueTask Handle(ISettingsProperties properties)
+            public global::System.Threading.Tasks.ValueTask Handle(ISettingsProperties properties)
             {
                 switch (Property)
                 {
@@ -1444,7 +1439,7 @@ namespace TestNamespace
     }
     static class SettingsSignal
     {
-        public static void EmitChanged(this DBusConnection c, ObjectPath p)
+        public static void EmitChanged(this global::Tmds.DBus.Protocol.DBusConnection c, global::Tmds.DBus.Protocol.ObjectPath p)
         {
             var writer = c.GetMessageWriter();
             writer.WriteSignalHeader(
@@ -1453,7 +1448,7 @@ namespace TestNamespace
                 member: "Changed");
             c.TrySendMessage(writer.CreateMessage());
         }
-        public static void EmitPropertiesChanged(this DBusConnection c, ObjectPath p, ISettingsProperties properties, ReadOnlySpan<SettingsProperty> changed, ReadOnlySpan<SettingsProperty> invalidated = default)
+        public static void EmitPropertiesChanged(this global::Tmds.DBus.Protocol.DBusConnection c, global::Tmds.DBus.Protocol.ObjectPath p, ISettingsProperties properties, global::System.ReadOnlySpan<SettingsProperty> changed, global::System.ReadOnlySpan<SettingsProperty> invalidated = default)
         {
             var writer = c.GetMessageWriter();
             writer.WriteSignalHeader(
@@ -1480,7 +1475,7 @@ namespace TestNamespace
                 }
             }
             writer.WriteDictionaryEnd(dictStart);
-            var arrayStart = writer.WriteArrayStart(DBusType.String);
+            var arrayStart = writer.WriteArrayStart(global::Tmds.DBus.Protocol.DBusType.String);
             foreach (var property in invalidated)
             {
                 switch (property)
@@ -1496,11 +1491,11 @@ namespace TestNamespace
             writer.WriteArrayEnd(arrayStart);
             c.TrySendMessage(writer.CreateMessage());
         }
-        public static void EmitPropertyChanged(this DBusConnection c, ObjectPath p, ISettingsProperties properties, SettingsProperty changed)
+        public static void EmitPropertyChanged(this global::Tmds.DBus.Protocol.DBusConnection c, global::Tmds.DBus.Protocol.ObjectPath p, ISettingsProperties properties, SettingsProperty changed)
         {
             EmitPropertiesChanged(c, p, properties, stackalloc[] { changed }, default);
         }
-        public static void EmitSettingsPropertiesChanged(this DBusConnection c, ObjectPath p, string? language = default, string? theme = default, ReadOnlySpan<SettingsProperty> invalidated = default)
+        public static void EmitSettingsPropertiesChanged(this global::Tmds.DBus.Protocol.DBusConnection c, global::Tmds.DBus.Protocol.ObjectPath p, string? language = default, string? theme = default, global::System.ReadOnlySpan<SettingsProperty> invalidated = default)
         {
             var writer = c.GetMessageWriter();
             writer.WriteSignalHeader(
@@ -1523,7 +1518,7 @@ namespace TestNamespace
                 writer.Write_v_s((string)language);
             }
             writer.WriteDictionaryEnd(dictStart);
-            var arrayStart = writer.WriteArrayStart(DBusType.String);
+            var arrayStart = writer.WriteArrayStart(global::Tmds.DBus.Protocol.DBusType.String);
             foreach (var property in invalidated)
             {
                 switch (property)
@@ -1540,10 +1535,10 @@ namespace TestNamespace
             c.TrySendMessage(writer.CreateMessage());
         }
     }
-    sealed partial class Marker : Tmds.DBus.Protocol.DBusObject
+    sealed partial class Marker : global::Tmds.DBus.Protocol.DBusObject
     {
         public const string DBusInterfaceName = "org.example.Marker";
-        public Marker(Tmds.DBus.Protocol.DBusConnection connection, string destination, ObjectPath path)
+        public Marker(global::Tmds.DBus.Protocol.DBusConnection connection, string destination, global::Tmds.DBus.Protocol.ObjectPath path)
             : base(connection, destination, path)
         { }
     }
@@ -1551,7 +1546,7 @@ namespace TestNamespace
     {
         internal static class Helper
         {
-            public static DBusHandler.DBusMethod FindMethodHandler(object handler, MethodContext context)
+            public static global::Tmds.DBus.Protocol.DBusHandler.DBusMethod FindMethodHandler(object handler, global::Tmds.DBus.Protocol.MethodContext context)
             {
                 var request = context.Request;
                 return default;
@@ -1560,142 +1555,142 @@ namespace TestNamespace
     }
     static partial class ObjectFactory
     {
-        public static Calculator CreateCalculator(this DBusService service, ObjectPath path) => new Calculator(service.Connection, service.Name, path);
-        public static Settings CreateSettings(this DBusService service, ObjectPath path) => new Settings(service.Connection, service.Name, path);
-        public static Marker CreateMarker(this DBusService service, ObjectPath path) => new Marker(service.Connection, service.Name, path);
+        public static Calculator CreateCalculator(this global::Tmds.DBus.Protocol.DBusService service, global::Tmds.DBus.Protocol.ObjectPath path) => new Calculator(service.Connection, service.Name, path);
+        public static Settings CreateSettings(this global::Tmds.DBus.Protocol.DBusService service, global::Tmds.DBus.Protocol.ObjectPath path) => new Settings(service.Connection, service.Name, path);
+        public static Marker CreateMarker(this global::Tmds.DBus.Protocol.DBusService service, global::Tmds.DBus.Protocol.ObjectPath path) => new Marker(service.Connection, service.Name, path);
     }
     file static class MessageReader
     {
-        public static double Read_d(Message message)
+        public static double Read_d(global::Tmds.DBus.Protocol.Message message)
         {
             var reader = message.GetBodyReader();
             return reader.ReadDouble();
         }
-        public static (uint, double) Read_ud(Message message)
+        public static (uint, double) Read_ud(global::Tmds.DBus.Protocol.Message message)
         {
             var reader = message.GetBodyReader();
             var arg0 = reader.ReadUInt32();
             var arg1 = reader.ReadDouble();
             return (arg0, arg1);
         }
-        public static (int, int) Read_ii(Message message)
+        public static (int, int) Read_ii(global::Tmds.DBus.Protocol.Message message)
         {
             var reader = message.GetBodyReader();
             var arg0 = reader.ReadInt32();
             var arg1 = reader.ReadInt32();
             return (arg0, arg1);
         }
-        public static (bool, double) Read_bd(Message message)
+        public static (bool, double) Read_bd(global::Tmds.DBus.Protocol.Message message)
         {
             var reader = message.GetBodyReader();
             var arg0 = reader.ReadBool();
             var arg1 = reader.ReadDouble();
             return (arg0, arg1);
         }
-        public static (string, double) Read_rsdz(Message message)
+        public static (string, double) Read_rsdz(global::Tmds.DBus.Protocol.Message message)
         {
             var reader = message.GetBodyReader();
             return reader.Read_rsdz();
         }
-        public static string Read_s(Message message)
+        public static string Read_s(global::Tmds.DBus.Protocol.Message message)
         {
             var reader = message.GetBodyReader();
             return reader.ReadString();
         }
-        public static (string, double) Read_sd(Message message)
+        public static (string, double) Read_sd(global::Tmds.DBus.Protocol.Message message)
         {
             var reader = message.GetBodyReader();
             var arg0 = reader.ReadString();
             var arg1 = reader.ReadDouble();
             return (arg0, arg1);
         }
-        public static double Read_v_d(Message message)
+        public static double Read_v_d(global::Tmds.DBus.Protocol.Message message)
         {
             var reader = message.GetBodyReader();
             reader.ReadSignature("d"u8);
             return reader.ReadDouble();
         }
-        public static ObjectPath Read_v_o(Message message)
+        public static global::Tmds.DBus.Protocol.ObjectPath Read_v_o(global::Tmds.DBus.Protocol.Message message)
         {
             var reader = message.GetBodyReader();
             reader.ReadSignature("o"u8);
             return reader.ReadObjectPath();
         }
-        public static (string, double) Read_v_rsdz(Message message)
+        public static (string, double) Read_v_rsdz(global::Tmds.DBus.Protocol.Message message)
         {
             var reader = message.GetBodyReader();
             reader.ReadSignature("(sd)"u8);
             return reader.Read_rsdz();
         }
-        public static ValueTuple<bool> Read_v_rbz(Message message)
+        public static global::System.ValueTuple<bool> Read_v_rbz(global::Tmds.DBus.Protocol.Message message)
         {
             var reader = message.GetBodyReader();
             reader.ReadSignature("(b)"u8);
             return reader.Read_rbz();
         }
-        public static int Read_i(Message message)
+        public static int Read_i(global::Tmds.DBus.Protocol.Message message)
         {
             var reader = message.GetBodyReader();
             return reader.ReadInt32();
         }
-        public static (double, double) Read_dd(Message message)
+        public static (double, double) Read_dd(global::Tmds.DBus.Protocol.Message message)
         {
             var reader = message.GetBodyReader();
             var arg0 = reader.ReadDouble();
             var arg1 = reader.ReadDouble();
             return (arg0, arg1);
         }
-        public static string Read_v_s(Message message)
+        public static string Read_v_s(global::Tmds.DBus.Protocol.Message message)
         {
             var reader = message.GetBodyReader();
             reader.ReadSignature("s"u8);
             return reader.ReadString();
         }
-        public static (string, double) Read_rsdz(this ref Reader reader)
+        public static (string, double) Read_rsdz(this ref global::Tmds.DBus.Protocol.Reader reader)
         {
             reader.AlignStruct();
             return (reader.ReadString(), reader.ReadDouble());
         }
-        public static ValueTuple<bool> Read_rbz(this ref Reader reader)
+        public static global::System.ValueTuple<bool> Read_rbz(this ref global::Tmds.DBus.Protocol.Reader reader)
         {
             reader.AlignStruct();
-            return new ValueTuple<bool>(reader.ReadBool());
+            return new global::System.ValueTuple<bool>(reader.ReadBool());
         }
     }
     file static class MessageWriterExtensions
     {
-        public static void Write_rsdz(this ref MessageWriter writer, (string, double) value)
+        public static void Write_rsdz(this ref global::Tmds.DBus.Protocol.MessageWriter writer, (string, double) value)
         {
             writer.WriteStructureStart();
             writer.WriteString(value.Item1);
             writer.WriteDouble(value.Item2);
         }
-        public static void Write_rbz(this ref MessageWriter writer, ValueTuple<bool> value)
+        public static void Write_rbz(this ref global::Tmds.DBus.Protocol.MessageWriter writer, global::System.ValueTuple<bool> value)
         {
             writer.WriteStructureStart();
             writer.WriteBool(value.Item1);
         }
-        public static void Write_v_d(this ref MessageWriter writer, double value)
+        public static void Write_v_d(this ref global::Tmds.DBus.Protocol.MessageWriter writer, double value)
         {
             writer.WriteSignature("d");
             writer.WriteDouble(value);
         }
-        public static void Write_v_o(this ref MessageWriter writer, ObjectPath value)
+        public static void Write_v_o(this ref global::Tmds.DBus.Protocol.MessageWriter writer, global::Tmds.DBus.Protocol.ObjectPath value)
         {
             writer.WriteSignature("o");
             writer.WriteObjectPath(value);
         }
-        public static void Write_v_rsdz(this ref MessageWriter writer, (string, double) value)
+        public static void Write_v_rsdz(this ref global::Tmds.DBus.Protocol.MessageWriter writer, (string, double) value)
         {
             writer.WriteSignature("(sd)");
             writer.Write_rsdz(value);
         }
-        public static void Write_v_rbz(this ref MessageWriter writer, ValueTuple<bool> value)
+        public static void Write_v_rbz(this ref global::Tmds.DBus.Protocol.MessageWriter writer, global::System.ValueTuple<bool> value)
         {
             writer.WriteSignature("(b)");
             writer.Write_rbz(value);
         }
-        public static void Write_v_s(this ref MessageWriter writer, string value)
+        public static void Write_v_s(this ref global::Tmds.DBus.Protocol.MessageWriter writer, string value)
         {
             writer.WriteSignature("s");
             writer.WriteString(value);
@@ -1708,14 +1703,10 @@ namespace TestNamespace
 #nullable enable
 namespace Tmds.DBus.Protocol
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Threading;
-    using System.Threading.Tasks;
     abstract class DBusHandler : IPathMethodHandler
     {
         // Identifies the D-Bus interfaces. Used with SupportsInterface to filter interfaces per path.
-        [Flags]
+        [global::System.Flags]
         public enum DBusInterface
         {
             // OrgFreedesktopDBusIntrospectable = 1,
@@ -1723,7 +1714,7 @@ namespace Tmds.DBus.Protocol
             OrgExampleMarker = 4,
             OrgExampleSettings = 8,
         }
-        private static ReadOnlyMemory<byte> OrgExampleCalculatorXml { get; } =
+        private static global::System.ReadOnlyMemory<byte> OrgExampleCalculatorXml { get; } =
             """
             <interface name="org.example.Calculator">
               <method name="Clear" />
@@ -1783,12 +1774,12 @@ namespace Tmds.DBus.Protocol
             </interface>
 
             """u8.ToArray();
-        private static ReadOnlyMemory<byte> OrgExampleMarkerXml { get; } =
+        private static global::System.ReadOnlyMemory<byte> OrgExampleMarkerXml { get; } =
             """
             <interface name="org.example.Marker" />
 
             """u8.ToArray();
-        private static ReadOnlyMemory<byte> OrgExampleSettingsXml { get; } =
+        private static global::System.ReadOnlyMemory<byte> OrgExampleSettingsXml { get; } =
             """
             <interface name="org.example.Settings">
               <method name="Save" />
@@ -1799,19 +1790,19 @@ namespace Tmds.DBus.Protocol
             </interface>
 
             """u8.ToArray();
-        private readonly SendOrPostCallback? _postDelegate;
+        private readonly global::System.Threading.SendOrPostCallback? _postDelegate;
         private const DBusInterface OrgFreedesktopDBusIntrospectable = (DBusInterface)1;
         private const DBusInterface InterfacesWithProperties = DBusInterface.OrgExampleCalculator | DBusInterface.OrgExampleSettings;
         public string Path { get; }
         public bool HandlesChildPaths { get; }
         public DBusConnection Connection { get; }
         // The SynchronizationContext on which method handlers are invoked.
-        protected SynchronizationContext? SynchronizationContext { get; }
+        protected global::System.Threading.SynchronizationContext? SynchronizationContext { get; }
         protected DBusHandler(DBusConnection connection, string path, bool handlesChildPaths, bool handleOnCapturedContext = true)
-            : this(connection, path, handlesChildPaths, handleOnCapturedContext ? SynchronizationContext.Current : null)
+            : this(connection, path, handlesChildPaths, handleOnCapturedContext ? global::System.Threading.SynchronizationContext.Current : null)
         {
         }
-        protected DBusHandler(DBusConnection connection, string path, bool handlesChildPaths, SynchronizationContext? synchronizationContext)
+        protected DBusHandler(DBusConnection connection, string path, bool handlesChildPaths, global::System.Threading.SynchronizationContext? synchronizationContext)
         {
             Connection = connection;
             Path = path;
@@ -1829,19 +1820,19 @@ namespace Tmds.DBus.Protocol
             }
         }
         // Override to add cross-cutting logic (e.g. logging, error handling) around method invocations.
-        protected virtual async ValueTask InvokeAsync(DBusMethod method, MethodContext context)
+        protected virtual async global::System.Threading.Tasks.ValueTask InvokeAsync(DBusMethod method, MethodContext context)
         {
             try
             {
                 await method.Invoke(context).ConfigureAwait(false);
             }
-            catch (Exception ex)
+            catch (global::System.Exception ex)
             {
                 HandleException(context, ex);
             }
         }
         // Override to customize exception handling for method invocations.
-        protected virtual void HandleException(MethodContext context, Exception ex)
+        protected virtual void HandleException(MethodContext context, global::System.Exception ex)
         {
             if (context.HandleException(ex, shouldDisconnect: false))
             {
@@ -1851,7 +1842,7 @@ namespace Tmds.DBus.Protocol
             {
                 context.ReplyError(dbusEx.ErrorName, dbusEx.ErrorMessage);
             }
-            else if (ex is ArgumentException)
+            else if (ex is global::System.ArgumentException)
             {
                 context.ReplyError("org.freedesktop.DBus.Error.InvalidArgs", ex.Message);
             }
@@ -1861,19 +1852,19 @@ namespace Tmds.DBus.Protocol
             }
         }
         // Override to filter interfaces for specific paths when the handler manages multiple paths.
-        protected virtual bool SupportsInterface(DBusInterface dbusInterface, ReadOnlySpan<char> path)
+        protected virtual bool SupportsInterface(DBusInterface dbusInterface, global::System.ReadOnlySpan<char> path)
         {
             return true;
         }
         // Override to customize introspection, e.g. to include child node names.
-        protected virtual ValueTask HandleIntrospectAsync(IntrospectContext context)
+        protected virtual global::System.Threading.Tasks.ValueTask HandleIntrospectAsync(IntrospectContext context)
         {
-            DBusInterface interfaces = GetSupportedInterfaces(context.MethodContext.Request.PathAsString.AsSpan());
+            DBusInterface interfaces = GetSupportedInterfaces(global::System.MemoryExtensions.AsSpan(context.MethodContext.Request.PathAsString));
             context.Reply(interfaces);
             return default;
         }
         // Context for IntrospectAsync. Call Reply to send the introspection XML response.
-        protected readonly struct IntrospectContext : IDisposable
+        protected readonly struct IntrospectContext : global::System.IDisposable
         {
             public MethodContext MethodContext { get; }
             public IntrospectContext(MethodContext methodContext)
@@ -1881,9 +1872,9 @@ namespace Tmds.DBus.Protocol
                 MethodContext = methodContext;
             }
             public void Dispose() => MethodContext.Dispose();
-            public void Reply(DBusInterface interfaces, IList<string>? childNames = null)
+            public void Reply(DBusInterface interfaces, global::System.Collections.Generic.IList<string>? childNames = null)
             {
-                var interfaceXmls = new ReadOnlyMemory<byte>[4];
+                var interfaceXmls = new global::System.ReadOnlyMemory<byte>[4];
                 int count = 0;
                 if ((interfaces & DBusInterface.OrgExampleCalculator) != 0)
                 {
@@ -1903,42 +1894,42 @@ namespace Tmds.DBus.Protocol
                 }
                 if (childNames is not null)
                 {
-                    MethodContext.ReplyIntrospectXml(interfaceXmls.AsSpan(0, count), childNames);
+                    MethodContext.ReplyIntrospectXml(global::System.MemoryExtensions.AsSpan(interfaceXmls, 0, count), childNames);
                 }
                 else
                 {
-                    MethodContext.ReplyIntrospectXml(interfaceXmls.AsSpan(0, count));
+                    MethodContext.ReplyIntrospectXml(global::System.MemoryExtensions.AsSpan(interfaceXmls, 0, count));
                 }
             }
         }
         internal readonly struct DBusMethod
         {
-            private readonly Func<object, MethodContext, ValueTask> _method;
+            private readonly global::System.Func<object, MethodContext, global::System.Threading.Tasks.ValueTask> _method;
             private readonly object _target;
-            public DBusMethod(Func<object, MethodContext, ValueTask> method, object target)
+            public DBusMethod(global::System.Func<object, MethodContext, global::System.Threading.Tasks.ValueTask> method, object target)
             {
                 _method = method;
                 _target = target;
             }
             public bool HasValue => _method is not null;
-            public ValueTask Invoke(MethodContext context)
+            public global::System.Threading.Tasks.ValueTask Invoke(MethodContext context)
             {
                 return _method?.Invoke(_target, context) ?? default;
             }
         }
-        ValueTask IPathMethodHandler.HandleMethodAsync(MethodContext context)
+        global::System.Threading.Tasks.ValueTask IPathMethodHandler.HandleMethodAsync(MethodContext context)
         {
             DBusInterface dbusInterface = ParseInterface(context);
-            DBusMethod method = (dbusInterface != OrgFreedesktopDBusIntrospectable && !SupportsInterface(dbusInterface, context.Request.PathAsString.AsSpan())) ? default : FindMethodHandler(context, dbusInterface);
+            DBusMethod method = (dbusInterface != OrgFreedesktopDBusIntrospectable && !SupportsInterface(dbusInterface, global::System.MemoryExtensions.AsSpan(context.Request.PathAsString))) ? default : FindMethodHandler(context, dbusInterface);
             if (!method.HasValue)
             {
                 return default;
             }
             return HandleAsync(method, context);
         }
-        private ValueTask HandleAsync(DBusMethod method, MethodContext context)
+        private global::System.Threading.Tasks.ValueTask HandleAsync(DBusMethod method, MethodContext context)
         {
-            SynchronizationContext? synchronizationContext = SynchronizationContext;
+            global::System.Threading.SynchronizationContext? synchronizationContext = SynchronizationContext;
             if (synchronizationContext is null)
             {
                 return InvokeAsync(method, context);
@@ -1950,7 +1941,7 @@ namespace Tmds.DBus.Protocol
                 return default;
             }
         }
-        private async ValueTask InvokeAndDisposeAsync(DBusMethod method, MethodContext context)
+        private async global::System.Threading.Tasks.ValueTask InvokeAndDisposeAsync(DBusMethod method, MethodContext context)
         {
             try
             {
@@ -2011,7 +2002,7 @@ namespace Tmds.DBus.Protocol
             };
             return result;
         }
-        protected DBusInterface GetSupportedInterfaces(ReadOnlySpan<char> path)
+        protected DBusInterface GetSupportedInterfaces(global::System.ReadOnlySpan<char> path)
         {
             DBusInterface interfaces = default;
             if (SupportsInterface(DBusInterface.OrgExampleCalculator, path) && this is TestNamespace.ICalculatorHandler)

--- a/test/Tmds.DBus.Generator.Tests/CodeGenerationTests.VerifyGeneratedOutput_ProxyOnly.verified.txt
+++ b/test/Tmds.DBus.Generator.Tests/CodeGenerationTests.VerifyGeneratedOutput_ProxyOnly.verified.txt
@@ -3,11 +3,6 @@
 #nullable enable
 namespace TestNamespace
 {
-    using System;
-    using Tmds.DBus.Protocol;
-    using System.Collections.Generic;
-    using System.Threading.Tasks;
-    using System.Runtime.CompilerServices;
     enum CalculatorProperty
     {
         UnknownProperty = 0,
@@ -19,16 +14,16 @@ namespace TestNamespace
     interface ICalculatorProperties
     {
         double LastResult { get; }
-        ObjectPath CurrentPath { get; }
+        global::Tmds.DBus.Protocol.ObjectPath CurrentPath { get; }
         (string, double) CurrentEntry { get; }
-        ValueTuple<bool> IsActive { get; set; }
+        global::System.ValueTuple<bool> IsActive { get; set; }
     }
     interface INullableCalculatorProperties
     {
         double? LastResult { get; }
-        ObjectPath? CurrentPath { get; }
+        global::Tmds.DBus.Protocol.ObjectPath? CurrentPath { get; }
         (string, double)? CurrentEntry { get; }
-        ValueTuple<bool>? IsActive { get; }
+        global::System.ValueTuple<bool>? IsActive { get; }
         bool AreAllPropertiesSet();
         CalculatorProperties EnsureAllPropertiesSet();
     }
@@ -47,14 +42,14 @@ namespace TestNamespace
         private static uint Flag(CalculatorProperty property) => property == 0 ? 0 : 1U << ((int)property - 1);
         public CalculatorProperties() { }
         #nullable disable
-        [System.Diagnostics.CodeAnalysis.SetsRequiredMembers]
+        [global::System.Diagnostics.CodeAnalysis.SetsRequiredMembers]
         private CalculatorProperties(bool _) { }
         #nullable enable
         private void EnsureSet(CalculatorProperty property)
         {
             if (!HasFlag(__set, property))
             {
-                throw new InvalidOperationException("Property is not set.");
+                throw new global::System.InvalidOperationException("Property is not set.");
             }
         }
         private double _lastResult = default!;
@@ -63,8 +58,8 @@ namespace TestNamespace
             get { EnsureSet(CalculatorProperty.LastResult); return _lastResult; }
             set { _lastResult = value; __set |= Flag(CalculatorProperty.LastResult); }
         }
-        private ObjectPath _currentPath = default!;
-        public required ObjectPath CurrentPath
+        private global::Tmds.DBus.Protocol.ObjectPath _currentPath = default!;
+        public required global::Tmds.DBus.Protocol.ObjectPath CurrentPath
         {
             get { EnsureSet(CalculatorProperty.CurrentPath); return _currentPath; }
             set { _currentPath = value; __set |= Flag(CalculatorProperty.CurrentPath); }
@@ -75,20 +70,20 @@ namespace TestNamespace
             get { EnsureSet(CalculatorProperty.CurrentEntry); return _currentEntry; }
             set { _currentEntry = value; __set |= Flag(CalculatorProperty.CurrentEntry); }
         }
-        private ValueTuple<bool> _isActive = default!;
-        public required ValueTuple<bool> IsActive
+        private global::System.ValueTuple<bool> _isActive = default!;
+        public required global::System.ValueTuple<bool> IsActive
         {
             get { EnsureSet(CalculatorProperty.IsActive); return _isActive; }
             set { _isActive = value; __set |= Flag(CalculatorProperty.IsActive); }
         }
         double? INullableCalculatorProperties.LastResult
             => IsSet(CalculatorProperty.LastResult) ? _lastResult : default(double?);
-        ObjectPath? INullableCalculatorProperties.CurrentPath
-            => IsSet(CalculatorProperty.CurrentPath) ? _currentPath : default(ObjectPath?);
+        global::Tmds.DBus.Protocol.ObjectPath? INullableCalculatorProperties.CurrentPath
+            => IsSet(CalculatorProperty.CurrentPath) ? _currentPath : default(global::Tmds.DBus.Protocol.ObjectPath?);
         (string, double)? INullableCalculatorProperties.CurrentEntry
             => IsSet(CalculatorProperty.CurrentEntry) ? _currentEntry : default((string, double)?);
-        ValueTuple<bool>? INullableCalculatorProperties.IsActive
-            => IsSet(CalculatorProperty.IsActive) ? _isActive : default(ValueTuple<bool>?);
+        global::System.ValueTuple<bool>? INullableCalculatorProperties.IsActive
+            => IsSet(CalculatorProperty.IsActive) ? _isActive : default(global::System.ValueTuple<bool>?);
         bool IChangedCalculatorProperties.HasLastResultChanged
             => IsSet(CalculatorProperty.LastResult) || IsInvalidated(CalculatorProperty.LastResult);
         bool IChangedCalculatorProperties.HasCurrentPathChanged
@@ -119,13 +114,13 @@ namespace TestNamespace
         {
             if (!AreAllPropertiesSet())
             {
-                throw new DBusUnexpectedValueException($"Not all properties have been set (0x{__set:x}).");
+                throw new global::Tmds.DBus.Protocol.DBusUnexpectedValueException($"Not all properties have been set (0x{__set:x}).");
             }
         }
-        public static CalculatorProperties ReadFrom(ref Reader reader, bool withInvalidated)
+        public static CalculatorProperties ReadFrom(ref global::Tmds.DBus.Protocol.Reader reader, bool withInvalidated)
         {
             var props = CreateUninitialized();
-            ArrayEnd arrayEnd = reader.ReadArrayStart(DBusType.Struct);
+            global::Tmds.DBus.Protocol.ArrayEnd arrayEnd = reader.ReadArrayStart(global::Tmds.DBus.Protocol.DBusType.Struct);
             while (reader.HasNext(arrayEnd))
             {
                 var property = reader.ReadString();
@@ -154,7 +149,7 @@ namespace TestNamespace
             }
             if (withInvalidated)
             {
-                ArrayEnd invalidatedEnd = reader.ReadArrayStart(DBusType.String);
+                global::Tmds.DBus.Protocol.ArrayEnd invalidatedEnd = reader.ReadArrayStart(global::Tmds.DBus.Protocol.DBusType.String);
                 while (reader.HasNext(invalidatedEnd))
                 {
                     var propertyName = reader.ReadString();
@@ -171,16 +166,16 @@ namespace TestNamespace
             return props;
         }
     }
-    sealed partial class Calculator : Tmds.DBus.Protocol.DBusObject
+    sealed partial class Calculator : global::Tmds.DBus.Protocol.DBusObject
     {
         public const string DBusInterfaceName = "org.example.Calculator";
-        public Calculator(Tmds.DBus.Protocol.DBusConnection connection, string destination, ObjectPath path)
+        public Calculator(global::Tmds.DBus.Protocol.DBusConnection connection, string destination, global::Tmds.DBus.Protocol.ObjectPath path)
             : base(connection, destination, path)
         { }
-        public Task ClearAsync()
+        public global::System.Threading.Tasks.Task ClearAsync()
         {
             return Connection.CallMethodAsync(CreateMessage());
-            MessageBuffer CreateMessage()
+            global::Tmds.DBus.Protocol.MessageBuffer CreateMessage()
             {
                 var writer = Connection.GetMessageWriter();
                 writer.WriteMethodCallHeader(
@@ -191,10 +186,10 @@ namespace TestNamespace
                 return writer.CreateMessage();
             }
         }
-        public Task<double> GetResultAsync()
+        public global::System.Threading.Tasks.Task<double> GetResultAsync()
         {
-            return Connection.CallMethodAsync(CreateMessage(), (Message m, object? s) => MessageReader.Read_d(m), this);
-            MessageBuffer CreateMessage()
+            return Connection.CallMethodAsync(CreateMessage(), (global::Tmds.DBus.Protocol.Message m, object? s) => MessageReader.Read_d(m), this);
+            global::Tmds.DBus.Protocol.MessageBuffer CreateMessage()
             {
                 var writer = Connection.GetMessageWriter();
                 writer.WriteMethodCallHeader(
@@ -205,10 +200,10 @@ namespace TestNamespace
                 return writer.CreateMessage();
             }
         }
-        public Task<(uint Count, double Total)> GetStatsAsync()
+        public global::System.Threading.Tasks.Task<(uint Count, double Total)> GetStatsAsync()
         {
-            return Connection.CallMethodAsync(CreateMessage(), (Message m, object? s) => MessageReader.Read_ud(m), this);
-            MessageBuffer CreateMessage()
+            return Connection.CallMethodAsync(CreateMessage(), (global::Tmds.DBus.Protocol.Message m, object? s) => MessageReader.Read_ud(m), this);
+            global::Tmds.DBus.Protocol.MessageBuffer CreateMessage()
             {
                 var writer = Connection.GetMessageWriter();
                 writer.WriteMethodCallHeader(
@@ -219,10 +214,10 @@ namespace TestNamespace
                 return writer.CreateMessage();
             }
         }
-        public Task StoreAsync(double value)
+        public global::System.Threading.Tasks.Task StoreAsync(double value)
         {
             return Connection.CallMethodAsync(CreateMessage());
-            MessageBuffer CreateMessage()
+            global::Tmds.DBus.Protocol.MessageBuffer CreateMessage()
             {
                 var writer = Connection.GetMessageWriter();
                 writer.WriteMethodCallHeader(
@@ -235,10 +230,10 @@ namespace TestNamespace
                 return writer.CreateMessage();
             }
         }
-        public Task<double> SquareAsync(double input)
+        public global::System.Threading.Tasks.Task<double> SquareAsync(double input)
         {
-            return Connection.CallMethodAsync(CreateMessage(), (Message m, object? s) => MessageReader.Read_d(m), this);
-            MessageBuffer CreateMessage()
+            return Connection.CallMethodAsync(CreateMessage(), (global::Tmds.DBus.Protocol.Message m, object? s) => MessageReader.Read_d(m), this);
+            global::Tmds.DBus.Protocol.MessageBuffer CreateMessage()
             {
                 var writer = Connection.GetMessageWriter();
                 writer.WriteMethodCallHeader(
@@ -251,10 +246,10 @@ namespace TestNamespace
                 return writer.CreateMessage();
             }
         }
-        public Task<(int Quotient, int Remainder)> DivModAsync(int dividend)
+        public global::System.Threading.Tasks.Task<(int Quotient, int Remainder)> DivModAsync(int dividend)
         {
-            return Connection.CallMethodAsync(CreateMessage(), (Message m, object? s) => MessageReader.Read_ii(m), this);
-            MessageBuffer CreateMessage()
+            return Connection.CallMethodAsync(CreateMessage(), (global::Tmds.DBus.Protocol.Message m, object? s) => MessageReader.Read_ii(m), this);
+            global::Tmds.DBus.Protocol.MessageBuffer CreateMessage()
             {
                 var writer = Connection.GetMessageWriter();
                 writer.WriteMethodCallHeader(
@@ -267,10 +262,10 @@ namespace TestNamespace
                 return writer.CreateMessage();
             }
         }
-        public Task LogOperationAsync(string operation, double value)
+        public global::System.Threading.Tasks.Task LogOperationAsync(string operation, double value)
         {
             return Connection.CallMethodAsync(CreateMessage());
-            MessageBuffer CreateMessage()
+            global::Tmds.DBus.Protocol.MessageBuffer CreateMessage()
             {
                 var writer = Connection.GetMessageWriter();
                 writer.WriteMethodCallHeader(
@@ -284,10 +279,10 @@ namespace TestNamespace
                 return writer.CreateMessage();
             }
         }
-        public Task<double> AddAsync(double a, double b)
+        public global::System.Threading.Tasks.Task<double> AddAsync(double a, double b)
         {
-            return Connection.CallMethodAsync(CreateMessage(), (Message m, object? s) => MessageReader.Read_d(m), this);
-            MessageBuffer CreateMessage()
+            return Connection.CallMethodAsync(CreateMessage(), (global::Tmds.DBus.Protocol.Message m, object? s) => MessageReader.Read_d(m), this);
+            global::Tmds.DBus.Protocol.MessageBuffer CreateMessage()
             {
                 var writer = Connection.GetMessageWriter();
                 writer.WriteMethodCallHeader(
@@ -301,10 +296,10 @@ namespace TestNamespace
                 return writer.CreateMessage();
             }
         }
-        public Task<(bool Equal, double Difference)> CompareAsync(double a, double b)
+        public global::System.Threading.Tasks.Task<(bool Equal, double Difference)> CompareAsync(double a, double b)
         {
-            return Connection.CallMethodAsync(CreateMessage(), (Message m, object? s) => MessageReader.Read_bd(m), this);
-            MessageBuffer CreateMessage()
+            return Connection.CallMethodAsync(CreateMessage(), (global::Tmds.DBus.Protocol.Message m, object? s) => MessageReader.Read_bd(m), this);
+            global::Tmds.DBus.Protocol.MessageBuffer CreateMessage()
             {
                 var writer = Connection.GetMessageWriter();
                 writer.WriteMethodCallHeader(
@@ -318,10 +313,10 @@ namespace TestNamespace
                 return writer.CreateMessage();
             }
         }
-        public Task<(string, double)> GetEntryAsync(string key)
+        public global::System.Threading.Tasks.Task<(string, double)> GetEntryAsync(string key)
         {
-            return Connection.CallMethodAsync(CreateMessage(), (Message m, object? s) => MessageReader.Read_rsdz(m), this);
-            MessageBuffer CreateMessage()
+            return Connection.CallMethodAsync(CreateMessage(), (global::Tmds.DBus.Protocol.Message m, object? s) => MessageReader.Read_rsdz(m), this);
+            global::Tmds.DBus.Protocol.MessageBuffer CreateMessage()
             {
                 var writer = Connection.GetMessageWriter();
                 writer.WriteMethodCallHeader(
@@ -334,10 +329,10 @@ namespace TestNamespace
                 return writer.CreateMessage();
             }
         }
-        public Task SetEntryAsync((string, double) entry)
+        public global::System.Threading.Tasks.Task SetEntryAsync((string, double) entry)
         {
             return Connection.CallMethodAsync(CreateMessage());
-            MessageBuffer CreateMessage()
+            global::Tmds.DBus.Protocol.MessageBuffer CreateMessage()
             {
                 var writer = Connection.GetMessageWriter();
                 writer.WriteMethodCallHeader(
@@ -350,34 +345,34 @@ namespace TestNamespace
                 return writer.CreateMessage();
             }
         }
-        public ValueTask<IDisposable> WatchResetAsync(Action handler, bool emitOnCapturedContext = true)
-            => WatchResetAsync(static (Notification n) => ((Action)n.State!)(), ObserverFlags.None, emitOnCapturedContext, handler);
-        public ValueTask<IDisposable> WatchResetAsync(Func<ValueTask> handler, bool emitOnCapturedContext = true)
-            => WatchResetAsync(static (Notification n) => ((Func<ValueTask>)n.State!)(), ObserverFlags.None, emitOnCapturedContext, handler);
-        public ValueTask<IDisposable> WatchResetAsync(Action<Notification> handler, ObserverFlags flags, bool emitOnCapturedContext = true, object? state = null)
+        public global::System.Threading.Tasks.ValueTask<global::System.IDisposable> WatchResetAsync(global::System.Action handler, bool emitOnCapturedContext = true)
+            => WatchResetAsync(static (global::Tmds.DBus.Protocol.Notification n) => ((global::System.Action)n.State!)(), global::Tmds.DBus.Protocol.ObserverFlags.None, emitOnCapturedContext, handler);
+        public global::System.Threading.Tasks.ValueTask<global::System.IDisposable> WatchResetAsync(global::System.Func<global::System.Threading.Tasks.ValueTask> handler, bool emitOnCapturedContext = true)
+            => WatchResetAsync(static (global::Tmds.DBus.Protocol.Notification n) => ((global::System.Func<global::System.Threading.Tasks.ValueTask>)n.State!)(), global::Tmds.DBus.Protocol.ObserverFlags.None, emitOnCapturedContext, handler);
+        public global::System.Threading.Tasks.ValueTask<global::System.IDisposable> WatchResetAsync(global::System.Action<global::Tmds.DBus.Protocol.Notification> handler, global::Tmds.DBus.Protocol.ObserverFlags flags, bool emitOnCapturedContext = true, object? state = null)
             => Connection.WatchSignalAsync(Destination, Path, DBusInterfaceName, "Reset", handler, flags, emitOnCapturedContext, state);
-        public ValueTask<IDisposable> WatchResetAsync(Func<Notification, ValueTask> handler, ObserverFlags flags, bool emitOnCapturedContext = true, object? state = null)
+        public global::System.Threading.Tasks.ValueTask<global::System.IDisposable> WatchResetAsync(global::System.Func<global::Tmds.DBus.Protocol.Notification, global::System.Threading.Tasks.ValueTask> handler, global::Tmds.DBus.Protocol.ObserverFlags flags, bool emitOnCapturedContext = true, object? state = null)
             => Connection.WatchSignalAsync(Destination, Path, DBusInterfaceName, "Reset", handler, flags, emitOnCapturedContext, state);
-        public ValueTask<IDisposable> WatchErrorAsync(Action<string> handler, bool emitOnCapturedContext = true)
-            => WatchErrorAsync(static (Notification<string> n) => ((Action<string>)n.State!)(n.Value), ObserverFlags.None, emitOnCapturedContext, handler);
-        public ValueTask<IDisposable> WatchErrorAsync(Func<string, ValueTask> handler, bool emitOnCapturedContext = true)
-            => WatchErrorAsync(static (Notification<string> n) => ((Func<string, ValueTask>)n.State!)(n.Value), ObserverFlags.None, emitOnCapturedContext, handler);
-        public ValueTask<IDisposable> WatchErrorAsync(Action<Notification<string>> handler, ObserverFlags flags, bool emitOnCapturedContext = true, object? state = null)
-            => Connection.WatchSignalAsync(Destination, Path, DBusInterfaceName, "Error", (Message m, object? s) => MessageReader.Read_s(m), handler, flags, emitOnCapturedContext, state);
-        public ValueTask<IDisposable> WatchErrorAsync(Func<Notification<string>, ValueTask> handler, ObserverFlags flags, bool emitOnCapturedContext = true, object? state = null)
-            => Connection.WatchSignalAsync(Destination, Path, DBusInterfaceName, "Error", (Message m, object? s) => MessageReader.Read_s(m), handler, flags, emitOnCapturedContext, state);
-        public ValueTask<IDisposable> WatchOperationCompleteAsync(Action<(string Operation, double Result)> handler, bool emitOnCapturedContext = true)
-            => WatchOperationCompleteAsync(static (Notification<(string Operation, double Result)> n) => ((Action<(string Operation, double Result)>)n.State!)(n.Value), ObserverFlags.None, emitOnCapturedContext, handler);
-        public ValueTask<IDisposable> WatchOperationCompleteAsync(Func<(string Operation, double Result), ValueTask> handler, bool emitOnCapturedContext = true)
-            => WatchOperationCompleteAsync(static (Notification<(string Operation, double Result)> n) => ((Func<(string Operation, double Result), ValueTask>)n.State!)(n.Value), ObserverFlags.None, emitOnCapturedContext, handler);
-        public ValueTask<IDisposable> WatchOperationCompleteAsync(Action<Notification<(string Operation, double Result)>> handler, ObserverFlags flags, bool emitOnCapturedContext = true, object? state = null)
-            => Connection.WatchSignalAsync(Destination, Path, DBusInterfaceName, "OperationComplete", (Message m, object? s) => MessageReader.Read_sd(m), handler, flags, emitOnCapturedContext, state);
-        public ValueTask<IDisposable> WatchOperationCompleteAsync(Func<Notification<(string Operation, double Result)>, ValueTask> handler, ObserverFlags flags, bool emitOnCapturedContext = true, object? state = null)
-            => Connection.WatchSignalAsync(Destination, Path, DBusInterfaceName, "OperationComplete", (Message m, object? s) => MessageReader.Read_sd(m), handler, flags, emitOnCapturedContext, state);
-        public Task SetIsActiveAsync(ValueTuple<bool> value)
+        public global::System.Threading.Tasks.ValueTask<global::System.IDisposable> WatchErrorAsync(global::System.Action<string> handler, bool emitOnCapturedContext = true)
+            => WatchErrorAsync(static (global::Tmds.DBus.Protocol.Notification<string> n) => ((global::System.Action<string>)n.State!)(n.Value), global::Tmds.DBus.Protocol.ObserverFlags.None, emitOnCapturedContext, handler);
+        public global::System.Threading.Tasks.ValueTask<global::System.IDisposable> WatchErrorAsync(global::System.Func<string, global::System.Threading.Tasks.ValueTask> handler, bool emitOnCapturedContext = true)
+            => WatchErrorAsync(static (global::Tmds.DBus.Protocol.Notification<string> n) => ((global::System.Func<string, global::System.Threading.Tasks.ValueTask>)n.State!)(n.Value), global::Tmds.DBus.Protocol.ObserverFlags.None, emitOnCapturedContext, handler);
+        public global::System.Threading.Tasks.ValueTask<global::System.IDisposable> WatchErrorAsync(global::System.Action<global::Tmds.DBus.Protocol.Notification<string>> handler, global::Tmds.DBus.Protocol.ObserverFlags flags, bool emitOnCapturedContext = true, object? state = null)
+            => Connection.WatchSignalAsync(Destination, Path, DBusInterfaceName, "Error", (global::Tmds.DBus.Protocol.Message m, object? s) => MessageReader.Read_s(m), handler, flags, emitOnCapturedContext, state);
+        public global::System.Threading.Tasks.ValueTask<global::System.IDisposable> WatchErrorAsync(global::System.Func<global::Tmds.DBus.Protocol.Notification<string>, global::System.Threading.Tasks.ValueTask> handler, global::Tmds.DBus.Protocol.ObserverFlags flags, bool emitOnCapturedContext = true, object? state = null)
+            => Connection.WatchSignalAsync(Destination, Path, DBusInterfaceName, "Error", (global::Tmds.DBus.Protocol.Message m, object? s) => MessageReader.Read_s(m), handler, flags, emitOnCapturedContext, state);
+        public global::System.Threading.Tasks.ValueTask<global::System.IDisposable> WatchOperationCompleteAsync(global::System.Action<(string Operation, double Result)> handler, bool emitOnCapturedContext = true)
+            => WatchOperationCompleteAsync(static (global::Tmds.DBus.Protocol.Notification<(string Operation, double Result)> n) => ((global::System.Action<(string Operation, double Result)>)n.State!)(n.Value), global::Tmds.DBus.Protocol.ObserverFlags.None, emitOnCapturedContext, handler);
+        public global::System.Threading.Tasks.ValueTask<global::System.IDisposable> WatchOperationCompleteAsync(global::System.Func<(string Operation, double Result), global::System.Threading.Tasks.ValueTask> handler, bool emitOnCapturedContext = true)
+            => WatchOperationCompleteAsync(static (global::Tmds.DBus.Protocol.Notification<(string Operation, double Result)> n) => ((global::System.Func<(string Operation, double Result), global::System.Threading.Tasks.ValueTask>)n.State!)(n.Value), global::Tmds.DBus.Protocol.ObserverFlags.None, emitOnCapturedContext, handler);
+        public global::System.Threading.Tasks.ValueTask<global::System.IDisposable> WatchOperationCompleteAsync(global::System.Action<global::Tmds.DBus.Protocol.Notification<(string Operation, double Result)>> handler, global::Tmds.DBus.Protocol.ObserverFlags flags, bool emitOnCapturedContext = true, object? state = null)
+            => Connection.WatchSignalAsync(Destination, Path, DBusInterfaceName, "OperationComplete", (global::Tmds.DBus.Protocol.Message m, object? s) => MessageReader.Read_sd(m), handler, flags, emitOnCapturedContext, state);
+        public global::System.Threading.Tasks.ValueTask<global::System.IDisposable> WatchOperationCompleteAsync(global::System.Func<global::Tmds.DBus.Protocol.Notification<(string Operation, double Result)>, global::System.Threading.Tasks.ValueTask> handler, global::Tmds.DBus.Protocol.ObserverFlags flags, bool emitOnCapturedContext = true, object? state = null)
+            => Connection.WatchSignalAsync(Destination, Path, DBusInterfaceName, "OperationComplete", (global::Tmds.DBus.Protocol.Message m, object? s) => MessageReader.Read_sd(m), handler, flags, emitOnCapturedContext, state);
+        public global::System.Threading.Tasks.Task SetIsActiveAsync(global::System.ValueTuple<bool> value)
         {
             return Connection.CallMethodAsync(CreateMessage());
-            MessageBuffer CreateMessage()
+            global::Tmds.DBus.Protocol.MessageBuffer CreateMessage()
             {
                 var writer = Connection.GetMessageWriter();
                 writer.WriteMethodCallHeader(
@@ -393,57 +388,57 @@ namespace TestNamespace
                 return writer.CreateMessage();
             }
         }
-        public Task<double> GetLastResultAsync()
-            => Connection.CallMethodAsync(CreateGetPropertyMessage("LastResult"), (Message m, object? s) => MessageReader.Read_v_d(m), this);
-        public Task<ObjectPath> GetCurrentPathAsync()
-            => Connection.CallMethodAsync(CreateGetPropertyMessage("CurrentPath"), (Message m, object? s) => MessageReader.Read_v_o(m), this);
-        public Task<(string, double)> GetCurrentEntryAsync()
-            => Connection.CallMethodAsync(CreateGetPropertyMessage("CurrentEntry"), (Message m, object? s) => MessageReader.Read_v_rsdz(m), this);
-        public Task<ValueTuple<bool>> GetIsActiveAsync()
-            => Connection.CallMethodAsync(CreateGetPropertyMessage("IsActive"), (Message m, object? s) => MessageReader.Read_v_rbz(m), this);
-        public Task<CalculatorProperties> GetPropertiesAsync()
+        public global::System.Threading.Tasks.Task<double> GetLastResultAsync()
+            => Connection.CallMethodAsync(CreateGetPropertyMessage("LastResult"), (global::Tmds.DBus.Protocol.Message m, object? s) => MessageReader.Read_v_d(m), this);
+        public global::System.Threading.Tasks.Task<global::Tmds.DBus.Protocol.ObjectPath> GetCurrentPathAsync()
+            => Connection.CallMethodAsync(CreateGetPropertyMessage("CurrentPath"), (global::Tmds.DBus.Protocol.Message m, object? s) => MessageReader.Read_v_o(m), this);
+        public global::System.Threading.Tasks.Task<(string, double)> GetCurrentEntryAsync()
+            => Connection.CallMethodAsync(CreateGetPropertyMessage("CurrentEntry"), (global::Tmds.DBus.Protocol.Message m, object? s) => MessageReader.Read_v_rsdz(m), this);
+        public global::System.Threading.Tasks.Task<global::System.ValueTuple<bool>> GetIsActiveAsync()
+            => Connection.CallMethodAsync(CreateGetPropertyMessage("IsActive"), (global::Tmds.DBus.Protocol.Message m, object? s) => MessageReader.Read_v_rbz(m), this);
+        public global::System.Threading.Tasks.Task<CalculatorProperties> GetPropertiesAsync()
         {
-            return Connection.CallMethodAsync(CreateGetAllPropertiesMessage(), (Message m, object? s) => ReadMessage(m), this);
-            static CalculatorProperties ReadMessage(Message message)
+            return Connection.CallMethodAsync(CreateGetAllPropertiesMessage(), (global::Tmds.DBus.Protocol.Message m, object? s) => ReadMessage(m), this);
+            static CalculatorProperties ReadMessage(global::Tmds.DBus.Protocol.Message message)
             {
                 var reader = message.GetBodyReader();
                 return CalculatorProperties.ReadFrom(ref reader, withInvalidated: false);
             }
         }
-        public Task<INullableCalculatorProperties> GetNullablePropertiesAsync()
+        public global::System.Threading.Tasks.Task<INullableCalculatorProperties> GetNullablePropertiesAsync()
         {
-            return Connection.CallMethodAsync(CreateGetAllPropertiesMessage(), (Message m, object? s) => ReadMessage(m), this);
-            static INullableCalculatorProperties ReadMessage(Message message)
+            return Connection.CallMethodAsync(CreateGetAllPropertiesMessage(), (global::Tmds.DBus.Protocol.Message m, object? s) => ReadMessage(m), this);
+            static INullableCalculatorProperties ReadMessage(global::Tmds.DBus.Protocol.Message message)
             {
                 var reader = message.GetBodyReader();
                 return CalculatorProperties.ReadFrom(ref reader, withInvalidated: false);
             }
         }
-        public ValueTask<IDisposable> WatchPropertiesChangedAsync(Action<IChangedCalculatorProperties> handler, bool emitOnCapturedContext = true)
-            => WatchPropertiesChangedAsync(static (Notification<IChangedCalculatorProperties> n) => ((Action<IChangedCalculatorProperties>)n.State!)(n.Value), ObserverFlags.None, emitOnCapturedContext, handler);
-        public ValueTask<IDisposable> WatchPropertiesChangedAsync(Func<IChangedCalculatorProperties, ValueTask> handler, bool emitOnCapturedContext = true)
-            => WatchPropertiesChangedAsync(static (Notification<IChangedCalculatorProperties> n) => ((Func<IChangedCalculatorProperties, ValueTask>)n.State!)(n.Value), ObserverFlags.None, emitOnCapturedContext, handler);
-        public ValueTask<IDisposable> WatchPropertiesChangedAsync(Action<Notification<IChangedCalculatorProperties>> handler, ObserverFlags flags, bool emitOnCapturedContext = true, object? state = null)
+        public global::System.Threading.Tasks.ValueTask<global::System.IDisposable> WatchPropertiesChangedAsync(global::System.Action<IChangedCalculatorProperties> handler, bool emitOnCapturedContext = true)
+            => WatchPropertiesChangedAsync(static (global::Tmds.DBus.Protocol.Notification<IChangedCalculatorProperties> n) => ((global::System.Action<IChangedCalculatorProperties>)n.State!)(n.Value), global::Tmds.DBus.Protocol.ObserverFlags.None, emitOnCapturedContext, handler);
+        public global::System.Threading.Tasks.ValueTask<global::System.IDisposable> WatchPropertiesChangedAsync(global::System.Func<IChangedCalculatorProperties, global::System.Threading.Tasks.ValueTask> handler, bool emitOnCapturedContext = true)
+            => WatchPropertiesChangedAsync(static (global::Tmds.DBus.Protocol.Notification<IChangedCalculatorProperties> n) => ((global::System.Func<IChangedCalculatorProperties, global::System.Threading.Tasks.ValueTask>)n.State!)(n.Value), global::Tmds.DBus.Protocol.ObserverFlags.None, emitOnCapturedContext, handler);
+        public global::System.Threading.Tasks.ValueTask<global::System.IDisposable> WatchPropertiesChangedAsync(global::System.Action<global::Tmds.DBus.Protocol.Notification<IChangedCalculatorProperties>> handler, global::Tmds.DBus.Protocol.ObserverFlags flags, bool emitOnCapturedContext = true, object? state = null)
         {
-            return Connection.WatchPropertiesChangedAsync(Destination, Path, DBusInterfaceName, (Message m, object? s) => ReadMessage(m), handler, flags, emitOnCapturedContext, state);
-            static IChangedCalculatorProperties ReadMessage(Message message)
+            return Connection.WatchPropertiesChangedAsync(Destination, Path, DBusInterfaceName, (global::Tmds.DBus.Protocol.Message m, object? s) => ReadMessage(m), handler, flags, emitOnCapturedContext, state);
+            static IChangedCalculatorProperties ReadMessage(global::Tmds.DBus.Protocol.Message message)
             {
                 var reader = message.GetBodyReader();
                 reader.ReadString(); // interface
                 return CalculatorProperties.ReadFrom(ref reader, withInvalidated: true);
             }
         }
-        public ValueTask<IDisposable> WatchPropertiesChangedAsync(Func<Notification<IChangedCalculatorProperties>, ValueTask> handler, ObserverFlags flags, bool emitOnCapturedContext = true, object? state = null)
+        public global::System.Threading.Tasks.ValueTask<global::System.IDisposable> WatchPropertiesChangedAsync(global::System.Func<global::Tmds.DBus.Protocol.Notification<IChangedCalculatorProperties>, global::System.Threading.Tasks.ValueTask> handler, global::Tmds.DBus.Protocol.ObserverFlags flags, bool emitOnCapturedContext = true, object? state = null)
         {
-            return Connection.WatchPropertiesChangedAsync(Destination, Path, DBusInterfaceName, (Message m, object? s) => ReadMessage(m), handler, flags, emitOnCapturedContext, state);
-            static IChangedCalculatorProperties ReadMessage(Message message)
+            return Connection.WatchPropertiesChangedAsync(Destination, Path, DBusInterfaceName, (global::Tmds.DBus.Protocol.Message m, object? s) => ReadMessage(m), handler, flags, emitOnCapturedContext, state);
+            static IChangedCalculatorProperties ReadMessage(global::Tmds.DBus.Protocol.Message message)
             {
                 var reader = message.GetBodyReader();
                 reader.ReadString(); // interface
                 return CalculatorProperties.ReadFrom(ref reader, withInvalidated: true);
             }
         }
-        private MessageBuffer CreateGetPropertyMessage(string property)
+        private global::Tmds.DBus.Protocol.MessageBuffer CreateGetPropertyMessage(string property)
         {
             var writer = Connection.GetMessageWriter();
             writer.WriteMethodCallHeader(
@@ -456,7 +451,7 @@ namespace TestNamespace
             writer.WriteString(property);
             return writer.CreateMessage();
         }
-        private MessageBuffer CreateGetAllPropertiesMessage()
+        private global::Tmds.DBus.Protocol.MessageBuffer CreateGetAllPropertiesMessage()
         {
             var writer = Connection.GetMessageWriter();
             writer.WriteMethodCallHeader(
@@ -501,14 +496,14 @@ namespace TestNamespace
         private static uint Flag(SettingsProperty property) => property == 0 ? 0 : 1U << ((int)property - 1);
         public SettingsProperties() { }
         #nullable disable
-        [System.Diagnostics.CodeAnalysis.SetsRequiredMembers]
+        [global::System.Diagnostics.CodeAnalysis.SetsRequiredMembers]
         private SettingsProperties(bool _) { }
         #nullable enable
         private void EnsureSet(SettingsProperty property)
         {
             if (!HasFlag(__set, property))
             {
-                throw new InvalidOperationException("Property is not set.");
+                throw new global::System.InvalidOperationException("Property is not set.");
             }
         }
         private string _theme = default!;
@@ -553,13 +548,13 @@ namespace TestNamespace
         {
             if (!AreAllPropertiesSet())
             {
-                throw new DBusUnexpectedValueException($"Not all properties have been set (0x{__set:x}).");
+                throw new global::Tmds.DBus.Protocol.DBusUnexpectedValueException($"Not all properties have been set (0x{__set:x}).");
             }
         }
-        public static SettingsProperties ReadFrom(ref Reader reader, bool withInvalidated)
+        public static SettingsProperties ReadFrom(ref global::Tmds.DBus.Protocol.Reader reader, bool withInvalidated)
         {
             var props = CreateUninitialized();
-            ArrayEnd arrayEnd = reader.ReadArrayStart(DBusType.Struct);
+            global::Tmds.DBus.Protocol.ArrayEnd arrayEnd = reader.ReadArrayStart(global::Tmds.DBus.Protocol.DBusType.Struct);
             while (reader.HasNext(arrayEnd))
             {
                 var property = reader.ReadString();
@@ -580,7 +575,7 @@ namespace TestNamespace
             }
             if (withInvalidated)
             {
-                ArrayEnd invalidatedEnd = reader.ReadArrayStart(DBusType.String);
+                global::Tmds.DBus.Protocol.ArrayEnd invalidatedEnd = reader.ReadArrayStart(global::Tmds.DBus.Protocol.DBusType.String);
                 while (reader.HasNext(invalidatedEnd))
                 {
                     var propertyName = reader.ReadString();
@@ -596,16 +591,16 @@ namespace TestNamespace
         }
         double ISettingsProperties.Volume { set { } }
     }
-    sealed partial class Settings : Tmds.DBus.Protocol.DBusObject
+    sealed partial class Settings : global::Tmds.DBus.Protocol.DBusObject
     {
         public const string DBusInterfaceName = "org.example.Settings";
-        public Settings(Tmds.DBus.Protocol.DBusConnection connection, string destination, ObjectPath path)
+        public Settings(global::Tmds.DBus.Protocol.DBusConnection connection, string destination, global::Tmds.DBus.Protocol.ObjectPath path)
             : base(connection, destination, path)
         { }
-        public Task SaveAsync()
+        public global::System.Threading.Tasks.Task SaveAsync()
         {
             return Connection.CallMethodAsync(CreateMessage());
-            MessageBuffer CreateMessage()
+            global::Tmds.DBus.Protocol.MessageBuffer CreateMessage()
             {
                 var writer = Connection.GetMessageWriter();
                 writer.WriteMethodCallHeader(
@@ -616,18 +611,18 @@ namespace TestNamespace
                 return writer.CreateMessage();
             }
         }
-        public ValueTask<IDisposable> WatchChangedAsync(Action handler, bool emitOnCapturedContext = true)
-            => WatchChangedAsync(static (Notification n) => ((Action)n.State!)(), ObserverFlags.None, emitOnCapturedContext, handler);
-        public ValueTask<IDisposable> WatchChangedAsync(Func<ValueTask> handler, bool emitOnCapturedContext = true)
-            => WatchChangedAsync(static (Notification n) => ((Func<ValueTask>)n.State!)(), ObserverFlags.None, emitOnCapturedContext, handler);
-        public ValueTask<IDisposable> WatchChangedAsync(Action<Notification> handler, ObserverFlags flags, bool emitOnCapturedContext = true, object? state = null)
+        public global::System.Threading.Tasks.ValueTask<global::System.IDisposable> WatchChangedAsync(global::System.Action handler, bool emitOnCapturedContext = true)
+            => WatchChangedAsync(static (global::Tmds.DBus.Protocol.Notification n) => ((global::System.Action)n.State!)(), global::Tmds.DBus.Protocol.ObserverFlags.None, emitOnCapturedContext, handler);
+        public global::System.Threading.Tasks.ValueTask<global::System.IDisposable> WatchChangedAsync(global::System.Func<global::System.Threading.Tasks.ValueTask> handler, bool emitOnCapturedContext = true)
+            => WatchChangedAsync(static (global::Tmds.DBus.Protocol.Notification n) => ((global::System.Func<global::System.Threading.Tasks.ValueTask>)n.State!)(), global::Tmds.DBus.Protocol.ObserverFlags.None, emitOnCapturedContext, handler);
+        public global::System.Threading.Tasks.ValueTask<global::System.IDisposable> WatchChangedAsync(global::System.Action<global::Tmds.DBus.Protocol.Notification> handler, global::Tmds.DBus.Protocol.ObserverFlags flags, bool emitOnCapturedContext = true, object? state = null)
             => Connection.WatchSignalAsync(Destination, Path, DBusInterfaceName, "Changed", handler, flags, emitOnCapturedContext, state);
-        public ValueTask<IDisposable> WatchChangedAsync(Func<Notification, ValueTask> handler, ObserverFlags flags, bool emitOnCapturedContext = true, object? state = null)
+        public global::System.Threading.Tasks.ValueTask<global::System.IDisposable> WatchChangedAsync(global::System.Func<global::Tmds.DBus.Protocol.Notification, global::System.Threading.Tasks.ValueTask> handler, global::Tmds.DBus.Protocol.ObserverFlags flags, bool emitOnCapturedContext = true, object? state = null)
             => Connection.WatchSignalAsync(Destination, Path, DBusInterfaceName, "Changed", handler, flags, emitOnCapturedContext, state);
-        public Task SetVolumeAsync(double value)
+        public global::System.Threading.Tasks.Task SetVolumeAsync(double value)
         {
             return Connection.CallMethodAsync(CreateMessage());
-            MessageBuffer CreateMessage()
+            global::Tmds.DBus.Protocol.MessageBuffer CreateMessage()
             {
                 var writer = Connection.GetMessageWriter();
                 writer.WriteMethodCallHeader(
@@ -643,10 +638,10 @@ namespace TestNamespace
                 return writer.CreateMessage();
             }
         }
-        public Task SetLanguageAsync(string value)
+        public global::System.Threading.Tasks.Task SetLanguageAsync(string value)
         {
             return Connection.CallMethodAsync(CreateMessage());
-            MessageBuffer CreateMessage()
+            global::Tmds.DBus.Protocol.MessageBuffer CreateMessage()
             {
                 var writer = Connection.GetMessageWriter();
                 writer.WriteMethodCallHeader(
@@ -662,53 +657,53 @@ namespace TestNamespace
                 return writer.CreateMessage();
             }
         }
-        public Task<string> GetThemeAsync()
-            => Connection.CallMethodAsync(CreateGetPropertyMessage("Theme"), (Message m, object? s) => MessageReader.Read_v_s(m), this);
-        public Task<string> GetLanguageAsync()
-            => Connection.CallMethodAsync(CreateGetPropertyMessage("Language"), (Message m, object? s) => MessageReader.Read_v_s(m), this);
-        public Task<SettingsProperties> GetPropertiesAsync()
+        public global::System.Threading.Tasks.Task<string> GetThemeAsync()
+            => Connection.CallMethodAsync(CreateGetPropertyMessage("Theme"), (global::Tmds.DBus.Protocol.Message m, object? s) => MessageReader.Read_v_s(m), this);
+        public global::System.Threading.Tasks.Task<string> GetLanguageAsync()
+            => Connection.CallMethodAsync(CreateGetPropertyMessage("Language"), (global::Tmds.DBus.Protocol.Message m, object? s) => MessageReader.Read_v_s(m), this);
+        public global::System.Threading.Tasks.Task<SettingsProperties> GetPropertiesAsync()
         {
-            return Connection.CallMethodAsync(CreateGetAllPropertiesMessage(), (Message m, object? s) => ReadMessage(m), this);
-            static SettingsProperties ReadMessage(Message message)
+            return Connection.CallMethodAsync(CreateGetAllPropertiesMessage(), (global::Tmds.DBus.Protocol.Message m, object? s) => ReadMessage(m), this);
+            static SettingsProperties ReadMessage(global::Tmds.DBus.Protocol.Message message)
             {
                 var reader = message.GetBodyReader();
                 return SettingsProperties.ReadFrom(ref reader, withInvalidated: false);
             }
         }
-        public Task<INullableSettingsProperties> GetNullablePropertiesAsync()
+        public global::System.Threading.Tasks.Task<INullableSettingsProperties> GetNullablePropertiesAsync()
         {
-            return Connection.CallMethodAsync(CreateGetAllPropertiesMessage(), (Message m, object? s) => ReadMessage(m), this);
-            static INullableSettingsProperties ReadMessage(Message message)
+            return Connection.CallMethodAsync(CreateGetAllPropertiesMessage(), (global::Tmds.DBus.Protocol.Message m, object? s) => ReadMessage(m), this);
+            static INullableSettingsProperties ReadMessage(global::Tmds.DBus.Protocol.Message message)
             {
                 var reader = message.GetBodyReader();
                 return SettingsProperties.ReadFrom(ref reader, withInvalidated: false);
             }
         }
-        public ValueTask<IDisposable> WatchPropertiesChangedAsync(Action<IChangedSettingsProperties> handler, bool emitOnCapturedContext = true)
-            => WatchPropertiesChangedAsync(static (Notification<IChangedSettingsProperties> n) => ((Action<IChangedSettingsProperties>)n.State!)(n.Value), ObserverFlags.None, emitOnCapturedContext, handler);
-        public ValueTask<IDisposable> WatchPropertiesChangedAsync(Func<IChangedSettingsProperties, ValueTask> handler, bool emitOnCapturedContext = true)
-            => WatchPropertiesChangedAsync(static (Notification<IChangedSettingsProperties> n) => ((Func<IChangedSettingsProperties, ValueTask>)n.State!)(n.Value), ObserverFlags.None, emitOnCapturedContext, handler);
-        public ValueTask<IDisposable> WatchPropertiesChangedAsync(Action<Notification<IChangedSettingsProperties>> handler, ObserverFlags flags, bool emitOnCapturedContext = true, object? state = null)
+        public global::System.Threading.Tasks.ValueTask<global::System.IDisposable> WatchPropertiesChangedAsync(global::System.Action<IChangedSettingsProperties> handler, bool emitOnCapturedContext = true)
+            => WatchPropertiesChangedAsync(static (global::Tmds.DBus.Protocol.Notification<IChangedSettingsProperties> n) => ((global::System.Action<IChangedSettingsProperties>)n.State!)(n.Value), global::Tmds.DBus.Protocol.ObserverFlags.None, emitOnCapturedContext, handler);
+        public global::System.Threading.Tasks.ValueTask<global::System.IDisposable> WatchPropertiesChangedAsync(global::System.Func<IChangedSettingsProperties, global::System.Threading.Tasks.ValueTask> handler, bool emitOnCapturedContext = true)
+            => WatchPropertiesChangedAsync(static (global::Tmds.DBus.Protocol.Notification<IChangedSettingsProperties> n) => ((global::System.Func<IChangedSettingsProperties, global::System.Threading.Tasks.ValueTask>)n.State!)(n.Value), global::Tmds.DBus.Protocol.ObserverFlags.None, emitOnCapturedContext, handler);
+        public global::System.Threading.Tasks.ValueTask<global::System.IDisposable> WatchPropertiesChangedAsync(global::System.Action<global::Tmds.DBus.Protocol.Notification<IChangedSettingsProperties>> handler, global::Tmds.DBus.Protocol.ObserverFlags flags, bool emitOnCapturedContext = true, object? state = null)
         {
-            return Connection.WatchPropertiesChangedAsync(Destination, Path, DBusInterfaceName, (Message m, object? s) => ReadMessage(m), handler, flags, emitOnCapturedContext, state);
-            static IChangedSettingsProperties ReadMessage(Message message)
+            return Connection.WatchPropertiesChangedAsync(Destination, Path, DBusInterfaceName, (global::Tmds.DBus.Protocol.Message m, object? s) => ReadMessage(m), handler, flags, emitOnCapturedContext, state);
+            static IChangedSettingsProperties ReadMessage(global::Tmds.DBus.Protocol.Message message)
             {
                 var reader = message.GetBodyReader();
                 reader.ReadString(); // interface
                 return SettingsProperties.ReadFrom(ref reader, withInvalidated: true);
             }
         }
-        public ValueTask<IDisposable> WatchPropertiesChangedAsync(Func<Notification<IChangedSettingsProperties>, ValueTask> handler, ObserverFlags flags, bool emitOnCapturedContext = true, object? state = null)
+        public global::System.Threading.Tasks.ValueTask<global::System.IDisposable> WatchPropertiesChangedAsync(global::System.Func<global::Tmds.DBus.Protocol.Notification<IChangedSettingsProperties>, global::System.Threading.Tasks.ValueTask> handler, global::Tmds.DBus.Protocol.ObserverFlags flags, bool emitOnCapturedContext = true, object? state = null)
         {
-            return Connection.WatchPropertiesChangedAsync(Destination, Path, DBusInterfaceName, (Message m, object? s) => ReadMessage(m), handler, flags, emitOnCapturedContext, state);
-            static IChangedSettingsProperties ReadMessage(Message message)
+            return Connection.WatchPropertiesChangedAsync(Destination, Path, DBusInterfaceName, (global::Tmds.DBus.Protocol.Message m, object? s) => ReadMessage(m), handler, flags, emitOnCapturedContext, state);
+            static IChangedSettingsProperties ReadMessage(global::Tmds.DBus.Protocol.Message message)
             {
                 var reader = message.GetBodyReader();
                 reader.ReadString(); // interface
                 return SettingsProperties.ReadFrom(ref reader, withInvalidated: true);
             }
         }
-        private MessageBuffer CreateGetPropertyMessage(string property)
+        private global::Tmds.DBus.Protocol.MessageBuffer CreateGetPropertyMessage(string property)
         {
             var writer = Connection.GetMessageWriter();
             writer.WriteMethodCallHeader(
@@ -721,7 +716,7 @@ namespace TestNamespace
             writer.WriteString(property);
             return writer.CreateMessage();
         }
-        private MessageBuffer CreateGetAllPropertiesMessage()
+        private global::Tmds.DBus.Protocol.MessageBuffer CreateGetAllPropertiesMessage()
         {
             var writer = Connection.GetMessageWriter();
             writer.WriteMethodCallHeader(
@@ -734,114 +729,114 @@ namespace TestNamespace
             return writer.CreateMessage();
         }
     }
-    sealed partial class Marker : Tmds.DBus.Protocol.DBusObject
+    sealed partial class Marker : global::Tmds.DBus.Protocol.DBusObject
     {
         public const string DBusInterfaceName = "org.example.Marker";
-        public Marker(Tmds.DBus.Protocol.DBusConnection connection, string destination, ObjectPath path)
+        public Marker(global::Tmds.DBus.Protocol.DBusConnection connection, string destination, global::Tmds.DBus.Protocol.ObjectPath path)
             : base(connection, destination, path)
         { }
     }
     static partial class ObjectFactory
     {
-        public static Calculator CreateCalculator(this DBusService service, ObjectPath path) => new Calculator(service.Connection, service.Name, path);
-        public static Settings CreateSettings(this DBusService service, ObjectPath path) => new Settings(service.Connection, service.Name, path);
-        public static Marker CreateMarker(this DBusService service, ObjectPath path) => new Marker(service.Connection, service.Name, path);
+        public static Calculator CreateCalculator(this global::Tmds.DBus.Protocol.DBusService service, global::Tmds.DBus.Protocol.ObjectPath path) => new Calculator(service.Connection, service.Name, path);
+        public static Settings CreateSettings(this global::Tmds.DBus.Protocol.DBusService service, global::Tmds.DBus.Protocol.ObjectPath path) => new Settings(service.Connection, service.Name, path);
+        public static Marker CreateMarker(this global::Tmds.DBus.Protocol.DBusService service, global::Tmds.DBus.Protocol.ObjectPath path) => new Marker(service.Connection, service.Name, path);
     }
     file static class MessageReader
     {
-        public static double Read_d(Message message)
+        public static double Read_d(global::Tmds.DBus.Protocol.Message message)
         {
             var reader = message.GetBodyReader();
             return reader.ReadDouble();
         }
-        public static (uint, double) Read_ud(Message message)
+        public static (uint, double) Read_ud(global::Tmds.DBus.Protocol.Message message)
         {
             var reader = message.GetBodyReader();
             var arg0 = reader.ReadUInt32();
             var arg1 = reader.ReadDouble();
             return (arg0, arg1);
         }
-        public static (int, int) Read_ii(Message message)
+        public static (int, int) Read_ii(global::Tmds.DBus.Protocol.Message message)
         {
             var reader = message.GetBodyReader();
             var arg0 = reader.ReadInt32();
             var arg1 = reader.ReadInt32();
             return (arg0, arg1);
         }
-        public static (bool, double) Read_bd(Message message)
+        public static (bool, double) Read_bd(global::Tmds.DBus.Protocol.Message message)
         {
             var reader = message.GetBodyReader();
             var arg0 = reader.ReadBool();
             var arg1 = reader.ReadDouble();
             return (arg0, arg1);
         }
-        public static (string, double) Read_rsdz(Message message)
+        public static (string, double) Read_rsdz(global::Tmds.DBus.Protocol.Message message)
         {
             var reader = message.GetBodyReader();
             return reader.Read_rsdz();
         }
-        public static string Read_s(Message message)
+        public static string Read_s(global::Tmds.DBus.Protocol.Message message)
         {
             var reader = message.GetBodyReader();
             return reader.ReadString();
         }
-        public static (string, double) Read_sd(Message message)
+        public static (string, double) Read_sd(global::Tmds.DBus.Protocol.Message message)
         {
             var reader = message.GetBodyReader();
             var arg0 = reader.ReadString();
             var arg1 = reader.ReadDouble();
             return (arg0, arg1);
         }
-        public static double Read_v_d(Message message)
+        public static double Read_v_d(global::Tmds.DBus.Protocol.Message message)
         {
             var reader = message.GetBodyReader();
             reader.ReadSignature("d"u8);
             return reader.ReadDouble();
         }
-        public static ObjectPath Read_v_o(Message message)
+        public static global::Tmds.DBus.Protocol.ObjectPath Read_v_o(global::Tmds.DBus.Protocol.Message message)
         {
             var reader = message.GetBodyReader();
             reader.ReadSignature("o"u8);
             return reader.ReadObjectPath();
         }
-        public static (string, double) Read_v_rsdz(Message message)
+        public static (string, double) Read_v_rsdz(global::Tmds.DBus.Protocol.Message message)
         {
             var reader = message.GetBodyReader();
             reader.ReadSignature("(sd)"u8);
             return reader.Read_rsdz();
         }
-        public static ValueTuple<bool> Read_v_rbz(Message message)
+        public static global::System.ValueTuple<bool> Read_v_rbz(global::Tmds.DBus.Protocol.Message message)
         {
             var reader = message.GetBodyReader();
             reader.ReadSignature("(b)"u8);
             return reader.Read_rbz();
         }
-        public static string Read_v_s(Message message)
+        public static string Read_v_s(global::Tmds.DBus.Protocol.Message message)
         {
             var reader = message.GetBodyReader();
             reader.ReadSignature("s"u8);
             return reader.ReadString();
         }
-        public static (string, double) Read_rsdz(this ref Reader reader)
+        public static (string, double) Read_rsdz(this ref global::Tmds.DBus.Protocol.Reader reader)
         {
             reader.AlignStruct();
             return (reader.ReadString(), reader.ReadDouble());
         }
-        public static ValueTuple<bool> Read_rbz(this ref Reader reader)
+        public static global::System.ValueTuple<bool> Read_rbz(this ref global::Tmds.DBus.Protocol.Reader reader)
         {
             reader.AlignStruct();
-            return new ValueTuple<bool>(reader.ReadBool());
+            return new global::System.ValueTuple<bool>(reader.ReadBool());
         }
     }
     file static class MessageWriterExtensions
     {
-        public static void Write_rsdz(this ref MessageWriter writer, (string, double) value)
+        public static void Write_rsdz(this ref global::Tmds.DBus.Protocol.MessageWriter writer, (string, double) value)
         {
             writer.WriteStructureStart();
             writer.WriteString(value.Item1);
             writer.WriteDouble(value.Item2);
         }
-        public static void Write_rbz(this ref MessageWriter writer, ValueTuple<bool> value)
+        public static void Write_rbz(this ref global::Tmds.DBus.Protocol.MessageWriter writer, global::System.ValueTuple<bool> value)
         {
             writer.WriteStructureStart();
             writer.WriteBool(value.Item1);
@@ -854,31 +849,27 @@ namespace TestNamespace
 #nullable enable
 namespace Tmds.DBus.Protocol
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Threading;
-    using System.Threading.Tasks;
     abstract class DBusHandler : IPathMethodHandler
     {
         // Identifies the D-Bus interfaces. Used with SupportsInterface to filter interfaces per path.
-        [Flags]
+        [global::System.Flags]
         public enum DBusInterface
         {
             // OrgFreedesktopDBusIntrospectable = 1,
         }
-        private readonly SendOrPostCallback? _postDelegate;
+        private readonly global::System.Threading.SendOrPostCallback? _postDelegate;
         private const DBusInterface OrgFreedesktopDBusIntrospectable = (DBusInterface)1;
         private const DBusInterface InterfacesWithProperties = 0;
         public string Path { get; }
         public bool HandlesChildPaths { get; }
         public DBusConnection Connection { get; }
         // The SynchronizationContext on which method handlers are invoked.
-        protected SynchronizationContext? SynchronizationContext { get; }
+        protected global::System.Threading.SynchronizationContext? SynchronizationContext { get; }
         protected DBusHandler(DBusConnection connection, string path, bool handlesChildPaths, bool handleOnCapturedContext = true)
-            : this(connection, path, handlesChildPaths, handleOnCapturedContext ? SynchronizationContext.Current : null)
+            : this(connection, path, handlesChildPaths, handleOnCapturedContext ? global::System.Threading.SynchronizationContext.Current : null)
         {
         }
-        protected DBusHandler(DBusConnection connection, string path, bool handlesChildPaths, SynchronizationContext? synchronizationContext)
+        protected DBusHandler(DBusConnection connection, string path, bool handlesChildPaths, global::System.Threading.SynchronizationContext? synchronizationContext)
         {
             Connection = connection;
             Path = path;
@@ -896,19 +887,19 @@ namespace Tmds.DBus.Protocol
             }
         }
         // Override to add cross-cutting logic (e.g. logging, error handling) around method invocations.
-        protected virtual async ValueTask InvokeAsync(DBusMethod method, MethodContext context)
+        protected virtual async global::System.Threading.Tasks.ValueTask InvokeAsync(DBusMethod method, MethodContext context)
         {
             try
             {
                 await method.Invoke(context).ConfigureAwait(false);
             }
-            catch (Exception ex)
+            catch (global::System.Exception ex)
             {
                 HandleException(context, ex);
             }
         }
         // Override to customize exception handling for method invocations.
-        protected virtual void HandleException(MethodContext context, Exception ex)
+        protected virtual void HandleException(MethodContext context, global::System.Exception ex)
         {
             if (context.HandleException(ex, shouldDisconnect: false))
             {
@@ -918,7 +909,7 @@ namespace Tmds.DBus.Protocol
             {
                 context.ReplyError(dbusEx.ErrorName, dbusEx.ErrorMessage);
             }
-            else if (ex is ArgumentException)
+            else if (ex is global::System.ArgumentException)
             {
                 context.ReplyError("org.freedesktop.DBus.Error.InvalidArgs", ex.Message);
             }
@@ -928,19 +919,19 @@ namespace Tmds.DBus.Protocol
             }
         }
         // Override to filter interfaces for specific paths when the handler manages multiple paths.
-        protected virtual bool SupportsInterface(DBusInterface dbusInterface, ReadOnlySpan<char> path)
+        protected virtual bool SupportsInterface(DBusInterface dbusInterface, global::System.ReadOnlySpan<char> path)
         {
             return true;
         }
         // Override to customize introspection, e.g. to include child node names.
-        protected virtual ValueTask HandleIntrospectAsync(IntrospectContext context)
+        protected virtual global::System.Threading.Tasks.ValueTask HandleIntrospectAsync(IntrospectContext context)
         {
-            DBusInterface interfaces = GetSupportedInterfaces(context.MethodContext.Request.PathAsString.AsSpan());
+            DBusInterface interfaces = GetSupportedInterfaces(global::System.MemoryExtensions.AsSpan(context.MethodContext.Request.PathAsString));
             context.Reply(interfaces);
             return default;
         }
         // Context for IntrospectAsync. Call Reply to send the introspection XML response.
-        protected readonly struct IntrospectContext : IDisposable
+        protected readonly struct IntrospectContext : global::System.IDisposable
         {
             public MethodContext MethodContext { get; }
             public IntrospectContext(MethodContext methodContext)
@@ -948,9 +939,9 @@ namespace Tmds.DBus.Protocol
                 MethodContext = methodContext;
             }
             public void Dispose() => MethodContext.Dispose();
-            public void Reply(DBusInterface interfaces, IList<string>? childNames = null)
+            public void Reply(DBusInterface interfaces, global::System.Collections.Generic.IList<string>? childNames = null)
             {
-                var interfaceXmls = new ReadOnlyMemory<byte>[1];
+                var interfaceXmls = new global::System.ReadOnlyMemory<byte>[1];
                 int count = 0;
                 if ((interfaces & InterfacesWithProperties) != 0)
                 {
@@ -958,42 +949,42 @@ namespace Tmds.DBus.Protocol
                 }
                 if (childNames is not null)
                 {
-                    MethodContext.ReplyIntrospectXml(interfaceXmls.AsSpan(0, count), childNames);
+                    MethodContext.ReplyIntrospectXml(global::System.MemoryExtensions.AsSpan(interfaceXmls, 0, count), childNames);
                 }
                 else
                 {
-                    MethodContext.ReplyIntrospectXml(interfaceXmls.AsSpan(0, count));
+                    MethodContext.ReplyIntrospectXml(global::System.MemoryExtensions.AsSpan(interfaceXmls, 0, count));
                 }
             }
         }
         internal readonly struct DBusMethod
         {
-            private readonly Func<object, MethodContext, ValueTask> _method;
+            private readonly global::System.Func<object, MethodContext, global::System.Threading.Tasks.ValueTask> _method;
             private readonly object _target;
-            public DBusMethod(Func<object, MethodContext, ValueTask> method, object target)
+            public DBusMethod(global::System.Func<object, MethodContext, global::System.Threading.Tasks.ValueTask> method, object target)
             {
                 _method = method;
                 _target = target;
             }
             public bool HasValue => _method is not null;
-            public ValueTask Invoke(MethodContext context)
+            public global::System.Threading.Tasks.ValueTask Invoke(MethodContext context)
             {
                 return _method?.Invoke(_target, context) ?? default;
             }
         }
-        ValueTask IPathMethodHandler.HandleMethodAsync(MethodContext context)
+        global::System.Threading.Tasks.ValueTask IPathMethodHandler.HandleMethodAsync(MethodContext context)
         {
             DBusInterface dbusInterface = ParseInterface(context);
-            DBusMethod method = (dbusInterface != OrgFreedesktopDBusIntrospectable && !SupportsInterface(dbusInterface, context.Request.PathAsString.AsSpan())) ? default : FindMethodHandler(context, dbusInterface);
+            DBusMethod method = (dbusInterface != OrgFreedesktopDBusIntrospectable && !SupportsInterface(dbusInterface, global::System.MemoryExtensions.AsSpan(context.Request.PathAsString))) ? default : FindMethodHandler(context, dbusInterface);
             if (!method.HasValue)
             {
                 return default;
             }
             return HandleAsync(method, context);
         }
-        private ValueTask HandleAsync(DBusMethod method, MethodContext context)
+        private global::System.Threading.Tasks.ValueTask HandleAsync(DBusMethod method, MethodContext context)
         {
-            SynchronizationContext? synchronizationContext = SynchronizationContext;
+            global::System.Threading.SynchronizationContext? synchronizationContext = SynchronizationContext;
             if (synchronizationContext is null)
             {
                 return InvokeAsync(method, context);
@@ -1005,7 +996,7 @@ namespace Tmds.DBus.Protocol
                 return default;
             }
         }
-        private async ValueTask InvokeAndDisposeAsync(DBusMethod method, MethodContext context)
+        private async global::System.Threading.Tasks.ValueTask InvokeAndDisposeAsync(DBusMethod method, MethodContext context)
         {
             try
             {
@@ -1060,7 +1051,7 @@ namespace Tmds.DBus.Protocol
             };
             return result;
         }
-        protected DBusInterface GetSupportedInterfaces(ReadOnlySpan<char> path)
+        protected DBusInterface GetSupportedInterfaces(global::System.ReadOnlySpan<char> path)
         {
             DBusInterface interfaces = default;
             return interfaces;


### PR DESCRIPTION
Fixes https://github.com/tmds/Tmds.DBus/issues/450.